### PR TITLE
fixed bug TDQ-9942 tdqReportRun component exist compile error on the 6.0

### DIFF
--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/preferences/PreferenceInitializer.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/preferences/PreferenceInitializer.java
@@ -89,7 +89,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
         Bundle refBundle = Platform.getBundle("org.talend.dataquality.reporting"); //$NON-NLS-1$
         if (refBundle != null) {
             try {
-                String dirPath = FileLocator.getBundleFile(refBundle).getPath();
+                String dirPath = FileLocator.getBundleFile(refBundle).getPath().replace(File.separatorChar, '/');
                 store.setDefault(TalendDesignerPrefConstants.DQ_REPORTING_BUNDLE_DIR, dirPath);
             } catch (IOException e) {
                 e.printStackTrace();


### PR DESCRIPTION
convert separator from "\" to "/" make it is work on the windows