### PR TITLE
[TBD-1931] Add hive-exec dependency into Impala components for CDH 5.4

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/plugin.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/plugin.xml
@@ -6120,6 +6120,9 @@
 	            description="The lastest Impala libraries of CDH 5.4"
 	            id="IMPALA-LIB-CDH_5_4_LASTEST"
 	            name="IMPALA-LIB-CDH_5_4_LASTEST">
+             <library
+                id="hive-exec-cdh5.4-lastest">
+             </library>
 	         <library
 	            id="hive-metastore-cdh5.4-lastest">
 	         </library>


### PR DESCRIPTION
Impala components throw ClassNotFoundException when CDH 5.4 is the selected distribution. This commit fixes that issue.