### PR TITLE
[TBD-2623] Backport of TBD-1931 on maintenance/5.6

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/plugin.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/plugin.xml
@@ -31,858 +31,858 @@
             id="org.talend.designer.components.localprovider.BoxJetFileProvider">
       </jetProvider>
    </extension>
-   
+
 	<extension point="org.talend.core.runtime.librariesNeeded">
-	
+
 		<!-- cdh5.4 libraries -->
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="hadoop-common-cdh5.4-lastest"           
+        	id="hadoop-common-cdh5.4-lastest"
          	name="hadoop-common-2.6.0-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.4/lib/hadoop-common-2.6.0-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="hadoop-hdfs-cdh5.4-lastest"           
+        	id="hadoop-hdfs-cdh5.4-lastest"
          	name="hadoop-hdfs-2.6.0-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.4/lib/hadoop-hdfs-2.6.0-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="hadoop-auth-cdh5.4-lastest"           
+        	id="hadoop-auth-cdh5.4-lastest"
          	name="hadoop-auth-2.6.0-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.4/lib/hadoop-auth-2.6.0-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="avro-cdh5.4-lastest"       
+        	id="avro-cdh5.4-lastest"
          	name="avro-1.7.6-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.4/lib/avro-1.7.6-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="hadoop-mapreduce-client-common-cdh5.4-lastest"           
+        	id="hadoop-mapreduce-client-common-cdh5.4-lastest"
          	name="hadoop-mapreduce-client-common-2.6.0-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.4/lib/hadoop-mapreduce-client-common-2.6.0-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="hadoop-mapreduce-client-core-cdh5.4-lastest"           
+        	id="hadoop-mapreduce-client-core-cdh5.4-lastest"
          	name="hadoop-mapreduce-client-core-2.6.0-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.4/lib/hadoop-mapreduce-client-core-2.6.0-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="hadoop-mapreduce-client-jobclient-cdh5.4-lastest"           
+        	id="hadoop-mapreduce-client-jobclient-cdh5.4-lastest"
          	name="hadoop-mapreduce-client-jobclient-2.6.0-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.4/lib/hadoop-mapreduce-client-jobclient-2.6.0-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="hadoop-yarn-api-cdh5.4-lastest"       
+        	id="hadoop-yarn-api-cdh5.4-lastest"
          	name="hadoop-yarn-api-2.6.0-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.4/lib/hadoop-yarn-api-2.6.0-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="hadoop-yarn-client-cdh5.4-lastest"       
+        	id="hadoop-yarn-client-cdh5.4-lastest"
          	name="hadoop-yarn-client-2.6.0-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.4/lib/hadoop-yarn-client-2.6.0-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="hadoop-yarn-common-cdh5.4-lastest"       
+        	id="hadoop-yarn-common-cdh5.4-lastest"
          	name="hadoop-yarn-common-2.6.0-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.4/lib/hadoop-yarn-common-2.6.0-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="hbase-common-cdh5.4-lastest"       
+        	id="hbase-common-cdh5.4-lastest"
          	name="hbase-common-1.0.0-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.4/lib/hbase-common-1.0.0-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="hbase-client-cdh5.4-lastest"       
+        	id="hbase-client-cdh5.4-lastest"
          	name="hbase-client-1.0.0-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.4/lib/hbase-client-1.0.0-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="hbase-protocol-cdh5.4-lastest"       
+        	id="hbase-protocol-cdh5.4-lastest"
          	name="hbase-protocol-1.0.0-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.4/lib/hbase-protocol-1.0.0-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="hbase-server-cdh5.4-lastest"       
+        	id="hbase-server-cdh5.4-lastest"
          	name="hbase-server-1.0.0-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.4/lib/hbase-server-1.0.0-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="hbase-hadoop-compat-cdh5.4-lastest"       
+        	id="hbase-hadoop-compat-cdh5.4-lastest"
          	name="hbase-hadoop-compat-1.0.0-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.4/lib/hbase-hadoop-compat-1.0.0-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.zookeeper"
-        	id="zookeeper-cdh5.4-lastest"       
+        	id="zookeeper-cdh5.4-lastest"
          	name="zookeeper-3.4.5-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.zookeeper/lib/zookeeper-3.4.5-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.pig"
-        	id="pig-withouthadoop-cdh5.4-lastest"       
+        	id="pig-withouthadoop-cdh5.4-lastest"
          	name="pig-0.12.0-cdh5.4.0-withouthadoop.jar"
          	uripath="platform:/plugin/org.talend.libraries.pig/lib/pig-0.12.0-cdh5.4.0-withouthadoop.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hcatalog"
-        	id="hive-hcatalog-core-cdh5.4-lastest"       
+        	id="hive-hcatalog-core-cdh5.4-lastest"
          	name="hive-hcatalog-core-1.1.0-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hcatalog/lib/hive-hcatalog-core-1.1.0-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hcatalog"
-        	id="hive-hcatalog-pig-adapter-cdh5.4-lastest"       
+        	id="hive-hcatalog-pig-adapter-cdh5.4-lastest"
          	name="hive-hcatalog-pig-adapter-1.1.0-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hcatalog/lib/hive-hcatalog-pig-adapter-1.1.0-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hcatalog"
-        	id="hive-hcatalog-server-extensions-cdh5.4-lastest"       
+        	id="hive-hcatalog-server-extensions-cdh5.4-lastest"
          	name="hive-hcatalog-server-extensions-1.1.0-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hcatalog/lib/hive-hcatalog-server-extensions-1.1.0-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="hive-metastore-cdh5.4-lastest"       
+        	id="hive-metastore-cdh5.4-lastest"
          	name="hive-metastore-1.1.0-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.4/lib/hive-metastore-1.1.0-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="hive-exec-cdh5.4-lastest"       
+        	id="hive-exec-cdh5.4-lastest"
          	name="hive-exec-1.1.0-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.4/lib/hive-exec-1.1.0-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="hive-jdbc-cdh5.4-lastest"       
+        	id="hive-jdbc-cdh5.4-lastest"
          	name="hive-jdbc-1.1.0-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.4/lib/hive-jdbc-1.1.0-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="hive-service-cdh5.4-lastest"       
+        	id="hive-service-cdh5.4-lastest"
          	name="hive-service-1.1.0-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.4/lib/hive-service-1.1.0-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="hive-common-cdh5.4-lastest"       
+        	id="hive-common-cdh5.4-lastest"
          	name="hive-common-1.1.0-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.4/lib/hive-common-1.1.0-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="hive-serde-cdh5.4-lastest"       
+        	id="hive-serde-cdh5.4-lastest"
          	name="hive-serde-1.1.0-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.4/lib/hive-serde-1.1.0-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="hive-hbase-handler-cdh5.4-lastest"       
+        	id="hive-hbase-handler-cdh5.4-lastest"
          	name="hive-hbase-handler-1.1.0-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.4/lib/hive-hbase-handler-1.1.0-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.sqoop"
-        	id="sqoop-cdh5.4-lastest"       
+        	id="sqoop-cdh5.4-lastest"
          	name="sqoop-1.4.5-cdh5.4.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.sqoop/lib/sqoop-1.4.5-cdh5.4.0.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="calcite-avatica-1.0.0-incubating.jar"       
+        	id="calcite-avatica-1.0.0-incubating.jar"
          	name="calcite-avatica-1.0.0-incubating.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="calcite-core-1.0.0-incubating.jar"       
+        	id="calcite-core-1.0.0-incubating.jar"
          	name="calcite-core-1.0.0-incubating.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="calcite-linq4j-1.0.0-incubating.jar"       
+        	id="calcite-linq4j-1.0.0-incubating.jar"
          	name="calcite-linq4j-1.0.0-incubating.jar">
     	</libraryNeeded>
-    	
+
 		<!-- cdh5.1 libraries -->
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.1"
-        	id="hadoop-common-cdh5.1-lastest"           
+        	id="hadoop-common-cdh5.1-lastest"
          	name="hadoop-common-2.3.0-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.1/lib/hadoop-common-2.3.0-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.1"
-        	id="hadoop-hdfs-cdh5.1-lastest"           
+        	id="hadoop-hdfs-cdh5.1-lastest"
          	name="hadoop-hdfs-2.3.0-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.1/lib/hadoop-hdfs-2.3.0-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.1"
-        	id="hadoop-auth-cdh5.1-lastest"           
+        	id="hadoop-auth-cdh5.1-lastest"
          	name="hadoop-auth-2.3.0-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.1/lib/hadoop-auth-2.3.0-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.1"
-        	id="hadoop-core-cdh5.1-lastest"           
+        	id="hadoop-core-cdh5.1-lastest"
          	name="hadoop-core-2.3.0-mr1-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.1/lib/hadoop-core-2.3.0-mr1-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.1"
-        	id="avro-cdh5.1-lastest"       
+        	id="avro-cdh5.1-lastest"
          	name="avro-1.7.5-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.1/lib/avro-1.7.5-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.1"
-        	id="hadoop-mapreduce-client-common-cdh5.1-lastest"           
+        	id="hadoop-mapreduce-client-common-cdh5.1-lastest"
          	name="hadoop-mapreduce-client-common-2.3.0-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.1/lib/hadoop-mapreduce-client-common-2.3.0-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.1"
-        	id="hadoop-mapreduce-client-core-cdh5.1-lastest"           
+        	id="hadoop-mapreduce-client-core-cdh5.1-lastest"
          	name="hadoop-mapreduce-client-core-2.3.0-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.1/lib/hadoop-mapreduce-client-core-2.3.0-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.1"
-        	id="hadoop-mapreduce-client-jobclient-cdh5.1-lastest"           
+        	id="hadoop-mapreduce-client-jobclient-cdh5.1-lastest"
          	name="hadoop-mapreduce-client-jobclient-2.3.0-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.1/lib/hadoop-mapreduce-client-jobclient-2.3.0-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.1"
-        	id="hadoop-yarn-api-cdh5.1-lastest"       
+        	id="hadoop-yarn-api-cdh5.1-lastest"
          	name="hadoop-yarn-api-2.3.0-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.1/lib/hadoop-yarn-api-2.3.0-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.1"
-        	id="hadoop-yarn-client-cdh5.1-lastest"       
+        	id="hadoop-yarn-client-cdh5.1-lastest"
          	name="hadoop-yarn-client-2.3.0-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.1/lib/hadoop-yarn-client-2.3.0-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.1"
-        	id="hadoop-yarn-common-cdh5.1-lastest"       
+        	id="hadoop-yarn-common-cdh5.1-lastest"
          	name="hadoop-yarn-common-2.3.0-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.1/lib/hadoop-yarn-common-2.3.0-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.1"
-        	id="hbase-common-cdh5.1-lastest"       
+        	id="hbase-common-cdh5.1-lastest"
          	name="hbase-common-0.98.1-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.1/lib/hbase-common-0.98.1-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.1"
-        	id="hbase-client-cdh5.1-lastest"       
+        	id="hbase-client-cdh5.1-lastest"
          	name="hbase-client-0.98.1-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.1/lib/hbase-client-0.98.1-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.1"
-        	id="hbase-protocol-cdh5.1-lastest"       
+        	id="hbase-protocol-cdh5.1-lastest"
          	name="hbase-protocol-0.98.1-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.1/lib/hbase-protocol-0.98.1-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.1"
-        	id="hbase-server-cdh5.1-lastest"       
+        	id="hbase-server-cdh5.1-lastest"
          	name="hbase-server-0.98.1-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.1/lib/hbase-server-0.98.1-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.1"
-        	id="hbase-hadoop-compat-cdh5.1-lastest"       
+        	id="hbase-hadoop-compat-cdh5.1-lastest"
          	name="hbase-hadoop-compat-0.98.1-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.1/lib/hbase-hadoop-compat-0.98.1-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.zookeeper"
-        	id="zookeeper-cdh5.1-lastest"       
+        	id="zookeeper-cdh5.1-lastest"
          	name="zookeeper-3.4.5-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.zookeeper/lib/zookeeper-3.4.5-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.pig"
-        	id="pig-withouthadoop-cdh5.1-lastest"       
+        	id="pig-withouthadoop-cdh5.1-lastest"
          	name="pig-0.12.0-cdh5.1.2-withouthadoop.jar"
          	uripath="platform:/plugin/org.talend.libraries.pig/lib/pig-0.12.0-cdh5.1.2-withouthadoop.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hcatalog"
-        	id="hive-hcatalog-core-cdh5.1-lastest"       
+        	id="hive-hcatalog-core-cdh5.1-lastest"
          	name="hive-hcatalog-core-0.12.0-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hcatalog/lib/hive-hcatalog-core-0.12.0-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hcatalog"
-        	id="hive-hcatalog-pig-adapter-cdh5.1-lastest"       
+        	id="hive-hcatalog-pig-adapter-cdh5.1-lastest"
          	name="hive-hcatalog-pig-adapter-0.12.0-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hcatalog/lib/hive-hcatalog-pig-adapter-0.12.0-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hcatalog"
-        	id="hive-hcatalog-server-extensions-cdh5.1-lastest"       
+        	id="hive-hcatalog-server-extensions-cdh5.1-lastest"
          	name="hive-hcatalog-server-extensions-0.12.0-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hcatalog/lib/hive-hcatalog-server-extensions-0.12.0-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.1"
-        	id="hive-metastore-cdh5.1-lastest"       
+        	id="hive-metastore-cdh5.1-lastest"
          	name="hive-metastore-0.12.0-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.1/lib/hive-metastore-0.12.0-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.1"
-        	id="hive-exec-cdh5.1-lastest"       
+        	id="hive-exec-cdh5.1-lastest"
          	name="hive-exec-0.12.0-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.1/lib/hive-exec-0.12.0-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.1"
-        	id="hive-jdbc-cdh5.1-lastest"       
+        	id="hive-jdbc-cdh5.1-lastest"
          	name="hive-jdbc-0.12.0-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.1/lib/hive-jdbc-0.12.0-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.1"
-        	id="hive-service-cdh5.1-lastest"       
+        	id="hive-service-cdh5.1-lastest"
          	name="hive-service-0.12.0-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.1/lib/hive-service-0.12.0-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.1"
-        	id="hive-common-cdh5.1-lastest"       
+        	id="hive-common-cdh5.1-lastest"
          	name="hive-common-0.12.0-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.1/lib/hive-common-0.12.0-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.1"
-        	id="hive-serde-cdh5.1-lastest"       
+        	id="hive-serde-cdh5.1-lastest"
          	name="hive-serde-0.12.0-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.1/lib/hive-serde-0.12.0-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.1"
-        	id="hive-hbase-handler-cdh5.1-lastest"       
+        	id="hive-hbase-handler-cdh5.1-lastest"
          	name="hive-hbase-handler-0.12.0-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5.1/lib/hive-hbase-handler-0.12.0-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.sqoop"
-        	id="sqoop-cdh5.1-lastest"       
+        	id="sqoop-cdh5.1-lastest"
          	name="sqoop-1.4.4-cdh5.1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.sqoop/lib/sqoop-1.4.4-cdh5.1.2.jar">
     	</libraryNeeded>
-    	
+
     	<!-- hdp2.2 libraries -->
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.2"
-        	id="hadoop-common-hdp2.2-lastest"           
+        	id="hadoop-common-hdp2.2-lastest"
          	name="hadoop-common-2.6.0.2.2.0.0-2041.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.2/lib/hadoop-common-2.6.0.2.2.0.0-2041.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.2"
-        	id="hadoop-hdfs-hdp2.2-lastest"           
+        	id="hadoop-hdfs-hdp2.2-lastest"
          	name="hadoop-hdfs-2.6.0.2.2.0.0-2041.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.2/lib/hadoop-hdfs-2.6.0.2.2.0.0-2041.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.2"
-        	id="hadoop-auth-hdp2.2-lastest"           
+        	id="hadoop-auth-hdp2.2-lastest"
          	name="hadoop-auth-2.6.0.2.2.0.0-2041.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.2/lib/hadoop-auth-2.6.0.2.2.0.0-2041.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.2"
-        	id="avro-hdp2.2-lastest"       
+        	id="avro-hdp2.2-lastest"
          	name="avro-1.7.5.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.2/lib/avro-1.7.5.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.2"
-        	id="hadoop-mapreduce-client-common-hdp2.2-lastest"           
+        	id="hadoop-mapreduce-client-common-hdp2.2-lastest"
          	name="hadoop-mapreduce-client-common-2.6.0.2.2.0.0-2041.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.2/lib/hadoop-mapreduce-client-common-2.6.0.2.2.0.0-2041.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.2"
-        	id="hadoop-mapreduce-client-core-hdp2.2-lastest"           
+        	id="hadoop-mapreduce-client-core-hdp2.2-lastest"
          	name="hadoop-mapreduce-client-core-2.6.0.2.2.0.0-2041.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.2/lib/hadoop-mapreduce-client-core-2.6.0.2.2.0.0-2041.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.2"
-        	id="hadoop-mapreduce-client-jobclient-hdp2.2-lastest"           
+        	id="hadoop-mapreduce-client-jobclient-hdp2.2-lastest"
          	name="hadoop-mapreduce-client-jobclient-2.6.0.2.2.0.0-2041.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.2/lib/hadoop-mapreduce-client-jobclient-2.6.0.2.2.0.0-2041.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.2"
-        	id="hadoop-yarn-api-hdp2.2-lastest"       
+        	id="hadoop-yarn-api-hdp2.2-lastest"
          	name="hadoop-yarn-api-2.6.0.2.2.0.0-2041.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.2/lib/hadoop-yarn-api-2.6.0.2.2.0.0-2041.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.2"
-        	id="hadoop-yarn-client-hdp2.2-lastest"       
+        	id="hadoop-yarn-client-hdp2.2-lastest"
          	name="hadoop-yarn-client-2.6.0.2.2.0.0-2041.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.2/lib/hadoop-yarn-client-2.6.0.2.2.0.0-2041.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.2"
-        	id="hadoop-yarn-common-hdp2.2-lastest"       
+        	id="hadoop-yarn-common-hdp2.2-lastest"
          	name="hadoop-yarn-common-2.6.0.2.2.0.0-2041.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.2/lib/hadoop-yarn-common-2.6.0.2.2.0.0-2041.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.2"
-        	id="hbase-common-hdp2.2-lastest"       
+        	id="hbase-common-hdp2.2-lastest"
          	name="hbase-common-0.98.4.2.2.0.0-2041-hadoop2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.2/lib/hbase-common-0.98.4.2.2.0.0-2041-hadoop2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.2"
-        	id="hbase-client-hdp2.2-lastest"       
+        	id="hbase-client-hdp2.2-lastest"
          	name="hbase-client-0.98.4.2.2.0.0-2041-hadoop2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.2/lib/hbase-client-0.98.4.2.2.0.0-2041-hadoop2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.2"
-        	id="hbase-protocol-hdp2.2-lastest"       
+        	id="hbase-protocol-hdp2.2-lastest"
          	name="hbase-protocol-0.98.4.2.2.0.0-2041-hadoop2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.2/lib/hbase-protocol-0.98.4.2.2.0.0-2041-hadoop2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.2"
-        	id="hbase-server-hdp2.2-lastest"       
+        	id="hbase-server-hdp2.2-lastest"
          	name="hbase-server-0.98.4.2.2.0.0-2041-hadoop2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.2/lib/hbase-server-0.98.4.2.2.0.0-2041-hadoop2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.2"
-        	id="hbase-hadoop-compat-hdp2.2-lastest"       
+        	id="hbase-hadoop-compat-hdp2.2-lastest"
          	name="hbase-hadoop-compat-0.98.4.2.2.0.0-2041-hadoop2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.2/lib/hbase-hadoop-compat-0.98.4.2.2.0.0-2041-hadoop2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.zookeeper"
-        	id="zookeeper-hdp2.2-lastest"       
+        	id="zookeeper-hdp2.2-lastest"
          	name="zookeeper-3.4.6.2.2.0.0-2041.jar"
          	uripath="platform:/plugin/org.talend.libraries.zookeeper/lib/zookeeper-3.4.6.2.2.0.0-2041.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.pig"
-        	id="pig-withouthadoop-hdp2.2-lastest"       
+        	id="pig-withouthadoop-hdp2.2-lastest"
          	name="pig-0.14.0.2.2.0.0-2041-core-h2.jar"
          	uripath="platform:/plugin/org.talend.libraries.pig/lib/pig-0.14.0.2.2.0.0-2041-core-h2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hcatalog"
-        	id="hive-hcatalog-core-hdp2.2-lastest"       
+        	id="hive-hcatalog-core-hdp2.2-lastest"
          	name="hive-hcatalog-core-0.14.0.2.2.0.0-2041.jar"
          	uripath="platform:/plugin/org.talend.libraries.hcatalog/lib/hive-hcatalog-core-0.14.0.2.2.0.0-2041.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hcatalog"
-        	id="hive-hcatalog-pig-adapter-hdp2.2-lastest"       
+        	id="hive-hcatalog-pig-adapter-hdp2.2-lastest"
          	name="hive-hcatalog-pig-adapter-0.14.0.2.2.0.0-2041.jar"
          	uripath="platform:/plugin/org.talend.libraries.hcatalog/lib/hive-hcatalog-pig-adapter-0.14.0.2.2.0.0-2041.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hcatalog"
-        	id="hive-hcatalog-server-extensions-hdp2.2-lastest"       
+        	id="hive-hcatalog-server-extensions-hdp2.2-lastest"
          	name="hive-hcatalog-server-extensions-0.14.0.2.2.0.0-2041.jar"
          	uripath="platform:/plugin/org.talend.libraries.hcatalog/lib/hive-hcatalog-server-extensions-0.14.0.2.2.0.0-2041.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.2"
-        	id="hive-metastore-hdp2.2-lastest"       
+        	id="hive-metastore-hdp2.2-lastest"
          	name="hive-metastore-0.14.0.2.2.0.0-2041.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.2/lib/hive-metastore-0.14.0.2.2.0.0-2041.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.2"
-        	id="hive-jdbc-hdp2.2-lastest"       
+        	id="hive-jdbc-hdp2.2-lastest"
          	name="hive-jdbc-0.14.0.2.2.0.0-2041.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.2/lib/hive-jdbc-0.14.0.2.2.0.0-2041.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.2"
-        	id="hive-service-hdp2.2-lastest"       
+        	id="hive-service-hdp2.2-lastest"
          	name="hive-service-0.14.0.2.2.0.0-2041.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.2/lib/hive-service-0.14.0.2.2.0.0-2041.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.2"
-        	id="hive-exec-hdp2.2-lastest"       
+        	id="hive-exec-hdp2.2-lastest"
          	name="hive-exec-0.14.0.2.2.0.0-2041.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.2/lib/hive-exec-0.14.0.2.2.0.0-2041.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.2"
-        	id="hive-common-hdp2.2-lastest"       
+        	id="hive-common-hdp2.2-lastest"
          	name="hive-common-0.14.0.2.2.0.0-2041.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.2/lib/hive-common-0.14.0.2.2.0.0-2041.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.2"
-        	id="hive-serde-hdp2.2-lastest"       
+        	id="hive-serde-hdp2.2-lastest"
          	name="hive-serde-0.14.0.2.2.0.0-2041.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.2/lib/hive-serde-0.14.0.2.2.0.0-2041.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.1"
-        	id="hive-exec-hdp2.1-lastest"       
+        	id="hive-exec-hdp2.1-lastest"
          	name="hive-exec-0.13.0.2.1.1.0-385.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.1/lib/hive-exec-0.13.0.2.1.1.0-385.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.1"
-        	id="hive-common-hdp2.1-lastest"       
+        	id="hive-common-hdp2.1-lastest"
          	name="hive-common-0.13.0.2.1.1.0-385.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.1/lib/hive-common-0.13.0.2.1.1.0-385.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.1"
-        	id="hive-serde-hdp2.1-lastest"       
+        	id="hive-serde-hdp2.1-lastest"
          	name="hive-serde-0.13.0.2.1.1.0-385.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.1/lib/hive-serde-0.13.0.2.1.1.0-385.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.2"
-        	id="hive-hbase-handler-hdp2.2-lastest"       
+        	id="hive-hbase-handler-hdp2.2-lastest"
          	name="hive-hbase-handler-0.14.0.2.2.0.0-2041.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.2/lib/hive-hbase-handler-0.14.0.2.2.0.0-2041.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.sqoop"
-        	id="sqoop-hdp2.2-lastest"       
+        	id="sqoop-hdp2.2-lastest"
          	name="sqoop-1.4.5.2.2.0.0-2041.jar"
          	uripath="platform:/plugin/org.talend.libraries.sqoop/lib/sqoop-1.4.5.2.2.0.0-2041.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.jackson"
-        	id="joda-time-2.3.jar"       
+        	id="joda-time-2.3.jar"
          	name="joda-time-2.3.jar"
          	uripath="platform:/plugin/org.talend.libraries.jackson/lib/joda-time-2.3.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.2"
-        	id="automaton-1.11-8.jar"       
+        	id="automaton-1.11-8.jar"
          	name="automaton-1.11-8.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.2/lib/automaton-1.11-8.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.2"
-        	id="high-scale-lib-1.1.1.jar"       
+        	id="high-scale-lib-1.1.1.jar"
          	name="high-scale-lib-1.1.1.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.2/lib/high-scale-lib-1.1.1.jar">
     	</libraryNeeded>
-    	
+
     	<!-- MAPR 40X libraries-->
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.mapr.4.0.1"
-        	id="maprfs-4.0.X-lastest"       
+        	id="maprfs-4.0.X-lastest"
          	name="maprfs-4.0.1-mapr.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.mapr.4.0.1"
-        	id="mapr-hbase-4.0.X-lastest"       
+        	id="mapr-hbase-4.0.X-lastest"
          	name="mapr-hbase-4.0.1-mapr.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.mapr.4.0.1"
-        	id="hadoop-common-mapr-4.0.X-lastest"       
+        	id="hadoop-common-mapr-4.0.X-lastest"
          	name="hadoop-common-2.4.1-mapr-1408.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.mapr.4.0.1/lib/hadoop-common-2.4.1-mapr-1408.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.mapr.4.0.1"
-        	id="hadoop-auth-mapr-4.0.X-lastest"       
+        	id="hadoop-auth-mapr-4.0.X-lastest"
          	name="hadoop-auth-2.4.1-mapr-1408.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.mapr.4.0.1/lib/hadoop-auth-2.4.1-mapr-1408.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.mapr.4.0.1"
-        	id="hadoop-hdfs-mapr-4.0.X-lastest"       
+        	id="hadoop-hdfs-mapr-4.0.X-lastest"
          	name="hadoop-hdfs-2.4.1-mapr-1408.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.mapr.4.0.1/lib/hadoop-hdfs-2.4.1-mapr-1408.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.mapr.4.0.1"
-        	id="hadoop-mapreduce-client-common-mapr-4.0.X-lastest"       
+        	id="hadoop-mapreduce-client-common-mapr-4.0.X-lastest"
          	name="hadoop-mapreduce-client-common-2.4.1-mapr-1408.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.mapr.4.0.1/lib/hadoop-mapreduce-client-common-2.4.1-mapr-1408.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.mapr.4.0.1"
-        	id="hadoop-mapreduce-client-core-mapr-4.0.X-lastest"       
+        	id="hadoop-mapreduce-client-core-mapr-4.0.X-lastest"
          	name="hadoop-mapreduce-client-core-2.4.1-mapr-1408.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.mapr.4.0.1/lib/hadoop-mapreduce-client-core-2.4.1-mapr-1408.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.mapr.4.0.1"
-        	id="hadoop-mapreduce-client-jobclient-mapr-4.0.X-lastest"       
+        	id="hadoop-mapreduce-client-jobclient-mapr-4.0.X-lastest"
          	name="hadoop-mapreduce-client-jobclient-2.4.1-mapr-1408.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.mapr.4.0.1/lib/hadoop-mapreduce-client-jobclient-2.4.1-mapr-1408.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.mapr.4.0.1"
-        	id="hadoop-yarn-api-mapr-4.0.X-lastest"       
+        	id="hadoop-yarn-api-mapr-4.0.X-lastest"
          	name="hadoop-yarn-api-2.4.1-mapr-1408.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.mapr.4.0.1/lib/hadoop-yarn-api-2.4.1-mapr-1408.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.mapr.4.0.1"
-        	id="hadoop-yarn-client-mapr-4.0.X-lastest"       
+        	id="hadoop-yarn-client-mapr-4.0.X-lastest"
          	name="hadoop-yarn-client-2.4.1-mapr-1408.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.mapr.4.0.1/lib/hadoop-yarn-client-2.4.1-mapr-1408.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.mapr.4.0.1"
-        	id="hadoop-yarn-common-mapr-4.0.X-lastest"       
+        	id="hadoop-yarn-common-mapr-4.0.X-lastest"
          	name="hadoop-yarn-common-2.4.1-mapr-1408.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.mapr.4.0.1/lib/hadoop-yarn-common-2.4.1-mapr-1408.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.zookeeper"
-        	id="zookeeper-mapr-4.0.X-lastest"       
+        	id="zookeeper-mapr-4.0.X-lastest"
          	name="zookeeper-3.4.5-mapr-1406.jar"
          	uripath="platform:/plugin/org.talend.libraries.zookeeper/lib/zookeeper-3.4.5-mapr-1406.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.mapr.4.0.1"
-        	id="hbase-mapr-4.0.X-lastest"       
+        	id="hbase-mapr-4.0.X-lastest"
          	name="hbase-0.94.21-mapr-1407.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.mapr.4.0.1/lib/hbase-0.94.21-mapr-1407.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.mapr.4.0.1"
-        	id="hive-hbase-handler-mapr-4.0.X-lastest"       
+        	id="hive-hbase-handler-mapr-4.0.X-lastest"
          	name="hive-hbase-handler-0.13.0-mapr-1408.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.mapr.4.0.1/lib/hive-hbase-handler-0.13.0-mapr-1408.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.pig"
-        	id="pig-withouthadoop-mapr-4.0.X-lastest"       
+        	id="pig-withouthadoop-mapr-4.0.X-lastest"
          	name="pig-withouthadoop-0.12.1-mapr-1408-h2.jar"
          	uripath="platform:/plugin/org.talend.libraries.pig/lib/pig-withouthadoop-0.12.1-mapr-1408-h2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.pig"
-        	id="libprotodefs-mapr-4.0.X-lastest"       
+        	id="libprotodefs-mapr-4.0.X-lastest"
          	name="libprotodefs-4.0.1-mapr.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hcatalog"
-        	id="hive-hcatalog-core-mapr-4.0.X-lastest"       
+        	id="hive-hcatalog-core-mapr-4.0.X-lastest"
          	name="hive-hcatalog-core-0.13.0-mapr-1408.jar"
          	uripath="platform:/plugin/org.talend.libraries.hcatalog/lib/hive-hcatalog-core-0.13.0-mapr-1408.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hcatalog"
-        	id="hive-hcatalog-pig-adapter-mapr-4.0.X-lastest"       
+        	id="hive-hcatalog-pig-adapter-mapr-4.0.X-lastest"
          	name="hive-hcatalog-pig-adapter-0.13.0-mapr-1408.jar"
          	uripath="platform:/plugin/org.talend.libraries.hcatalog/lib/hive-hcatalog-pig-adapter-0.13.0-mapr-1408.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hcatalog"
-        	id="hive-hcatalog-server-extensions-mapr-4.0.X-lastest"       
+        	id="hive-hcatalog-server-extensions-mapr-4.0.X-lastest"
          	name="hive-hcatalog-server-extensions-0.13.0-mapr-1408.jar"
          	uripath="platform:/plugin/org.talend.libraries.hcatalog/lib/hive-hcatalog-server-extensions-0.13.0-mapr-1408.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.mapr.4.0.1"
-        	id="hive-exec-mapr-4.0.X-lastest"       
+        	id="hive-exec-mapr-4.0.X-lastest"
          	name="hive-exec-0.13.0-mapr-1408.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.mapr.4.0.1/lib/hive-exec-0.13.0-mapr-1408.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.mapr.4.0.1"
-        	id="hive-metastore-mapr-4.0.X-lastest"       
+        	id="hive-metastore-mapr-4.0.X-lastest"
          	name="hive-metastore-0.13.0-mapr-1408.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.mapr.4.0.1/lib/hive-metastore-0.13.0-mapr-1408.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.mapr.4.0.1"
-        	id="hive-jdbc-mapr-4.0.X-lastest"       
+        	id="hive-jdbc-mapr-4.0.X-lastest"
          	name="hive-jdbc-0.13.0-mapr-1408.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.mapr.4.0.1/lib/hive-jdbc-0.13.0-mapr-1408.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.mapr.4.0.1"
-        	id="hive-service-mapr-4.0.X-lastest"       
+        	id="hive-service-mapr-4.0.X-lastest"
          	name="hive-service-0.13.0-mapr-1408.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.mapr.4.0.1/lib/hive-service-0.13.0-mapr-1408.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.mapr.4.0.1"
-        	id="hive-common-mapr-4.0.X-lastest"       
+        	id="hive-common-mapr-4.0.X-lastest"
          	name="hive-common-0.13.0-mapr-1408.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.mapr.4.0.1/lib/hive-common-0.13.0-mapr-1408.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.mapr.4.0.1"
-        	id="hive-serde-mapr-4.0.X-lastest"       
+        	id="hive-serde-mapr-4.0.X-lastest"
          	name="hive-serde-0.13.0-mapr-1408.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.mapr.4.0.1/lib/hive-serde-0.13.0-mapr-1408.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.sqoop"
-        	id="sqoop-mapr-4.0.X-lastest"       
+        	id="sqoop-mapr-4.0.X-lastest"
          	name="sqoop-1.4.4-mapr-1408.jar"
          	uripath="platform:/plugin/org.talend.libraries.sqoop/lib/sqoop-1.4.4-mapr-1408.jar">
     	</libraryNeeded>
-    	
+
     	<!-- common libraries -->
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.apache.common"
-        	id="commons-configuration-1.6.jar"       
+        	id="commons-configuration-1.6.jar"
          	name="commons-configuration-1.6.jar"
          	uripath="platform:/plugin/org.talend.libraries.apache.common/lib/commons-configuration-1.6.jar">
     	</libraryNeeded>
 
         <libraryNeeded
             context="plugin:org.talend.libraries.apache.common"
-            id="commons-lang-2.6.jar"       
+            id="commons-lang-2.6.jar"
             name="commons-lang-2.6.jar"
             uripath="platform:/plugin/org.talend.libraries.apache.common/lib/commons-lang-2.6.jar"
             bundleID="" />
@@ -903,24 +903,24 @@
 
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.apache.common"
-        	id="commons-cli-1.2.jar"       
+        	id="commons-cli-1.2.jar"
          	name="commons-cli-1.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.apache.common/lib/commons-cli-1.2.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.apache.common"
-        	id="commons-codec-1.4.jar"       
+        	id="commons-codec-1.4.jar"
          	name="commons-codec-1.4.jar"
          	uripath="platform:/plugin/org.talend.libraries.apache.common/lib/commons-codec-1.4.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.apache.common"
-        	id="commons-codec-1.7.jar"       
+        	id="commons-codec-1.7.jar"
          	name="commons-codec-1.7.jar"
          	uripath="platform:/plugin/org.talend.libraries.apache.common/lib/commons-codec-1.7.jar">
-    	</libraryNeeded>    	
+    	</libraryNeeded>
 
         <libraryNeeded
             context="plugin:org.talend.libraries.apache.common"
@@ -931,24 +931,24 @@
 
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.guava"
-        	id="guava-11.0.2.jar"       
+        	id="guava-11.0.2.jar"
          	name="guava-11.0.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.guava/lib/guava-11.0.2.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.guava"
-        	id="guava-12.0.1.jar"       
+        	id="guava-12.0.1.jar"
          	name="guava-12.0.1.jar"
          	uripath="platform:/plugin/org.talend.libraries.guava/lib/guava-12.0.1.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.0"
-        	id="protobuf-java-2.5.0.jar"       
+        	id="protobuf-java-2.5.0.jar"
          	name="protobuf-java-2.5.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.0/lib/protobuf-java-2.5.0.jar">
-    	</libraryNeeded> 
+    	</libraryNeeded>
 
         <libraryNeeded
             context="plugin:org.talend.libraries.apache"
@@ -973,301 +973,301 @@
 
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.1"
-        	id="jersey-core-1.9.jar"       
+        	id="jersey-core-1.9.jar"
          	name="jersey-core-1.9.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.jetty"
-        	id="jetty-util-6.1.26.hwx.jar"       
+        	id="jetty-util-6.1.26.hwx.jar"
          	name="jetty-util-6.1.26.hwx.jar"
          	uripath="platform:/plugin/org.talend.libraries.jetty/lib/jetty-util-6.1.26.hwx.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.1"
-        	id="avro-1.5.4.jar"       
+        	id="avro-1.5.4.jar"
          	name="avro-1.5.4.jar"
          	uripath="platform:/plugin/org.talend.designer.components.bigdata/components/tPigLoad/avro-1.5.4.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.jackson"
-        	id="jackson-mapper-asl-1.8.8.jar"       
+        	id="jackson-mapper-asl-1.8.8.jar"
          	name="jackson-mapper-asl-1.8.8.jar"
          	uripath="platform:/plugin/org.talend.libraries.jackson/lib/jackson-mapper-asl-1.8.8.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.jackson"
-        	id="jackson-mapper-asl-1.9.13.jar"       
+        	id="jackson-mapper-asl-1.9.13.jar"
          	name="jackson-mapper-asl-1.9.13.jar"
          	uripath="platform:/plugin/org.talend.libraries.jackson/lib/jackson-mapper-asl-1.9.13.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.jackson"
-        	id="jackson-core-asl-1.8.8.jar"       
+        	id="jackson-core-asl-1.8.8.jar"
          	name="jackson-core-asl-1.8.8.jar"
          	uripath="platform:/plugin/org.talend.libraries.jackson/lib/jackson-core-asl-1.8.8.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.jackson"
-        	id="jackson-core-asl-1.9.13.jar"       
+        	id="jackson-core-asl-1.9.13.jar"
          	name="jackson-core-asl-1.9.13.jar"
          	uripath="platform:/plugin/org.talend.libraries.jackson/lib/jackson-core-asl-1.9.13.jar">
     	</libraryNeeded>
-    	
+
 	   	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.0"
-        	id="netty-3.6.6.Final.jar"       
+        	id="netty-3.6.6.Final.jar"
          	name="netty-3.6.6.Final.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.0/lib/netty-3.6.6.Final.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.1"
-        	id="htrace-core-2.04.jar"       
+        	id="htrace-core-2.04.jar"
          	name="htrace-core-2.04.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.1/lib/htrace-core-2.04.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.2"
-        	id="htrace-core-3.0.4.jar"       
+        	id="htrace-core-3.0.4.jar"
          	name="htrace-core-3.0.4.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.2/lib/htrace-core-3.0.4.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="htrace-core-3.1.0-incubating.jar"       
+        	id="htrace-core-3.1.0-incubating.jar"
          	name="htrace-core-3.1.0-incubating.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.pig"
-        	id="snappy-java-1.0.5.jar"       
+        	id="snappy-java-1.0.5.jar"
          	name="snappy-java-1.0.5.jar"
          	uripath="platform:/plugin/org.talend.libraries.pig/lib/snappy-java-1.0.5.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.1.2"
-        	id="libfb303-0.9.0.jar"       
+        	id="libfb303-0.9.0.jar"
          	name="libfb303-0.9.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.1.2/lib/libfb303-0.9.0.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5"
-        	id="libthrift-0.9.0.cloudera.2.jar"       
+        	id="libthrift-0.9.0.cloudera.2.jar"
          	name="libthrift-0.9.0.cloudera.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.cloudera.cdh5/lib/libthrift-0.9.0.cloudera.2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.1.2"
-        	id="libthrift-0.9.0.jar"       
+        	id="libthrift-0.9.0.jar"
          	name="libthrift-0.9.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.1.2/lib/libthrift-0.9.0.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="libfb303-0.9.2.jar"       
+        	id="libfb303-0.9.2.jar"
          	name="libfb303-0.9.2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.cloudera.cdh5.4"
-        	id="libthrift-0.9.2.jar"       
+        	id="libthrift-0.9.2.jar"
          	name="libthrift-0.9.2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.0"
-        	id="jdo-api-3.0.1.jar"       
+        	id="jdo-api-3.0.1.jar"
          	name="jdo-api-3.0.1.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.0/lib/jdo-api-3.0.1.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.apache.common"
-        	id="commons-io-2.4.jar"       
+        	id="commons-io-2.4.jar"
          	name="commons-io-2.4.jar"
          	uripath="platform:/plugin/org.talend.libraries.apache.common/lib/commons-io-2.4.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.pig"
-        	id="piggybank-cdh5.1.jar"       
+        	id="piggybank-cdh5.1.jar"
          	name="piggybank-cdh5.1.jar"
          	uripath="platform:/plugin/org.talend.libraries.pig/lib/piggybank-cdh5.1.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.pig"
-        	id="piggybank-cdh5.4.jar"       
+        	id="piggybank-cdh5.4.jar"
          	name="piggybank-cdh5.4.jar"
          	uripath="platform:/plugin/org.talend.libraries.pig/lib/piggybank-cdh5.4.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.pig"
-        	id="piggybank-hdp2.2.jar"       
+        	id="piggybank-hdp2.2.jar"
          	name="piggybank-hdp2.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.pig/lib/piggybank-hdp2.2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.apache.axis2"
-        	id="antlr-runtime-3.4.jar"       
+        	id="antlr-runtime-3.4.jar"
          	name="antlr-runtime-3.4.jar"
          	uripath="platform:/plugin/org.talend.libraries.apache.axis2/lib/antlr-runtime-3.4.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.apache.http"
-        	id="commons-httpclient-3.0.1.jar"       
+        	id="commons-httpclient-3.0.1.jar"
          	name="commons-httpclient-3.0.1.jar"
          	uripath="platform:/plugin/org.talend.libraries.apache.http/lib/commons-httpclient-3.0.1.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.0"
-        	id="datanucleus-api-jdo-3.2.1.jar"       
+        	id="datanucleus-api-jdo-3.2.1.jar"
          	name="datanucleus-api-jdo-3.2.1.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.0/lib/datanucleus-api-jdo-3.2.1.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.0"
-        	id="datanucleus-core-3.2.2.jar"       
+        	id="datanucleus-core-3.2.2.jar"
          	name="datanucleus-core-3.2.2.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.0/lib/datanucleus-core-3.2.2.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.0"
-        	id="datanucleus-rdbms-3.2.1.jar"       
+        	id="datanucleus-rdbms-3.2.1.jar"
          	name="datanucleus-rdbms-3.2.1.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.0/lib/datanucleus-rdbms-3.2.1.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.jdbc.derby"
-        	id="derby-10.4.2.0.jar"       
+        	id="derby-10.4.2.0.jar"
          	name="derby-10.4.2.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.jdbc.derby/lib/derby-10.4.2.0.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.1"
-        	id="datanucleus-api-jdo-3.2.6.jar"       
+        	id="datanucleus-api-jdo-3.2.6.jar"
          	name="datanucleus-api-jdo-3.2.6.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.1/lib/datanucleus-api-jdo-3.2.6.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.1"
-        	id="datanucleus-core-3.2.10.jar"       
+        	id="datanucleus-core-3.2.10.jar"
          	name="datanucleus-core-3.2.10.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.1/lib/datanucleus-core-3.2.10.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.hdp.2.1"
-        	id="datanucleus-rdbms-3.2.9.jar"       
+        	id="datanucleus-rdbms-3.2.9.jar"
          	name="datanucleus-rdbms-3.2.9.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.hdp.2.1/lib/datanucleus-rdbms-3.2.9.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.jdbc.derby"
-        	id="derby-10.11.1.1.jar"       
+        	id="derby-10.11.1.1.jar"
          	name="derby-10.11.1.1.jar"
          	uripath="platform:/plugin/org.talend.libraries.jdbc.derby/lib/derby-10.11.1.1.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.apache.http"
-        	id="httpclient-4.2.5.jar"       
+        	id="httpclient-4.2.5.jar"
          	name="httpclient-4.2.5.jar"
          	uripath="platform:/plugin/org.talend.libraries.apache.http/lib/httpclient-4.2.5.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.apache.http"
-        	id="httpcore-4.2.5.jar"       
+        	id="httpcore-4.2.5.jar"
          	name="httpcore-4.2.5.jar"
          	uripath="platform:/plugin/org.talend.libraries.apache.http/lib/httpcore-4.2.5.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.servlet"
-        	id="servlet-api-2.5-20081211.jar"       
+        	id="servlet-api-2.5-20081211.jar"
          	name="servlet-api-2.5-20081211.jar"
          	uripath="platform:/plugin/org.talend.libraries.servlet/lib/servlet-api-2.5-20081211.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.guava"
-        	id="guava-13.0.1.jar"       
+        	id="guava-13.0.1.jar"
          	name="guava-13.0.1.jar"
          	uripath="platform:/plugin/org.talend.libraries.guava/lib/guava-13.0.1.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.mapr.3.1.0"
-        	id="json-20080701.jar"       
+        	id="json-20080701.jar"
          	name="json-20080701.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.mapr.3.1.0/lib/json-20080701.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.mapr.4.0.1"
-        	id="amazon-s3.jar"       
+        	id="amazon-s3.jar"
          	name="amazon-s3.jar"
          	uripath="platform:/plugin/org.talend.designer.components.bigdata/components/tPigLoad/amazon-s3.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.s3"
-        	id="aws-java-sdk-1.5.4.jar"       
+        	id="aws-java-sdk-1.5.4.jar"
          	name="aws-java-sdk-1.5.4.jar"
          	uripath="platform:/plugin/org.talend.libraries.s3/lib/aws-java-sdk-1.5.4.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.hadoop.mapr.4.0.1"
-        	id="avro-1.7.4.jar"       
+        	id="avro-1.7.4.jar"
          	name="avro-1.7.4.jar"
          	uripath="platform:/plugin/org.talend.libraries.hadoop.mapr.4.0.1/lib/avro-1.7.4.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.jline"
-        	id="jline-1.0.jar"       
+        	id="jline-1.0.jar"
          	name="jline-1.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.jline/lib/jline-1.0.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.apache.kafka"
-        	id="curator-framework-2.6.0.jar"       
+        	id="curator-framework-2.6.0.jar"
          	name="curator-framework-2.6.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.apache.kafka/lib/curator-framework-2.6.0.jar">
     	</libraryNeeded>
-    	
+
     	<libraryNeeded
 	   		context="plugin:org.talend.libraries.apache.kafka"
-        	id="curator-client-2.6.0.jar"       
+        	id="curator-client-2.6.0.jar"
          	name="curator-client-2.6.0.jar"
          	uripath="platform:/plugin/org.talend.libraries.apache.kafka/lib/curator-client-2.6.0.jar">
     	</libraryNeeded>
-    	
+
     	<!-- group of hdfs libraries -->
     	<libraryNeededGroup
 	            description="The lastest HDFS libraries of CDH 5.4"
@@ -1322,7 +1322,7 @@
 	             id="htrace-core-3.0.4.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 		<libraryNeededGroup
 	            description="The lastest HDFS libraries of CDH 5.1"
 	            id="HDFS-LIB-CDH_5_1_LASTEST"
@@ -1373,7 +1373,7 @@
 	             id="jersey-core-1.9.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <libraryNeededGroup
 	            description="The lastest HDFS libraries of HDP 2.2"
 	            id="HDFS-LIB-HDP_2_2_LASTEST"
@@ -1433,7 +1433,7 @@
 	             id="htrace-core-3.0.4.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 		<libraryNeededGroup
 	            description="The lastest HDFS libraries of MAPR40X"
 	            id="HDFS-LIB-MAPR40X_LASTEST"
@@ -1560,7 +1560,7 @@
 	             id="htrace-core-3.0.4.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 		<libraryNeededGroup
 	            description="The lastest Map Reduce libraries of CDH 5.1"
 	            id="MAPREDUCE-LIB-CDH_5_1_LASTEST"
@@ -1635,7 +1635,7 @@
 	             id="log4j-1.2.17.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <libraryNeededGroup
 	            description="The lastest MR1 libraries of CDH 5.1"
 	            id="MAPREDUCE-MR1-LIB-CDH_5_1_LASTEST"
@@ -1695,7 +1695,7 @@
 	             id="log4j-1.2.17.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <libraryNeededGroup
 	            description="The lastest Map Reduce libraries of HDP 2.2"
 	            id="MAPREDUCE-LIB-HDP_2_2_LASTEST"
@@ -1773,7 +1773,7 @@
 	             id="htrace-core-3.0.4.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 		<libraryNeededGroup
 	            description="The lastest Map Reduce libraries of MAPR40X"
 	            id="MAPREDUCE-LIB-MAPR40X_LASTEST"
@@ -1857,7 +1857,7 @@
 	             id="log4j-1.2.17.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <!-- group of talend mapreduce&hbase libraries -->
 	    <libraryNeededGroup
 	            description="The lastest talend mapreduce hbase storage libraries of CDH 5.4"
@@ -1885,7 +1885,7 @@
 	             id="htrace-core-3.1.0-incubating.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 		<libraryNeededGroup
 	            description="The lastest talend mapreduce hbase storage libraries of CDH 5.1"
 	            id="MAPREDUCE-HBASE-LIB-CDH_5_1_LASTEST"
@@ -1909,7 +1909,7 @@
 	             id="htrace-core-2.04.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <libraryNeededGroup
 	            description="The lastest talend mapreduce hbase storage libraries of HDP 2.2"
 	            id="MAPREDUCE-HBASE-LIB-HDP_2_2_LASTEST"
@@ -1933,7 +1933,7 @@
 	             id="htrace-core-2.04.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 		<libraryNeededGroup
 	            description="The lastest talend mapreduce hbase storage libraries of MAPR40X"
 	            id="MAPREDUCE-HBASE-LIB-MAPR40X_LASTEST"
@@ -1945,7 +1945,7 @@
 	             id="zookeeper-mapr-4.0.X-lastest">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <!-- group of hbase libraries -->
 	    <libraryNeededGroup
 	            description="The lastest HBase libraries of CDH 5.4"
@@ -2015,7 +2015,7 @@
 	             id="slf4j-log4j12-1.7.5.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <libraryNeededGroup
 	            description="The lastest HBase libraries of CDH 5.1"
 	            id="HBASE-LIB-CDH_5_1_LASTEST"
@@ -2081,7 +2081,7 @@
 	             id="slf4j-log4j12-1.7.5.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <libraryNeededGroup
 	            description="The lastest HBase libraries of HDP 2.2"
 	            id="HBASE-LIB-HDP_2_2_LASTEST"
@@ -2147,7 +2147,7 @@
 	             id="slf4j-log4j12-1.7.5.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <libraryNeededGroup
 	            description="The lastest HBase libraries of MAPR 4.0.X"
 	            id="HBASE-LIB-MAPR40X_LASTEST"
@@ -2201,7 +2201,7 @@
 	             id="slf4j-log4j12-1.7.5.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <!-- group of sqoop common libraries -->
 	    <libraryNeededGroup
 	            description="The lastest Sqoop libraries of CDH 5.4"
@@ -2283,7 +2283,7 @@
 	             id="htrace-core-3.0.4.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 		<libraryNeededGroup
 	            description="The lastest Sqoop libraries of CDH 5.1"
 	            id="SQOOP-LIB-CDH_5_1_LASTEST"
@@ -2361,7 +2361,7 @@
 	             id="log4j-1.2.17.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <libraryNeededGroup
 	            description="The lastest Sqoop MR1 libraries of CDH 5.1"
 	            id="SQOOP-MR1-LIB-CDH_5_1_LASTEST"
@@ -2424,7 +2424,7 @@
 	             id="log4j-1.2.17.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <libraryNeededGroup
 	            description="The lastest Sqoop libraries of HDP 2.2"
 	            id="SQOOP-LIB-HDP_2_2_LASTEST"
@@ -2505,7 +2505,7 @@
 	             id="htrace-core-3.0.4.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <libraryNeededGroup
 	            description="The lastest Sqoop libraries of MAPR40X"
 	            id="SQOOP-LIB-MAPR40X_LASTEST"
@@ -2598,7 +2598,7 @@
 	             id="log4j-1.2.17.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <!-- group of pig common libraries -->
 	    <libraryNeededGroup
 	            description="The lastest Pig libraries of CDH 5.4"
@@ -2680,7 +2680,7 @@
 	             id="htrace-core-3.0.4.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 		<libraryNeededGroup
 	            description="The lastest Pig libraries of CDH 5.1"
 	            id="PIG-LIB-CDH_5_1_LASTEST"
@@ -2758,7 +2758,7 @@
 	             id="snappy-java-1.0.5.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <libraryNeededGroup
 	            description="The lastest Pig with MR1 libraries of CDH 5.1"
 	            id="PIG-MR1-LIB-CDH_5_1_LASTEST"
@@ -2821,7 +2821,7 @@
 	             id="snappy-java-1.0.5.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <libraryNeededGroup
 	            description="The lastest Pig libraries of HDP 2.2"
 	            id="PIG-LIB-HDP_2_2_LASTEST"
@@ -2920,7 +2920,7 @@
 	             id="automaton-1.11-8.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <libraryNeededGroup
 	            description="The lastest Pig libraries of MAPR40X"
 	            id="PIG-LIB-MAPR40X_LASTEST"
@@ -3010,7 +3010,7 @@
 	             id="snappy-java-1.0.5.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <!-- group of pig hcat storage libraries -->
 	    <libraryNeededGroup
 	            description="The lastest pig hcat storage libraries of CDH 5.4"
@@ -3041,7 +3041,7 @@
 	             id="libthrift-0.9.2.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 		<libraryNeededGroup
 	            description="The lastest pig hcat storage libraries of CDH 5.1"
 	            id="PIG-HCAT-LIB-CDH_5_1_LASTEST"
@@ -3071,7 +3071,7 @@
 	             id="libfb303-0.9.0.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <libraryNeededGroup
 	            description="The lastest pig hcat storage libraries of HDP 2.2"
 	            id="PIG-HCAT-LIB-HDP_2_2_LASTEST"
@@ -3101,7 +3101,7 @@
 	             id="libfb303-0.9.0.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 		<libraryNeededGroup
 	            description="The lastest pig hcat storage libraries of MAPR40X"
 	            id="PIG-HCAT-LIB-MAPR40X_LASTEST"
@@ -3131,7 +3131,7 @@
 	             id="libfb303-0.9.0.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <!-- group of pig hbase storage libraries -->
 	    <libraryNeededGroup
 	            description="The lastest pig hbase storage libraries of CDH 5.4"
@@ -3165,7 +3165,7 @@
 	             id="netty-3.6.6.Final.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 		<libraryNeededGroup
 	            description="The lastest pig hbase storage libraries of CDH 5.1"
 	            id="PIG-HBASE-LIB-CDH_5_1_LASTEST"
@@ -3195,7 +3195,7 @@
 	             id="netty-3.6.6.Final.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <libraryNeededGroup
 	            description="The lastest pig hbase storage libraries of HDP 2.2"
 	            id="PIG-HBASE-LIB-HDP_2_2_LASTEST"
@@ -3225,7 +3225,7 @@
 	             id="netty-3.6.6.Final.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <libraryNeededGroup
 	            description="The lastest pig hbase storage libraries of MAPR40X"
 	            id="PIG-HBASE-LIB-MAPR40X_LASTEST"
@@ -3237,7 +3237,7 @@
 	             id="zookeeper-mapr-4.0.X-lastest">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <!-- group of pig rc file storage libraries -->
 	    <libraryNeededGroup
 	            description="The lastest pig rc file storage libraries of CDH 5.4"
@@ -3253,7 +3253,7 @@
 	             id="hive-exec-cdh5.4-lastest">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 		<libraryNeededGroup
 	            description="The lastest pig rc file storage libraries of CDH 5.1"
 	            id="PIG-RCFILE-LIB-CDH_5_1_LASTEST"
@@ -3268,7 +3268,7 @@
 	             id="hive-exec-cdh5.1-lastest">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <libraryNeededGroup
 	            description="The lastest pig rc file storage libraries of HDP 2.2"
 	            id="PIG-RCFILE-LIB-HDP_2_2_LASTEST"
@@ -3283,7 +3283,7 @@
 	             id="hive-exec-hdp2.1-lastest">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <libraryNeededGroup
 	            description="The lastest pig rc file storage libraries of MAPR40X"
 	            id="PIG-RCFILE-LIB-MAPR40X_LASTEST"
@@ -3298,7 +3298,7 @@
 	             id="hive-exec-mapr-4.0.X-lastest">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <!-- group of pig avro storage libraries -->
 	    <libraryNeededGroup
 	            description="The lastest pig avro storage libraries of CDH 5.4"
@@ -3314,7 +3314,7 @@
 	             id="avro-cdh5.4-lastest">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 		<libraryNeededGroup
 	            description="The lastest pig avro storage libraries of CDH 5.1"
 	            id="PIG-AVRO-LIB-CDH_5_1_LASTEST"
@@ -3329,7 +3329,7 @@
 	             id="avro-cdh5.1-lastest">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <libraryNeededGroup
 	            description="The lastest pig avro storage libraries of HDP 2.2"
 	            id="PIG-AVRO-LIB-HDP_2_2_LASTEST"
@@ -3344,7 +3344,7 @@
 	             id="avro-hdp2.2-lastest">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <libraryNeededGroup
 	            description="The lastest pig avro storage libraries of MAPR40X"
 	            id="PIG-AVRO-LIB-MAPR40X_LASTEST"
@@ -3359,8 +3359,8 @@
 	             id="avro-1.7.4.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
-	    
+
+
 	    <!-- group of hive common libraries -->
 	    <libraryNeededGroup
 	            description="The lastest Hive libraries of CDH 5.4"
@@ -3502,7 +3502,7 @@
 	             id="calcite-avatica-1.0.0-incubating.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 		<libraryNeededGroup
 	            description="The lastest Hive libraries of CDH 5.1"
 	            id="HIVE-LIB-CDH_5_1_LASTEST"
@@ -3625,7 +3625,7 @@
 	             id="derby-10.4.2.0.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <libraryNeededGroup
 	            description="The lastest Hive MR1 libraries of CDH 5.1"
 	            id="HIVE-MR1-LIB-CDH_5_1_LASTEST"
@@ -3733,7 +3733,7 @@
 	             id="derby-10.4.2.0.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <libraryNeededGroup
 	            description="The lastest Hive libraries of HDP 2.2"
 	            id="HIVE-LIB-HDP_2_2_LASTEST"
@@ -3865,7 +3865,7 @@
 	             id="curator-client-2.6.0.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <libraryNeededGroup
 	            description="The lastest Hive libraries of MAPR40X"
 	            id="HIVE-LIB-MAPR40X_LASTEST"
@@ -3994,7 +3994,7 @@
 	             id="derby-10.4.2.0.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <!-- group of hive hbase storage libraries -->
 	    <libraryNeededGroup
 	            description="The lastest Hive hbase storage libraries of CDH 5.4"
@@ -4032,9 +4032,9 @@
 	         </library>
 	         <library
 	             id="servlet-api-2.5-20081211.jar">
-	         </library>		  
+	         </library>
 	    </libraryNeededGroup>
-	    
+
 		<libraryNeededGroup
 	            description="The lastest Hive hbase storage libraries of CDH 5.1"
 	            id="HIVE-HBASE-LIB-CDH_5_1_LASTEST"
@@ -4068,9 +4068,9 @@
 	         </library>
 	         <library
 	             id="servlet-api-2.5-20081211.jar">
-	         </library>		  
+	         </library>
 	    </libraryNeededGroup>
-	    
+
 	    <libraryNeededGroup
 	            description="The lastest Hive hbase storage libraries of HDP 2.2"
 	            id="HIVE-HBASE-LIB-HDP_2_2_LASTEST"
@@ -4107,12 +4107,12 @@
 	         </library>
 	         <library
 	             id="servlet-api-2.5-20081211.jar">
-	         </library>		  
+	         </library>
 	         <library
 	             id="high-scale-lib-1.1.1.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 		<libraryNeededGroup
 	            description="The lastest Hive hbase storage libraries of MAPR40X"
 	            id="HIVE-HBASE-LIB-MAPR40X_LASTEST"
@@ -4127,12 +4127,15 @@
 	             id="zookeeper-mapr-4.0.X-lastest">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
         <!-- group of impala libraries -->
 	    <libraryNeededGroup
 	            description="The lastest Impala libraries of CDH 5.4"
 	            id="IMPALA-LIB-CDH_5_4_LASTEST"
 	            name="IMPALA-LIB-CDH_5_4_LASTEST">
+           <library
+              id="hive-exec-cdh5.4-lastest">
+           </library>
 	         <library
 	            id="hive-metastore-cdh5.4-lastest">
 	         </library>
@@ -4176,7 +4179,7 @@
 	             id="log4j-1.2.17.jar">
 	         </library>
 	    </libraryNeededGroup>
-	    
+
 	</extension>
-	   
+
 </plugin>


### PR DESCRIPTION
This pull request is basically a backport on 5.6 of what we already did to fix TBD-1931.
Don't worry about the great number of addition/deletions on plugin.xml, my editor just deleted useless trailing spaces or tabulations at the end of the lines when possible.
The real change is just the addition of the hive-exec dependency for Impala on CDH 5.4.