### PR TITLE
[TBD-3244] Correctly output bytes.

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tWriteXMLFieldOut/tWriteXMLFieldOut_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tWriteXMLFieldOut/tWriteXMLFieldOut_main.javajet
@@ -100,6 +100,10 @@ class XMLTool{
 %>
 			<%=connName%>.<%=column.getLabel()%>.toPlainString()
 <%
+        }else if (javaType == JavaTypesManager.BYTE_ARRAY) {
+%>
+            new String(<%=connName%>.<%=column.getLabel()%>)
+<%
         }else{
 %>
             <%=connName%>.<%=column.getLabel()%>.toString()


### PR DESCRIPTION
(We use to save a string with the pointer to the object,
now we save the byte as a String.)