### PR TITLE
TDI-35892 : globalMap.get("tMysqlOutput_1_ERROR_MESSAGE") return null

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tMysqlOutput/tMysqlOutput_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMysqlOutput/tMysqlOutput_end.javajet
@@ -400,6 +400,7 @@ skeleton="../templates/db_output_bulk.skeleton"
 	    	    	}
 					dbLog.logPrintedException("e.getMessage()");
 					%>
+					globalMap.put(currentComponent+"_ERROR_MESSAGE",e.getMessage());
                 	System.err.println(e.getMessage());
                 	<%
                 	}%>


### PR DESCRIPTION
without 'die on error' on the component
https://jira.talendforge.org/browse/TDI-35892