### PR TITLE
TDI-36044: 'Enable parallel execution' shouldn't been enabled when

### DIFF
--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/cmd/ChangeValuesFromRepository.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/cmd/ChangeValuesFromRepository.java
@@ -280,9 +280,11 @@ public class ChangeValuesFromRepository extends ChangeMetadataCommand {
                             }
                         }
                     }
-                    param.setReadOnly(false);
-                    // for job settings extra.(feature 2710)
-                    param.setRepositoryValueUsed(false);
+                    if (param.getRepositoryValue() != null) {
+                        param.setReadOnly(false);
+                        // for job settings extra.(feature 2710)
+                        param.setRepositoryValueUsed(false);
+                    }
                 }
 
             }


### PR DESCRIPTION
switch property type between built-in and repository.