### PR TITLE
TDI-36765: The handling of data source changed.

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tDB2Output/tDB2Output_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tDB2Output/tDB2Output_begin.javajet
@@ -162,20 +162,6 @@ if(("true").equals(useExistingConn)) {
     %>
     dbschema_<%=cid%> = (String)globalMap.get("<%=tableschema%>");
     conn_<%=cid%> = (java.sql.Connection)globalMap.get("<%=conn%>");
-    <%
-	INode connectionNode = NodeUtil.getNodeByUniqueName(node.getProcess(),connection);
-	boolean specify_alias = "true".equals(ElementParameterParser.getValue(connectionNode, "__SPECIFY_DATASOURCE_ALIAS__"));
-	if(specify_alias){
-		String alias = ElementParameterParser.getValue(connectionNode, "__DATASOURCE_ALIAS__");
-		String autoCommit = "true".equals(ElementParameterParser.getValue(connectionNode, "__AUTO_COMMIT__"))?"true":"false";
-		%>
-		if (null == conn_<%=cid%>) {
-			java.util.Map<String, routines.system.TalendDataSource> dataSources_<%=cid%> = (java.util.Map<String, routines.system.TalendDataSource>) globalMap.get(KEY_DB_DATASOURCES);
-			conn_<%=cid%> = dataSources_<%=cid%>.get(<%=(null != alias && !("".equals(alias)))?alias:"\"\""%>).getConnection();
-		}
-	<%
-	}
-	%>
     dbUser_<%=cid %> = (String)globalMap.get("<%=username%>");
     <%dbLog.conn().useExistConn("conn_"+cid+".getMetaData().getURL()", "conn_"+cid+".getMetaData().getUserName()");%>
     <%
@@ -185,8 +171,15 @@ if(("true").equals(useExistingConn)) {
 		String alias = ElementParameterParser.getValue(node, "__DATASOURCE_ALIAS__");
 		%>
 		java.util.Map<String, routines.system.TalendDataSource> dataSources_<%=cid%> = (java.util.Map<String, routines.system.TalendDataSource>) globalMap.get(KEY_DB_DATASOURCES);
-		if (null != dataSources_<%=cid%>) {
-			conn_<%=cid %> = dataSources_<%=cid%>.get(<%=(null != alias && !("".equals(alias)))?alias:"\"\""%>).getConnection();
+		if (dataSources_<%=cid%> != null) {
+			String dsAlias_<%=cid%> = <%=(null != alias && !("".equals(alias)))?alias:"\"\""%>;
+			if (dataSources_<%=cid%>.get(dsAlias_<%=cid%>) == null) {
+				throw new Exception("No data source with alias: " + dsAlias_<%=cid%> + " available!");
+			}
+			conn_<%=cid%> = dataSources_<%=cid%>.get(dsAlias_<%=cid%>).getRawDataSource().getConnection();
+			if (conn_<%=cid%> == null) {
+		   	throw new Exception("Unable to get a pooled database connection from pool: " + dsAlias_<%=cid%>);
+			}
 		} else {
 	<%
 	}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tJDBCOutput/tJDBCOutput_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tJDBCOutput/tJDBCOutput_begin.javajet
@@ -123,28 +123,6 @@ if(("true").equals(useExistingConn)){
 	String conn = "conn_" + connection;
 	%>
 	java.sql.Connection connection_<%=cid %> = (java.sql.Connection)globalMap.get("<%=conn %>");
-<%
-	INode connectionNode = null;
-	for (INode processNode : node.getProcess().getGeneratingNodes()) {
-		if(connection.equals(processNode.getUniqueName())) {
-			connectionNode = processNode;
-			break;
-		}
-	}
-	boolean specify_alias = "true".equals(ElementParameterParser.getValue(connectionNode, "__SPECIFY_DATASOURCE_ALIAS__"));
-	if(specify_alias){
-		String alias = ElementParameterParser.getValue(connectionNode, "__DATASOURCE_ALIAS__");
-		String autoCommit = "true".equals(ElementParameterParser.getValue(connectionNode, "__AUTO_COMMIT__"))?"true":"false";
-%>
-		if (null == connection_<%=cid %>) {
-			java.util.Map<String, routines.system.TalendDataSource> dataSources_<%=cid%> = (java.util.Map<String, routines.system.TalendDataSource>) globalMap.get(KEY_DB_DATASOURCES);
-			connection_<%=cid %> = dataSources_<%=cid%>.get(<%=(null != alias && !("".equals(alias)))?alias:"\"\""%>).getConnection();
-			if (connection_<%=cid%> != null) {
-				connection_<%=cid%>.setAutoCommit(<%=autoCommit%>);
-			}
-		}
-	<%
-	}
 	dbLog.conn().useExistConn("connection_"+cid+".getMetaData().getURL()", "connection_"+cid+".getMetaData().getUserName()");
 } else {
     %>
@@ -156,8 +134,15 @@ if(("true").equals(useExistingConn)){
 		String alias = ElementParameterParser.getValue(node, "__DATASOURCE_ALIAS__");
 	%>
 		java.util.Map<String, routines.system.TalendDataSource> dataSources_<%=cid%> = (java.util.Map<String, routines.system.TalendDataSource>) globalMap.get(KEY_DB_DATASOURCES);
-		if (null != dataSources_<%=cid%>) {
-			connection_<%=cid %> = dataSources_<%=cid%>.get(<%=(null != alias && !("".equals(alias)))?alias:"\"\""%>).getConnection();
+		if (dataSources_<%=cid%> != null) {
+			String dsAlias_<%=cid%> = <%=(null != alias && !("".equals(alias)))?alias:"\"\""%>;
+			if (dataSources_<%=cid%>.get(dsAlias_<%=cid%>) == null) {
+				throw new Exception("No data source with alias: " + dsAlias_<%=cid%> + " available!");
+			}
+			conn_<%=cid%> = dataSources_<%=cid%>.get(dsAlias_<%=cid%>).getRawDataSource().getConnection();
+			if (conn_<%=cid%> == null) {
+		   	throw new Exception("Unable to get a pooled database connection from pool: " + dsAlias_<%=cid%>);
+			}
 		} else {
 	<%
 	}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMysqlOutput/tMysqlOutput_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMysqlOutput/tMysqlOutput_begin.javajet
@@ -179,30 +179,6 @@ if(useExistingConnection) {
 	}
 %>
 	conn_<%=cid%> = (java.sql.Connection)globalMap.get("<%=conn%>");
-<%
-	INode connectionNode = null;
-	for (INode processNode : node.getProcess().getGeneratingNodes()) {
-		String nodeUniqueName = processNode.getUniqueName();
-		if(connection.equals(nodeUniqueName) || (connection+"_in").equals(nodeUniqueName)) {
-			connectionNode = processNode;
-			break;
-		}
-	}
-	boolean specify_alias = "true".equals(ElementParameterParser.getValue(connectionNode, "__SPECIFY_DATASOURCE_ALIAS__"));
-	if(specify_alias){
-		String alias = ElementParameterParser.getValue(connectionNode, "__DATASOURCE_ALIAS__");
-		String autoCommit = "true".equals(ElementParameterParser.getValue(connectionNode, "__AUTO_COMMIT__"))?"true":"false";
-%>
-		if (null == conn_<%=cid%>) {
-			java.util.Map<String, routines.system.TalendDataSource> dataSources_<%=cid%> = (java.util.Map<String, routines.system.TalendDataSource>) globalMap.get(KEY_DB_DATASOURCES);
-			conn_<%=cid%> = dataSources_<%=cid%>.get(<%=(null != alias && !("".equals(alias)))?alias:"\"\""%>).getConnection();
-			if (conn_<%=cid%> != null) {
-				conn_<%=cid%>.setAutoCommit(<%=autoCommit%>);
-			}
-		}
-	<%
-	}
-	%>
 	<%dbLog.conn().useExistConn("conn_"+cid+".getMetaData().getURL()", "conn_"+cid+".getMetaData().getUserName()");%>
 <%
 } else {
@@ -213,8 +189,15 @@ if(useExistingConnection) {
 		String alias = ElementParameterParser.getValue(node, "__DATASOURCE_ALIAS__");
 %>
 		java.util.Map<String, routines.system.TalendDataSource> dataSources_<%=cid%> = (java.util.Map<String, routines.system.TalendDataSource>) globalMap.get(KEY_DB_DATASOURCES);
-		if (null != dataSources_<%=cid%>) {
-			conn_<%=cid %> = dataSources_<%=cid%>.get(<%=(null != alias && !("".equals(alias)))?alias:"\"\""%>).getConnection();
+		if (dataSources_<%=cid%> != null) {
+			String dsAlias_<%=cid%> = <%=(null != alias && !("".equals(alias)))?alias:"\"\""%>;
+			if (dataSources_<%=cid%>.get(dsAlias_<%=cid%>) == null) {
+				throw new Exception("No data source with alias: " + dsAlias_<%=cid%> + " available!");
+			}
+			conn_<%=cid%> = dataSources_<%=cid%>.get(dsAlias_<%=cid%>).getRawDataSource().getConnection();
+			if (conn_<%=cid%> == null) {
+		   	throw new Exception("Unable to get a pooled database connection from pool: " + dsAlias_<%=cid%>);
+			}
 		} else {
 <%
 	}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tOracleOutput/tOracleOutput_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tOracleOutput/tOracleOutput_begin.javajet
@@ -206,23 +206,6 @@ skeleton="../templates/db_output_bulk.skeleton"
         %>
         dbschema_<%=cid%> = (String)globalMap.get("<%=schema%>");
         conn_<%=cid%> = (java.sql.Connection)globalMap.get("<%=conn%>");
-        <%
-        boolean specify_alias = "true".equals(ElementParameterParser.getValue(connectionNode, "__SPECIFY_DATASOURCE_ALIAS__"));
-        if(specify_alias){
-            String alias = ElementParameterParser.getValue(connectionNode, "__DATASOURCE_ALIAS__");
-            String autoCommit = "true".equals(ElementParameterParser.getValue(connectionNode, "__AUTO_COMMIT__"))?"true":"false";
-            %>
-            if (null == conn_<%=cid%>) {
-                java.util.Map<String, routines.system.TalendDataSource> dataSources_<%=cid%> = (java.util.Map<String, routines.system.TalendDataSource>) globalMap.get(KEY_DB_DATASOURCES);
-                conn_<%=cid%> = dataSources_<%=cid%>.get(<%=(null != alias && !("".equals(alias)))?alias:"\"\""%>).getConnection();
-                if (conn_<%=cid%> != null) {
-                    conn_<%=cid%>.setAutoCommit(<%=autoCommit%>);
-                }
-            }
-        <%
-        }
-        %>
-
         <%dbLog.conn().useExistConn("conn_"+cid+".getMetaData().getURL()", "conn_"+cid+".getMetaData().getUserName()");%>
     <%
     } else {
@@ -230,10 +213,17 @@ skeleton="../templates/db_output_bulk.skeleton"
         if(specify_alias){
             String alias = ElementParameterParser.getValue(node, "__DATASOURCE_ALIAS__");
             %>
-            java.util.Map<String, routines.system.TalendDataSource> dataSources_<%=cid%> = (java.util.Map<String, routines.system.TalendDataSource>) globalMap.get(KEY_DB_DATASOURCES);
-            if (null != dataSources_<%=cid%>) {
-                conn_<%=cid %> = dataSources_<%=cid%>.get(<%=(null != alias && !("".equals(alias)))?alias:"\"\""%>).getConnection();
-            } else {
+			java.util.Map<String, routines.system.TalendDataSource> dataSources_<%=cid%> = (java.util.Map<String, routines.system.TalendDataSource>) globalMap.get(KEY_DB_DATASOURCES);
+			if (dataSources_<%=cid%> != null) {
+				String dsAlias_<%=cid%> = <%=(null != alias && !("".equals(alias)))?alias:"\"\""%>;
+				if (dataSources_<%=cid%>.get(dsAlias_<%=cid%>) == null) {
+					throw new Exception("No data source with alias: " + dsAlias_<%=cid%> + " available!");
+				}
+				conn_<%=cid%> = dataSources_<%=cid%>.get(dsAlias_<%=cid%>).getRawDataSource().getConnection();
+				if (conn_<%=cid%> == null) {
+			   	throw new Exception("Unable to get a pooled database connection from pool: " + dsAlias_<%=cid%>);
+				}
+			} else {
         <%
         }
         %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPostgresqlOutput/tPostgresqlOutput_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPostgresqlOutput/tPostgresqlOutput_begin.javajet
@@ -174,21 +174,6 @@ if(("true").equals(useExistingConn)) {
 	String conn = "conn_" + connection;
 	%>
 	conn_<%=cid%> = (java.sql.Connection)globalMap.get("<%=conn%>");
-	<%
-	INode connectionNode = NodeUtil.getNodeByUniqueName(node.getProcess(),connection);
-	boolean specify_alias = "true".equals(ElementParameterParser.getValue(connectionNode, "__SPECIFY_DATASOURCE_ALIAS__"));
-	if(specify_alias){
-		String alias = ElementParameterParser.getValue(connectionNode, "__DATASOURCE_ALIAS__");
-		String autoCommit = "true".equals(ElementParameterParser.getValue(connectionNode, "__AUTO_COMMIT__"))?"true":"false";
-		%>
-		if (null == conn_<%=cid%>) {
-			java.util.Map<String, routines.system.TalendDataSource> dataSources_<%=cid%> = (java.util.Map<String, routines.system.TalendDataSource>) globalMap.get(KEY_DB_DATASOURCES);
-			conn_<%=cid%> = dataSources_<%=cid%>.get(<%=(null != alias && !("".equals(alias)))?alias:"\"\""%>).getConnection();
-		}
-	<%
-	}
-	%>
-	
 	<%dbLog.conn().useExistConn("conn_"+cid+".getMetaData().getURL()", "conn_"+cid+".getMetaData().getUserName()");%>
 	<%if(savePoint && !useBatchSize && !("true").equals(dieOnError)){%>
 		java.sql.Savepoint  sp_<%=cid %> = null;
@@ -199,8 +184,15 @@ if(("true").equals(useExistingConn)) {
 		String alias = ElementParameterParser.getValue(node, "__DATASOURCE_ALIAS__");
 		%>
 		java.util.Map<String, routines.system.TalendDataSource> dataSources_<%=cid%> = (java.util.Map<String, routines.system.TalendDataSource>) globalMap.get(KEY_DB_DATASOURCES);
-		if (null != dataSources_<%=cid%>) {
-			conn_<%=cid %> = dataSources_<%=cid%>.get(<%=(null != alias && !("".equals(alias)))?alias:"\"\""%>).getConnection();
+		if (dataSources_<%=cid%> != null) {
+			String dsAlias_<%=cid%> = <%=(null != alias && !("".equals(alias)))?alias:"\"\""%>;
+			if (dataSources_<%=cid%>.get(dsAlias_<%=cid%>) == null) {
+				throw new Exception("No data source with alias: " + dsAlias_<%=cid%> + " available!");
+			}
+			conn_<%=cid%> = dataSources_<%=cid%>.get(dsAlias_<%=cid%>).getRawDataSource().getConnection();
+			if (conn_<%=cid%> == null) {
+		   	throw new Exception("Unable to get a pooled database connection from pool: " + dsAlias_<%=cid%>);
+			}
 		} else {
 	<%
 	}

--- a/main/plugins/org.talend.designer.components.localprovider/components/templates/DB/AbstractDBConnection.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/templates/DB/AbstractDBConnection.javajet
@@ -19,6 +19,7 @@ imports="
     String dbuser = ElementParameterParser.getValue(node, "__USER__");
     String dbpass = ElementParameterParser.getValue(node, "__PASS__");
     String encoding = ElementParameterParser.getValue(node, "__ENCODING__");
+	String alias = ElementParameterParser.getValue(node, "__DATASOURCE_ALIAS__");
     
 	boolean isUseSharedConnection = ("true").equals(ElementParameterParser.getValue(node, "__USE_SHARED_CONNECTION__"));
 %>
@@ -48,12 +49,11 @@ imports="
 	} else {
 		boolean specify_alias = "true".equals(ElementParameterParser.getValue(node, "__SPECIFY_DATASOURCE_ALIAS__"));
 		if(specify_alias){
-			String alias = ElementParameterParser.getValue(node, "__DATASOURCE_ALIAS__");
 %>
-
-	if ((null == globalMap.get(KEY_DB_DATASOURCES)) || "".equals(<%=(null != alias && !("".equals(alias)))?alias:"\"\""%>)) {
+	java.util.Map<String, routines.system.TalendDataSource> dataSources_<%=cid%> = (java.util.Map<String, routines.system.TalendDataSource>) globalMap.get(KEY_DB_DATASOURCES);
+	if (dataSources_<%=cid%> == null) {
 <%
-		}
+		} // if(specify_alias)
 %>
 		<%connUtil.classForName(node);%>
 		<%
@@ -63,17 +63,26 @@ imports="
 		log4jCodeGenerateUtil.connect_end();
 		%>
 
-		globalMap.put("conn_<%=cid%>", conn_<%=cid%>);
 <%
 		if(specify_alias){
 %>
+	} else {
+    	String dsAlias_<%=cid%> = <%=(null != alias && !("".equals(alias)))?alias:"\"\""%>;
+      if (dataSources_<%=cid%>.get(dsAlias_<%=cid%>) == null) {
+       	throw new Exception("No DataSource with alias: " + dsAlias_<%=cid%> + " available!");
+      }
+	   conn_<%=cid%> = dataSources_<%=cid%>.get(dsAlias_<%=cid%>).getRawDataSource().getConnection();
+	   if (conn_<%=cid%> == null) {
+	   	throw new Exception("Unable to get a pooled database connection from pool: " + dsAlias_<%=cid%>);
+	   }
 	}
 <%
-		}
-	}
+		} // if(specify_alias)
+	} // else if(isUseSharedConnection)
 %>
 	if (null != conn_<%=cid%>) {
 		<%connUtil.setAutoCommit(node);%>
+		globalMap.put("conn_<%=cid%>", conn_<%=cid%>);
 	}
 <%
 	connUtil.afterComponentProcess(node);

--- a/main/plugins/org.talend.designer.components.localprovider/components/templates/DB/Commit/AbstractDBCommit.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/templates/DB/Commit/AbstractDBCommit.javajet
@@ -6,7 +6,7 @@ imports="
     org.talend.core.model.utils.NodeUtil
 " 
 %>
-<%@ include file="../../Log4j/Log4jDBConnUtil.javajet"%>
+<%@ include file="{org.talend.designer.components.localprovider}/Log4j/Log4jDBConnUtil.javajet"%>
 <%
     CodeGeneratorArgument codeGenArgument = (CodeGeneratorArgument) argument;
     INode node = (INode)codeGenArgument.getArgument();
@@ -20,23 +20,6 @@ imports="
     String conn = "conn_" + connection;
 %>
 	java.sql.Connection conn_<%=cid%> = (java.sql.Connection)globalMap.get("<%=conn%>");
-    <%
-	INode connectionNode = NodeUtil.getNodeByUniqueName(node.getProcess(),connection);
-	boolean specify_alias = "true".equals(ElementParameterParser.getValue(connectionNode, "__SPECIFY_DATASOURCE_ALIAS__"));
-	if(specify_alias){
-		String alias = ElementParameterParser.getValue(connectionNode, "__DATASOURCE_ALIAS__");
-		%>
-		if (null == conn_<%=cid%>) {
-			java.util.Map<String, routines.system.TalendDataSource> dataSources_<%=cid%> = (java.util.Map<String, routines.system.TalendDataSource>) globalMap.get(KEY_DB_DATASOURCES); 
-			if(dataSources_<%=cid%>!=null) {
-				if(dataSources_<%=cid%>.get(<%=(null != alias && !("".equals(alias)))?alias:"\"\""%>)!=null) {
-					conn_<%=cid%> = dataSources_<%=cid%>.get(<%=(null != alias && !("".equals(alias)))?alias:"\"\""%>).getConnection();
-				}
-			}
-		}
-	<%
-	}
-	%>
 	if(conn_<%=cid%> != null && !conn_<%=cid%>.isClosed())
 	{
 	<%  if(close){%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/templates/DB/Input/AbstractDBInputBegin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/templates/DB/Input/AbstractDBInputBegin.javajet
@@ -58,32 +58,11 @@ imports="
                 }
 %>
 		        conn_<%=cid%> = (java.sql.Connection)globalMap.get("<%=conn%>");
-<%
-                INode connectionNode = null;
-                for (INode processNode : node.getProcess().getGeneratingNodes()) {
-                	String nodeUniqueName = processNode.getUniqueName();
-                	if(connection.equals(nodeUniqueName) || (connection+"_in").equals(nodeUniqueName)) {
-                		connectionNode = processNode;
-                		break;
-                	}
-                }
-		        boolean specify_alias = "true".equals(ElementParameterParser.getValue(connectionNode, "__SPECIFY_DATASOURCE_ALIAS__"));
-		        if(specify_alias){
-	                String alias = ElementParameterParser.getValue(connectionNode, "__DATASOURCE_ALIAS__");
-%>
-		        	if (null == conn_<%=cid%>) {
-						java.util.Map<String, routines.system.TalendDataSource> dataSources_<%=cid%> = (java.util.Map<String, routines.system.TalendDataSource>) globalMap.get(KEY_DB_DATASOURCES);
-						conn_<%=cid%> = dataSources_<%=cid%>.get(<%=(null != alias && !("".equals(alias)))?alias:"\"\""%>).getConnection();
-						//globalMap.put("<%=conn%>", conn_<%=cid%>);
-		        	}
-		        <%
-		        }
-		        %>
-				<%log4jCodeGenerateUtil.useExistConnection(node);%>
+ 				  <%log4jCodeGenerateUtil.useExistConnection(node);%>
 <%
 				dbInputBeginUtil.afterUseExistConnection(node);
 
-		    } else {
+		    } else { // if(("true").equals(useExistingConn))
 				dbInputBeginUtil.createConnection(node);
 				if ("teradata_id".equalsIgnoreCase(dbms)) {
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/templates/DB/Input/HelpClass.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/templates/DB/Input/HelpClass.javajet
@@ -62,11 +62,18 @@ imports="
  		if(specify_alias){
 %>
             java.util.Map<String, routines.system.TalendDataSource> dataSources_<%=cid%> = (java.util.Map<String, routines.system.TalendDataSource>) globalMap.get(KEY_DB_DATASOURCES);
-            if (null != dataSources_<%=cid%>) {
+            if (dataSources_<%=cid%> != null) {
 <%
                 String alias = ElementParameterParser.getValue(node, "__DATASOURCE_ALIAS__");
 %>
-                conn_<%=cid%> = dataSources_<%=cid%>.get(<%=(null != alias && !("".equals(alias)))?alias:"\"\""%>).getConnection();
+					 String dsAlias_<%=cid%> = <%=(null != alias && !("".equals(alias)))?alias:"\"\""%>;
+                if (dataSources_<%=cid%>.get(dsAlias_<%=cid%>) == null) {
+                	throw new Exception("No data source with alias: " + dsAlias_<%=cid%> + " available!");
+                }
+                conn_<%=cid%> = dataSources_<%=cid%>.get(dsAlias_<%=cid%>).getRawDataSource().getConnection();
+                if (conn_<%=cid%> == null) {
+				   	throw new Exception("Unable to get a pooled database connection from pool: " + dsAlias_<%=cid%>);
+                }
             } else {
 <%
 		}

--- a/main/plugins/org.talend.designer.components.localprovider/components/templates/DB/Rollback/AbstractDBRollback.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/templates/DB/Rollback/AbstractDBRollback.javajet
@@ -19,24 +19,7 @@ imports="
 
     String conn = "conn_" + connection;
 %>
-	java.sql.Connection conn_<%=cid%> = (java.sql.Connection)globalMap.get("<%=conn%>");
-    <%
-	INode connectionNode = NodeUtil.getNodeByUniqueName(node.getProcess(),connection);
-	boolean specify_alias = "true".equals(ElementParameterParser.getValue(connectionNode, "__SPECIFY_DATASOURCE_ALIAS__"));
-	if(specify_alias){
-		String alias = ElementParameterParser.getValue(connectionNode, "__DATASOURCE_ALIAS__");
-		%>
-		if (null == conn_<%=cid%>) {
-			java.util.Map<String, routines.system.TalendDataSource> dataSources_<%=cid%> = (java.util.Map<String, routines.system.TalendDataSource>) globalMap.get(KEY_DB_DATASOURCES); 
-			if(dataSources_<%=cid%>!=null) {
-				if(dataSources_<%=cid%>.get(<%=(null != alias && !("".equals(alias)))?alias:"\"\""%>)!=null) {
-					conn_<%=cid%> = dataSources_<%=cid%>.get(<%=(null != alias && !("".equals(alias)))?alias:"\"\""%>).getConnection();
-				}
-			}
-		}
-	<%
-	}
-	%>
+	java.sql.Connection conn_<%=cid%> = (java.sql.Connection) globalMap.get("<%=conn%>");
 	if(conn_<%=cid%> != null && !conn_<%=cid%>.isClosed()) {
 		<%
 		if(close){

--- a/main/plugins/org.talend.designer.components.localprovider/components/templates/DB/Row/HelpClass.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/templates/DB/Row/HelpClass.javajet
@@ -60,39 +60,22 @@
 				%>
 				conn_<%=cid%> = (java.sql.Connection)globalMap.get("<%=conn%>");
 			<%	
-				INode connectionNode = null; 
-				for (INode processNode : node.getProcess().getGeneratingNodes()) { 
-					if(connection.equals(processNode.getUniqueName())) { 
-						connectionNode = processNode; 
-						break; 
-					} 
-				} 
-				boolean specify_alias = "true".equals(ElementParameterParser.getValue(connectionNode, "__SPECIFY_DATASOURCE_ALIAS__"));
-				if(specify_alias){ 
-					String alias = ElementParameterParser.getValue(connectionNode, "__DATASOURCE_ALIAS__"); 
-					String autoCommit = "true".equals(ElementParameterParser.getValue(connectionNode, "__AUTO_COMMIT__"))?"true":"false";
-				%> 
-					if (null == conn_<%=cid%>) {
-						java.util.Map<String, routines.system.TalendDataSource> dataSources_<%=cid%> = (java.util.Map<String, routines.system.TalendDataSource>) globalMap.get(KEY_DB_DATASOURCES); 
-						conn_<%=cid%> = dataSources_<%=cid%>.get(<%=(null != alias && !("".equals(alias)))?alias:"\"\""%>).getConnection();
-						if (conn_<%=cid%> != null) { 
-							conn_<%=cid%>.setAutoCommit(<%=autoCommit%>);
-						}
-					}
-				<%
-				}
 				this.afterUseExistConnection(node);
 			} else {
 	 			boolean specify_alias = "true".equals(ElementParameterParser.getValue(node, "__SPECIFY_DATASOURCE_ALIAS__"));
 		 		if(specify_alias){
 				%>
-		            java.util.Map<String, routines.system.TalendDataSource> dataSources_<%=cid%> = (java.util.Map<String, routines.system.TalendDataSource>) globalMap.get(KEY_DB_DATASOURCES);
-		            if (null != dataSources_<%=cid%>) {
-						<%
-		                String alias = ElementParameterParser.getValue(node, "__DATASOURCE_ALIAS__");
-						%>
-		                conn_<%=cid%> = dataSources_<%=cid%>.get(<%=(null != alias && !("".equals(alias)))?alias:"\"\""%>).getConnection();
-		            } else {
+            java.util.Map<String, routines.system.TalendDataSource> dataSources_<%=cid%> = (java.util.Map<String, routines.system.TalendDataSource>) globalMap.get(KEY_DB_DATASOURCES);
+            if (dataSources_<%=cid%> != null) {
+					String dsAlias_<%=cid%> = <%=(null != alias && !("".equals(alias)))?alias:"\"\""%>;
+					if (dataSources_<%=cid%>.get(dsAlias_<%=cid%>) == null) {
+						throw new Exception("No data source with alias: " + dsAlias_<%=cid%> + " available!");
+					}
+					conn_<%=cid%> = dataSources_<%=cid%>.get(dsAlias_<%=cid%>).getRawDataSource().getConnection();
+					if (conn_<%=cid%> == null) {
+				   	throw new Exception("Unable to get a pooled database connection from pool: " + dsAlias_<%=cid%>);
+					}
+            } else {
 				<%
 				}
 				this.classForName(node);

--- a/main/plugins/org.talend.designer.components.localprovider/components/templates/tMSSql/_tMSSqlConnection.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/templates/tMSSql/_tMSSqlConnection.javajet
@@ -17,19 +17,6 @@ if(useExistingConnection) {
 	%>
 	dbschema_<%=cid%> = (String)globalMap.get("<%=schema%>");
 	conn_<%=cid%> = (java.sql.Connection)globalMap.get("<%=conn%>");
-    <%
-	INode connectionNode = NodeUtil.getNodeByUniqueName(node.getProcess(),connection);
-	boolean specify_alias = "true".equals(ElementParameterParser.getValue(connectionNode, "__SPECIFY_DATASOURCE_ALIAS__"));
-	if(isEnableDatasource && specify_alias){
-		String alias = ElementParameterParser.getValue(connectionNode, "__DATASOURCE_ALIAS__");
-		%>
-		if (null == conn_<%=cid%>) {
-			java.util.Map<String, routines.system.TalendDataSource> dataSources_<%=cid%> = (java.util.Map<String, routines.system.TalendDataSource>) globalMap.get(KEY_DB_DATASOURCES);
-			conn_<%=cid%> = dataSources_<%=cid%>.get(<%=(null != alias && !("".equals(alias)))?alias:"\"\""%>).getConnection();
-		}
-	<%
-	}
-	%>
 	<%dbLog.conn().useExistConn("conn_"+cid+".getMetaData().getURL()", "conn_"+cid+".getMetaData().getUserName()");%>
 <%
 } else {
@@ -38,8 +25,15 @@ if(useExistingConnection) {
 		String alias = ElementParameterParser.getValue(node, "__DATASOURCE_ALIAS__");
 		%>
 		java.util.Map<String, routines.system.TalendDataSource> dataSources_<%=cid%> = (java.util.Map<String, routines.system.TalendDataSource>) globalMap.get(KEY_DB_DATASOURCES);
-		if (null != dataSources_<%=cid%>) {
-			conn_<%=cid %> = dataSources_<%=cid%>.get(<%=(null != alias && !("".equals(alias)))?alias:"\"\""%>).getConnection();
+		if (dataSources_<%=cid%> != null) {
+			String dsAlias_<%=cid%> = <%=(null != alias && !("".equals(alias)))?alias:"\"\""%>;
+			if (dataSources_<%=cid%>.get(dsAlias_<%=cid%>) == null) {
+				throw new Exception("No data source with alias: " + dsAlias_<%=cid%> + " available!");
+			}
+			conn_<%=cid%> = dataSources_<%=cid%>.get(dsAlias_<%=cid%>).getRawDataSource().getConnection();
+			if (conn_<%=cid%> == null) {
+		   	throw new Exception("Unable to get a pooled database connection from pool: " + dsAlias_<%=cid%>);
+			}
 		} else {
 	<%
 	}


### PR DESCRIPTION
In AbstractDBConnection.javajet the connection will be get from the data source and provided to all other components
In the Output_begin.javajet the connections will be gathered from the real data source be accessing the method getRawDataSource()
Checks included to avoid meaningless NullPointerExceptions in case of misconfigurations and send useful Exceptions.
Commit and Rollbacks only uses the connections from the tConnection component.
