### PR TITLE
TUP-3927：when a routines missing a jar, then run/build other jobs which

### DIFF
--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/java/JavaProcessorUtilities.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/java/JavaProcessorUtilities.java
@@ -316,7 +316,8 @@ public class JavaProcessorUtilities {
         for (ModuleNeeded moduleNeeded : ModulesNeededProvider.getRunningModules()) {
             optionalJarsOnlyForRoutines.add(moduleNeeded);
         }
-
+        
+        optionalJarsOnlyForRoutines.addAll(ModulesNeededProvider.getModulesNeededForRoutines(ERepositoryObjectType.ROUTINES));
         // list contains all routines linked to job as well as routines not used in the job
         // rebuild the list to have only the libs linked to routines "not used".
         optionalJarsOnlyForRoutines.removeAll(listModulesReallyNeeded);


### PR DESCRIPTION
has no relationship with it will all show missing jar first.