### PR TITLE
[TBD-3774] Rename HDP 2.3 assembly to fix path length on Windows

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/plugin.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/plugin.xml
@@ -838,13 +838,14 @@
         <libraryNeeded
             context="plugin:org.talend.libraries.hadoop.hdp.2.3"
             id="talend-spark-assembly-HDP_2_3"
-            name="talend-spark-assembly-1.4.1.2.3.2.0-2950-hadoop2.7.1.2.3.2.0-2950-without-parquet.jar" mvn_uri="mvn:org.talend.libraries/talend-spark-assembly-1.4.1.2.3.2.0-2950-hadoop2.7.1.2.3.2.0-2950-without-parquet/6.1.0">
+            name="talend-spark-assembly-1.4.1.2.3.2.0.jar" 
+            mvn_uri="mvn:org.talend.libraries/talend-spark-assembly-1.4.1.2.3.2.0/6.1.0">
         </libraryNeeded>
 
         <libraryNeeded
             context="plugin:org.talend.libraries.hadoop.hdp.2.3"
             id="spark-streaming-kafka-assembly-HDP_2_3"
-            name="spark-streaming-kafka-assembly_2.10-1.4.1.2.3.2.0-2950.jar" 
+            name="spark-streaming-kafka-assembly_2.10-1.4.1.2.3.2.0-2950.jar"
             mvn_uri="mvn:org.talend.libraries/spark-streaming-kafka-assembly_2.10-1.4.1.2.3.2.0-2950/6.1.0">
         </libraryNeeded>
 
@@ -1800,7 +1801,7 @@
          	name="commons-codec-1.4.jar" mvn_uri="mvn:org.talend.libraries/commons-codec-1.4/6.0.0"
          	uripath="platform:/plugin/org.talend.libraries.apache.common/lib/commons-codec-1.4.jar">
     	</libraryNeeded>
-    	
+
        <libraryNeeded
             context="plugin:org.talend.libraries.apache.common"
             id="commons-codec-1.5.jar"
@@ -2946,7 +2947,7 @@
         </libraryNeeded>
         <libraryNeeded
             id="commons-lang3-3.0.jar"
-            name="commons-lang3-3.0.jar" mvn_uri="mvn:org.talend.libraries/commons-lang3-3.0/6.0.0" 
+            name="commons-lang3-3.0.jar" mvn_uri="mvn:org.talend.libraries/commons-lang3-3.0/6.0.0"
             context="plugin:org.talend.libraries.apache.common"
             uripath="platform:/plugin/org.talend.libraries.apache.common/lib/commons-lang3-3.0.jar">
         </libraryNeeded>
@@ -7156,7 +7157,7 @@
                  id="derby-10.4.2.0.jar">
              </library>
         </libraryNeededGroup>
-        
+
         <libraryNeededGroup
                 description="The lastest Hive libraries of MAPR41X"
                 id="HIVE100-LIB-MAPR41X_LASTEST"
@@ -7471,7 +7472,7 @@
                  id="high-scale-lib-1.1.1.jar">
              </library>
         </libraryNeededGroup>
-        
+
         <libraryNeededGroup
                 description="The lastest Hive hbase storage libraries of MAPR41X"
                 id="HIVE100-HBASE-LIB-MAPR41X_LASTEST"


### PR DESCRIPTION
Cherry-pick of the commit included in pull-request #532