### PR TITLE
TDI-27409: Unable to export a job via TIS Studio with statistics enable

### DIFF
--- a/main/plugins/org.talend.designer.publish.core/src/org/talend/designer/publish/core/actions/AbstractPublishJobAction.java
+++ b/main/plugins/org.talend.designer.publish.core/src/org/talend/designer/publish/core/actions/AbstractPublishJobAction.java
@@ -115,7 +115,7 @@ public abstract class AbstractPublishJobAction implements IRunnableWithProgress 
             tmpJob = File.createTempFile("job", ".jar", null);
             jobScriptsManager = JobScriptsManagerFactory.createManagerInstance(
                     JobScriptsManagerFactory.getDefaultExportChoiceMap(), processItem.getProcess().getDefaultContext(),
-                    JobScriptsManager.LAUNCHER_ALL, IProcessor.NO_STATISTICS, IProcessor.NO_TRACES, JobExportType.OSGI);
+                    JobScriptsManager.LAUNCHER_ALL, IProcessor.STATES_RUNTIME, IProcessor.NO_TRACES, JobExportType.OSGI);
             // generate
             jobScriptsManager.setDestinationPath(tmpJob.getAbsolutePath());
             JobExportAction action = new JobExportAction(Collections.singletonList(node), jobVersion, bundleVersion,
@@ -162,6 +162,7 @@ public abstract class AbstractPublishJobAction implements IRunnableWithProgress 
             // TDI-32861, because for publish job, so means, must be binaries
             exportChoiceMap.put(ExportChoice.binaries, true);
             exportChoiceMap.put(ExportChoice.includeLibs, true);
+            exportChoiceMap.put(ExportChoice.addStatistics, true);
 
             ProcessItem processItem = (ProcessItem) node.getObject().getProperty().getItem();
 

--- a/main/plugins/org.talend.designer.publish.core/src/org/talend/designer/publish/core/actions/AbstractPublishJobAction.java
+++ b/main/plugins/org.talend.designer.publish.core/src/org/talend/designer/publish/core/actions/AbstractPublishJobAction.java
@@ -115,7 +115,7 @@ public abstract class AbstractPublishJobAction implements IRunnableWithProgress 
             tmpJob = File.createTempFile("job", ".jar", null);
             jobScriptsManager = JobScriptsManagerFactory.createManagerInstance(
                     JobScriptsManagerFactory.getDefaultExportChoiceMap(), processItem.getProcess().getDefaultContext(),
-                    JobScriptsManager.LAUNCHER_ALL, IProcessor.STATES_RUNTIME, IProcessor.NO_TRACES, JobExportType.OSGI);
+                    JobScriptsManager.LAUNCHER_ALL, IProcessor.NO_STATISTICS, IProcessor.NO_TRACES, JobExportType.OSGI);
             // generate
             jobScriptsManager.setDestinationPath(tmpJob.getAbsolutePath());
             JobExportAction action = new JobExportAction(Collections.singletonList(node), jobVersion, bundleVersion,


### PR DESCRIPTION
TDI-27409: Unable to export a job via TIS Studio with statistics enable--for fixing publishJob from both Studio and CommandLine