### PR TITLE
TUP-6195:Should better restore the jobsetting view after close a job,

### DIFF
--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/ActiveProcessTracker.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/ActiveProcessTracker.java
@@ -240,15 +240,7 @@ public class ActiveProcessTracker implements IPartListener {
         if (part instanceof AbstractMultiPageTalendEditor) {
             AbstractMultiPageTalendEditor mpte = (AbstractMultiPageTalendEditor) part;
             mpte.beforeDispose();
-        }
-        IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
-        if (page != null) {
-            if (page.getActiveEditor() != null) {
-                if (!page.getActiveEditor().getSite().getId().equals(DISTARTID)
-                        && !page.getActiveEditor().getSite().getId().equals(MDMSTARTID)) {
-                    JobSettings.switchToCurJobSettingsView();
-                }
-            }
+            JobSettings.switchToCurJobSettingsView();
         }
 
     }


### PR DESCRIPTION
now show unhandle error when switch pages