### PR TITLE
TUP-15922: BD batch job:there is error when click "Save the property to Metadata" of tFileOutputDelimited

### DIFF
--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/properties/controllers/PropertyTypeController.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/properties/controllers/PropertyTypeController.java
@@ -123,7 +123,9 @@ public class PropertyTypeController extends AbstractRepositoryController {
         INode node = (INode) param.getElement();
         //
         String componentName = node.getComponent().getName();
-        return RepositoryComponentManager.validComponent(componentName);
+        String repositoryValue = param.getRepositoryValue();
+        boolean isHDFSRepVal = repositoryValue != null && repositoryValue.contains("HDFS"); //$NON-NLS-1$
+        return !isHDFSRepVal && RepositoryComponentManager.validComponent(componentName);
         // for (EDatabaseComponentName eComponent : EDatabaseComponentName.values()) {
         // if (componentName.equals(eComponent.getInputComponentName())
         // || componentName.equals(eComponent.getOutPutComponentName())) {


### PR DESCRIPTION
Just disable the save metadata to HDFS button since the component only take Row Seperator and Field Seperator from HDFS connection.