### PR TITLE
[TESB-18057] Fix

### DIFF
--- a/main/plugins/org.talend.designer.codegen/jet_stub/footer.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/footer.javajet
@@ -749,7 +749,7 @@ this.globalResumeTicket = false;//to run others jobs
                         status = localStatus;
                     }
 
-                    if ("true".equals(((java.util.Map) threadLocal.get()).get("ESBJobInterruptedException"))) {
+                    if ("true".equals(((java.util.Map) threadLocal.get()).get("JobInterrupted"))) {
                         launchingThread.interrupt();
                     }
 

--- a/main/plugins/org.talend.designer.codegen/jet_stub/footer.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/footer.javajet
@@ -768,6 +768,8 @@ this.globalResumeTicket = false;//to run others jobs
             Thread.sleep(10);
         } catch (java.lang.InterruptedException e) {
             interrupted = true;
+        } catch (java.lang.Exception e) {
+            e.printStackTrace();
         }
     }
 

--- a/main/plugins/org.talend.designer.codegen/jet_stub/footer.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/footer.javajet
@@ -707,6 +707,8 @@ this.globalResumeTicket = true;//to run tPreJob
 
 this.globalResumeTicket = false;//to run others jobs
 
+final Thread launchingThread = Thread.currentThread();
+
 <%
 
     //5. all others sub-job (MultiThread mode)
@@ -748,6 +750,10 @@ this.globalResumeTicket = false;//to run others jobs
                         status = localStatus;
                     }
 
+                    if ("true".equals(((java.util.Map) threadLocal.get()).get("ESBJobInterruptedException"))) {
+                        launchingThread.interrupt();
+                    }
+
                     runningThreadCount.add(-1);
                 }
             }
@@ -757,13 +763,20 @@ this.globalResumeTicket = false;//to run others jobs
             }
         }
 %>
+    boolean interrupted = false;
     while (runningThreadCount.getCount() > 0) {
         try {
             Thread.sleep(10);
-        } catch (java.lang.Exception e) {
-            e.printStackTrace();
+        } catch (java.lang.InterruptedException e) {
+            interrupted = true;
         }
     }
+
+    if (interrupted) {
+        Thread.currentThread().interrupt();
+    }
+
+
 <%
     } else { // isRunInMultiThread  //5. all others sub-job (SingleThread  mode)
         for (INode rootNode : rootNodes) {

--- a/main/plugins/org.talend.designer.codegen/jet_stub/footer.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/footer.javajet
@@ -707,12 +707,11 @@ this.globalResumeTicket = true;//to run tPreJob
 
 this.globalResumeTicket = false;//to run others jobs
 
-final Thread launchingThread = Thread.currentThread();
-
 <%
 
     //5. all others sub-job (MultiThread mode)
     if(isRunInMultiThread){
+        %>final Thread launchingThread = Thread.currentThread();<%
         for (INode rootNode : rootNodes) {
             String componentName = rootNode.getComponent().getName();
             String uniqueName = rootNode.getUniqueName();


### PR DESCRIPTION
When a job is undeployed in Runtime, corresponding thread receives interruption request from Karaf, and job controller treats the request as an indicator that the job is undeployed,  otherwise it tries to restart the job (probably as a sort of failure recovery).

When job multi thread execution is turned on, corresponding interruption request is sent to one of the subthreads, but not to the thread that is monitored by job controller, which leads to infnite attempts to restart the job and unlimited growth of logs.

Proposed fix sends interruption request to the thread, monitored by job controller in case if one of the subthreads receives interruption request.