### PR TITLE
TDI-37774 : backport to 5.6. Add getNextException to show more error message (#764)

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tDB2Output/tDB2Output_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tDB2Output/tDB2Output_begin.javajet
@@ -43,7 +43,40 @@ boolean isEnableDebug = ("true").equals(ElementParameterParser.getValue(node,"__
 boolean useBatchSize = ("true").equals(ElementParameterParser.getValue(node,"__USE_BATCH_SIZE__"));
 String batchSize=ElementParameterParser.getValue(node,"__BATCH_SIZE__");
 %>
-
+class PrintSQLException_<%=cid%>{
+	public String getSQLException(java.sql.SQLException ex,boolean skipFirst) {
+		StringBuilder fullErrorMessage = new java.lang.StringBuilder();
+    	for (Throwable e : ex) {
+    		if(skipFirst){
+    		    skipFirst=false;
+    		    continue;
+    		}
+        	if (e instanceof java.sql.SQLException) {
+                fullErrorMessage.append("SQLState: " +((java.sql.SQLException)e).getSQLState()+'\n');
+                fullErrorMessage.append("Error Code: " +((java.sql.SQLException)e).getErrorCode()+'\n');
+                fullErrorMessage.append("Message: " + e.getMessage());
+                Throwable t = ex.getCause();
+                while(t != null) {
+                    System.err.println("Cause: " + t);
+                    fullErrorMessage .append("Cause: " + t);
+                    t = t.getCause();
+                }
+        	}
+    	}
+    	return fullErrorMessage.toString();
+	}
+}
+PrintSQLException_<%=cid%> printSQLException_<%=cid%> = new PrintSQLException_<%=cid%>();
+int nb_line_<%=cid%> = 0;
+int nb_line_update_<%=cid%> = 0;
+int nb_line_inserted_<%=cid%> = 0;
+int nb_line_deleted_<%=cid%> = 0;
+int nb_line_rejected_<%=cid%> = 0;
+int deletedCount_<%=cid%> = 0;
+int updatedCount_<%=cid%> = 0;
+int insertedCount_<%=cid%> = 0;
+int rejectedCount_<%=cid%> = 0;
+try{
 <%
 getManager(dbmsId, cid, node);
 
@@ -124,15 +157,7 @@ if(("UPDATE").equals(dataAction) || ("INSERT_OR_UPDATE").equals(dataAction) || (
 }
 %>
 
-int nb_line_<%=cid%> = 0;
-int nb_line_update_<%=cid%> = 0;
-int nb_line_inserted_<%=cid%> = 0;
-int nb_line_deleted_<%=cid%> = 0;
-int nb_line_rejected_<%=cid%> = 0;
-int deletedCount_<%=cid%> = 0;
-int updatedCount_<%=cid%> = 0;
-int insertedCount_<%=cid%> = 0;
-int rejectedCount_<%=cid%> = 0;
+
 boolean whetherReject_<%=cid%> = false;
 <%
 String useExistingConn = ElementParameterParser.getValue(node,"__USE_EXISTING_CONNECTION__");
@@ -475,6 +500,5 @@ class DataPropagateUtil_<%=cid%> {
 }
 
 DataPropagateUtil_<%=cid%> dataPropagateUtil_<%=cid%> = new DataPropagateUtil_<%=cid%>();
-
 
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tDB2Output/tDB2Output_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tDB2Output/tDB2Output_end.javajet
@@ -95,6 +95,7 @@ imports="
     	<%
     	}else {
     	%>
+    	String errormessage_<%=cid%> = printSQLException_<%=cid%>.getSQLException(e,false);
     	int countSum_<%=cid%> = 0;
 		for(int countEach_<%=cid%>: e.getUpdateCounts()) {
 			countSum_<%=cid%> += (countEach_<%=cid%> < 0 ? 0 : countEach_<%=cid%>);
@@ -112,12 +113,9 @@ imports="
     	    deletedCount_<%=cid%> += countSum_<%=cid%>;
     	<%
     	}
-    	dbLog.logPrintedException("e.getMessage()");
-    	%> 
-    	System.err.println(e.getMessage());
-    	<%
-    	}%>                	
-	}                                  
+    	dbLog.logPrintedException("errormessage_"+cid);
+    	}%>
+	}
     <%
     }%>   
                 
@@ -146,5 +144,24 @@ imports="
     <%
 	}
     %>
-    
-<%@ include file="../templates/DB/Output/DBOutputEndGlobalVars.javajet"%>
+    } catch (java.sql.SQLException e) {
+       
+       
+       <%
+       		if(("true").equals(dieOnError)) {
+       %>
+           String errormessage_<%=cid%> = printSQLException_<%=cid%>.getSQLException(e,true);
+           <%dbLog.logPrintedException("errormessage_"+cid);%>
+           throw(e);
+       <%
+            }else{
+       %>
+            String errormessage_<%=cid%> = printSQLException_<%=cid%>.getSQLException(e,false);
+       <%
+            dbLog.logPrintedException("errormessage_"+cid);
+            }
+       %>
+   }
+   <%@ include file="../templates/DB/Output/DBOutputEndGlobalVars.javajet"%>
+
+

--- a/main/plugins/org.talend.designer.components.localprovider/components/tDB2Output/tDB2Output_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tDB2Output/tDB2Output_main.javajet
@@ -1208,6 +1208,7 @@ skeleton="../templates/db_output_bulk.skeleton"
                 	<%
                 	}else {
                 	%>
+                	String errormessage_<%=cid%> = printSQLException_<%=cid%>.getSQLException(e,false);
                 	int countSum_<%=cid%> = 0;
 					for(int countEach_<%=cid%>: e.getUpdateCounts()) {
 						countSum_<%=cid%> += (countEach_<%=cid%> < 0 ? 0 : countEach_<%=cid%>);
@@ -1225,10 +1226,8 @@ skeleton="../templates/db_output_bulk.skeleton"
 			    	    deletedCount_<%=cid%> += countSum_<%=cid%>;
 			    	<%
 			    	}
-			    	dbLog.logPrintedException("e.getMessage()");
-			    	%> 
-                	System.err.println(e.getMessage());
-                	<%
+
+			    	dbLog.logPrintedException("errormessage_"+cid);
                 	}%>
                 }
                 <%
@@ -1277,6 +1276,7 @@ skeleton="../templates/db_output_bulk.skeleton"
                 	<%
                 	}else {
                 	%>
+                		String errormessage_<%=cid%> = printSQLException_<%=cid%>.getSQLException(e,false);
                 		int countSum_<%=cid%> = 0;
 						for(int countEach_<%=cid%>: e.getUpdateCounts()) {
 							countSum_<%=cid%> += (countEach_<%=cid%> < 0 ? 0 : countEach_<%=cid%>);
@@ -1294,10 +1294,7 @@ skeleton="../templates/db_output_bulk.skeleton"
             	    	    deletedCount_<%=cid%> += countSum_<%=cid%>;
             	    	<%
             	    	}
-            	    	dbLog.logPrintedException("e.getMessage()");
-            	    	%>
-                        System.err.println(e.getMessage());
-                	<%
+            	    	dbLog.logPrintedException("errormessage_"+cid);
                 	}%>
                 
                 }            	                              


### PR DESCRIPTION
* TDI-35416: Add getNextException to show more error message

* TDI-35416 : write a util for repetitive code. add log.

* TDI-35416 : make the code more clean.

* TDI-35416 : move setglobalVars out of try-catch add die on error

* TDI-35416 : Remove the duplicate record to log4j.

* TDI-35416 : replace the last system.err.print with log4j witch I
forgot.

Conflicts:
	main/plugins/org.talend.designer.components.localprovider/components/tDB2Output/tDB2Output_end.javajet
	main/plugins/org.talend.designer.components.localprovider/components/tDB2Output/tDB2Output_main.javajet