### PR TITLE
feat(TCOMP-230): add Reader wrapping with FlowVariablesReader

### DIFF
--- a/main/plugins/org.talend.designer.codegen/jet_stub/generic/component_begin.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/generic/component_begin.javajet
@@ -208,6 +208,8 @@ if (hasOutputOnly || asInputComponent) {
             (org.talend.components.api.component.runtime.Source)sourceOrSink_<%=cid%>;
     org.talend.components.api.component.runtime.Reader reader_<%=cid%> =
             source_<%=cid%>.createReader(container_<%=cid%>);
+			
+	reader_<%=cid%> = new FlowVariablesReader(reader_<%=cid%>, container_<%=cid%>);
 
     <%
     IConnection main = null;


### PR DESCRIPTION
Related to https://jira.talendforge.org/browse/TCOMP-230

It shows how FlowVariablesReader is supposed to be used in codegen.
Related PR is https://github.com/Talend/tcommon-studio-se/pull/794

Do not merge right now. It is likely to be changed according how FlowVariablesReader will be packed