### PR TITLE
TDI-38131:error message for tRunjob is not complete in tLogCatcher's output

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tRunJob/tRunJob_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tRunJob/tRunJob_main.javajet
@@ -417,7 +417,7 @@ String inputConnName = null;
 	  
 			<%if (dieOnError) { %> 
 				if (childJob_<%=cid %>.getErrorCode() != null || ("failure").equals(childJob_<%=cid %>.getStatus())) {
-	        		throw new RuntimeException("Child job running failed");
+	        		throw new RuntimeException("Child job running failed.\n"+childJob_<%=cid %>.getExceptionStackTrace());
 				}
 			<%}
 		}%>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TDI-38131