### PR TITLE
TESB-18750: Add ESB runtime server in target exec tab

### DIFF
--- a/main/plugins/org.talend.designer.runprocess/schema/runprocess_manager.exsd
+++ b/main/plugins/org.talend.designer.runprocess/schema/runprocess_manager.exsd
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Schema file written by PDE -->
-<schema targetNamespace="org.talend.designer.runprocess">
+<schema targetNamespace="org.talend.designer.runprocess" xmlns="http://www.w3.org/2001/XMLSchema">
 <annotation>
       <appInfo>
          <meta.schema plugin="org.talend.designer.runprocess" id="runprocess_manager" name="Runprocess Manager"/>
@@ -11,8 +11,13 @@
    </annotation>
 
    <element name="extension">
+      <annotation>
+         <appInfo>
+            <meta.element />
+         </appInfo>
+      </annotation>
       <complexType>
-         <sequence>
+         <sequence minOccurs="1" maxOccurs="unbounded">
             <element ref="runprocess_manager"/>
          </sequence>
          <attribute name="point" type="string" use="required">
@@ -100,13 +105,5 @@
       </documentation>
    </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="copyright"/>
-      </appInfo>
-      <documentation>
-         
-      </documentation>
-   </annotation>
 
 </schema>

--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/IESBRunContainerService.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/IESBRunContainerService.java
@@ -1,0 +1,26 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.designer.runprocess;
+
+import org.talend.core.IService;
+import org.talend.designer.runprocess.ui.JobJvmComposite;
+import org.talend.designer.runprocess.ui.TargetExecComposite;
+
+/**
+ * DOC yyan class global comment. Detailled comment
+ */
+public interface IESBRunContainerService extends IService {
+
+    void addRuntimeServer(TargetExecComposite targetExecComposite, JobJvmComposite jobComposite);
+
+}

--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/RunProcessPlugin.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/RunProcessPlugin.java
@@ -12,6 +12,8 @@
 // ============================================================================
 package org.talend.designer.runprocess;
 
+import java.util.List;
+
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 import org.talend.commons.utils.workbench.extensions.ExtensionImplementationProvider;
@@ -39,6 +41,8 @@ public class RunProcessPlugin extends AbstractUIPlugin {
 
     private ProjectPreferenceManager projectPreferenceManager;
 
+    private List<RunProcessContextManager> runProcessContextManagerList;
+
     /**
      * Constructs a new Activator.
      */
@@ -56,7 +60,8 @@ public class RunProcessPlugin extends AbstractUIPlugin {
         IExtensionPointLimiter extensionPointLimiter = new ExtensionPointLimiterImpl(
                 "org.talend.designer.runprocess.runprocess_manager", "runprocess_manager"); //$NON-NLS-1$ //$NON-NLS-2$
 
-        runProcessContextManager = ExtensionImplementationProvider.getSingleInstance(extensionPointLimiter, null);
+        runProcessContextManagerList = ExtensionImplementationProvider.getInstance(extensionPointLimiter);
+        runProcessContextManager = runProcessContextManagerList.size() > 0 ? runProcessContextManagerList.get(0) : null;
 
         if (runProcessContextManager == null) {
             runProcessContextManager = new RunProcessContextManager();
@@ -89,6 +94,21 @@ public class RunProcessPlugin extends AbstractUIPlugin {
      */
     public RunProcessContextManager getRunProcessContextManager() {
         return this.runProcessContextManager;
+    }
+
+    public void setRunProcessContextManager(RunProcessContextManager manager) {
+        boolean alreadyExists = false;
+        for (RunProcessContextManager mgr : runProcessContextManagerList) {
+            if (manager.getClass() == mgr.getClass()) {
+                runProcessContextManager = mgr;
+                alreadyExists = true;
+                break;
+            }
+        }
+        if (!alreadyExists) {
+            runProcessContextManagerList.add(manager);
+            runProcessContextManager = manager;
+        }
     }
 
     public ProjectPreferenceManager getProjectPreferenceManager() {

--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/ui/TargetExecComposite.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/ui/TargetExecComposite.java
@@ -28,12 +28,14 @@ import org.eclipse.swt.widgets.Display;
 import org.talend.commons.utils.workbench.extensions.ExtensionImplementationProvider;
 import org.talend.commons.utils.workbench.extensions.ExtensionPointLimiterImpl;
 import org.talend.commons.utils.workbench.extensions.IExtensionPointLimiter;
+import org.talend.core.GlobalServiceRegister;
 import org.talend.core.model.process.EComponentCategory;
 import org.talend.core.model.process.Element;
 import org.talend.core.model.properties.ConnectionItem;
 import org.talend.core.ui.CoreUIPlugin;
 import org.talend.core.ui.properties.tab.IDynamicProperty;
 import org.talend.designer.core.IMultiPageTalendEditor;
+import org.talend.designer.runprocess.IESBRunContainerService;
 import org.talend.designer.runprocess.RunProcessContext;
 import org.talend.designer.runprocess.i18n.Messages;
 import org.talend.designer.runprocess.ui.views.DefaultProcessViewHelper;
@@ -86,6 +88,14 @@ public class TargetExecComposite extends ScrolledComposite implements IDynamicPr
         panel.setBackground(Display.getDefault().getSystemColor(SWT.COLOR_DARK_RED));
 
         jobComposite = this.processViewHelper.getProcessComposite(panel);
+
+        //add ESB runtime container
+        if (GlobalServiceRegister.getDefault().isServiceRegistered(IESBRunContainerService.class)) {
+            IESBRunContainerService runContainerService = (IESBRunContainerService) GlobalServiceRegister.getDefault()
+                    .getService(IESBRunContainerService.class);
+            runContainerService.addRuntimeServer(this, jobComposite);
+        }
+
         // CSS
         CoreUIPlugin.setCSSClass(this, this.getClass().getSimpleName());
     }


### PR DESCRIPTION
Hi,

This is the studio-se part to support the ESB runtime server display in target exec tab. PLease consider the merget with another part together, https://github.com/Talend/tdi-studio-ee/pull/316

Regards,
Yi