### PR TITLE
log.info changed to log.debug

### DIFF
--- a/main/plugins/org.talend.designer.codegen/jet_stub/footer.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/footer.javajet
@@ -269,7 +269,7 @@
         int exitCode = <%=className %>Class.runJobInTOS(args);
         <%if(isLog4jEnabled){%>
 	        if(exitCode==0){
-		        log.info("TalendJob: '<%=codeGenArgument.getJobName()%>' - Done.");
+		        log.debug("TalendJob: '<%=codeGenArgument.getJobName()%>' - Done.");
 	        }
         <%}%>
 
@@ -434,7 +434,7 @@
 				}
 				org.apache.log4j.Logger.getRootLogger().setLevel(log.getLevel());
     	    }
-        	log.info("TalendJob: '<%=codeGenArgument.getJobName()%>' - Start.");
+        	log.debug("TalendJob: '<%=codeGenArgument.getJobName()%>' - Start.");
     	<%}%>
 
         if(clientHost == null) {

--- a/main/plugins/org.talend.designer.codegen/jet_stub/subprocess_footer.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/subprocess_footer.javajet
@@ -136,7 +136,7 @@
 
 			outputQueue_<%=cid%>.put(new DepartitionerPoison_<%=cid%>());
             <%if(isLog4jEnabled){%>
-            	log.info("<%=cid%>[" + Thread.currentThread().getName() + "] - Done.");
+            	log.debug("<%=cid%>[" + Thread.currentThread().getName() + "] - Done.");
             <%}%>
 		<%
     	}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tAccessBulkExec/tAccessBulkExec_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tAccessBulkExec/tAccessBulkExec_begin.javajet
@@ -116,13 +116,13 @@ skeleton="../templates/db_output_bulk.skeleton"
 		java.sql.Statement stmt_<%=cid%> = conn_<%=cid%>.createStatement();
 		<%if(isLog4jEnabled){%>
     		log.debug("<%=cid%> - Bulk SQL:"+bulkInsert_<%=cid%>+".");
-    		log.info("<%=cid%> - Bulk inserting data into " + tableName_<%=cid%> + "." );
+    		log.debug("<%=cid%> - Bulk inserting data into " + tableName_<%=cid%> + "." );
 		<%}%>
 		stmt_<%=cid%>.execute(bulkInsert_<%=cid%>);
 
 		stmt_<%=cid%>.close();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Bulk insert data into " + tableName_<%=cid%> + " has finished.");
+			log.debug("<%=cid%> - Bulk insert data into " + tableName_<%=cid%> + " has finished.");
     	<%}%>
 	<%
 	}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tAggregateIn/tAggregateIn_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tAggregateIn/tAggregateIn_begin.javajet
@@ -21,7 +21,7 @@ java.util.Collection<AggOperationStruct_<%=cid %>> values_<%=cid %> = hash_<%=ci
 
 globalMap.put("<%=cid %>_NB_LINE", values_<%=cid %>.size());
 
-<%log.info(log.str("Retrieving the aggregation results."));%>
+<%log.debug(log.str("Retrieving the aggregation results."));%>
 for(AggOperationStruct_<%=cid %> aggregated_row_<%=cid %> : values_<%=cid %>) { // G_AggR_600
 
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tAmazonEMRManage/tAmazonEMRManage_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tAmazonEMRManage/tAmazonEMRManage_begin.javajet
@@ -372,7 +372,7 @@
 	com.amazonaws.services.elasticmapreduce.model.RunJobFlowResult result_<%=cid%> = emr_<%=cid%>.runJobFlow(request_<%=cid%>);
 	
 	<%if(isLog4jEnabled) {%>
-	log.info("<%=cid%> - cluster status : " + result_<%=cid%>);
+	log.debug("<%=cid%> - cluster status : " + result_<%=cid%>);
 	<%}%>
 	
 	globalMap.put("<%=cid %>_CLUSTER_FINAL_ID", result_<%=cid%>.getJobFlowId());

--- a/main/plugins/org.talend.designer.components.localprovider/components/tAmazonRedshiftManage/tAmazonRedshiftManage_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tAmazonRedshiftManage/tAmazonRedshiftManage_begin.javajet
@@ -133,7 +133,7 @@
     
     	com.amazonaws.services.redshift.model.Cluster result_<%=cid%> = client_<%=cid%>.createCluster(request_<%=cid%>);
     	<%if(isLog4jEnabled) {%>
-    	log.info("<%=cid%> - cluster status : " + result_<%=cid%>);
+    	log.debug("<%=cid%> - cluster status : " + result_<%=cid%>);
     	<%}%>
     	globalMap.put("<%=cid %>_CLUSTER_FINAL_ID", result_<%=cid%>.getClusterIdentifier());
     	
@@ -175,7 +175,7 @@
     
 		com.amazonaws.services.redshift.model.Cluster result_<%=cid%> = client_<%=cid%>.deleteCluster(request_<%=cid%>);
 		<%if(isLog4jEnabled) {%>
-    	log.info("<%=cid%> - cluster status : " + result_<%=cid%>);
+    	log.debug("<%=cid%> - cluster status : " + result_<%=cid%>);
     	<%}%>
 		globalMap.put("<%=cid %>_CLUSTER_FINAL_ID", result_<%=cid%>.getClusterIdentifier());
 	<%
@@ -187,7 +187,7 @@
 				
 		com.amazonaws.services.redshift.model.Cluster result_<%=cid%> = client_<%=cid %>.modifyCluster(request_Modify_<%=cid %>);
 		<%if(isLog4jEnabled) {%>
-    	log.info("<%=cid%> - cluster status : " + result_<%=cid%>);
+    	log.debug("<%=cid%> - cluster status : " + result_<%=cid%>);
     	<%}%>
 		globalMap.put("<%=cid %>_CLUSTER_FINAL_ID", result_<%=cid%>.getClusterIdentifier());
 		
@@ -263,7 +263,7 @@
 		;
 		com.amazonaws.services.redshift.model.Cluster result_<%=cid%> = client_<%=cid%>.restoreFromClusterSnapshot(request_<%=cid%>);
 		<%if(isLog4jEnabled) {%>
-    	log.info("<%=cid%> - cluster status : " + result_<%=cid%>);
+    	log.debug("<%=cid%> - cluster status : " + result_<%=cid%>);
     	<%}%>
 		globalMap.put("<%=cid %>_CLUSTER_FINAL_ID", result_<%=cid%>.getClusterIdentifier());
 		
@@ -305,7 +305,7 @@
 		;
 		com.amazonaws.services.redshift.model.Snapshot result_<%=cid%> = client_<%=cid%>.deleteClusterSnapshot(request_<%=cid%>);
 		<%if(isLog4jEnabled) {%>
-    	log.info("<%=cid%> - cluster status : " + result_<%=cid%>);
+    	log.debug("<%=cid%> - cluster status : " + result_<%=cid%>);
     	<%}%>
 		globalMap.put("<%=cid %>_CLUSTER_FINAL_ID", result_<%=cid%>.getClusterIdentifier());
 	<%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tAzureStorageConnection/tAzureStorageConnection_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tAzureStorageConnection/tAzureStorageConnection_begin.javajet
@@ -27,7 +27,7 @@
 <%
 	if(isLog4jEnabled) {
 %>
-		log.info("<%=cid%> - Create the cloud storage account object successfully.");
+		log.debug("<%=cid%> - Create the cloud storage account object successfully.");
 <%
 	}
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tAzureStorageContainerCreate/tAzureStorageContainerCreate_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tAzureStorageContainerCreate/tAzureStorageContainerCreate_main.javajet
@@ -30,7 +30,7 @@
 <%
 		if(isLog4jEnabled) {
 %>
-		log.info("<%=cid%> - Get the existed cloud storage account object from <%=azure_connection%>.");
+		log.debug("<%=cid%> - Get the existed cloud storage account object from <%=azure_connection%>.");
 <%
 		}
 	}else{
@@ -40,7 +40,7 @@
 <%
 		if(isLog4jEnabled) {
 %>
-		log.info("<%=cid%> - Create the cloud storage account object successfully.");
+		log.debug("<%=cid%> - Create the cloud storage account object successfully.");
 <%
 		}
 	}
@@ -59,9 +59,9 @@
 	if(isLog4jEnabled) {
 %>
 		if(result_<%=cid%>) {
-			log.info("<%=cid%> - The container doesn't exist and is created successfully.");
+			log.debug("<%=cid%> - The container doesn't exist and is created successfully.");
 		} else {
-			log.info("<%=cid%> - The container already exists or is not created successfully.");
+			log.debug("<%=cid%> - The container already exists or is not created successfully.");
 		}
 <%
 	}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tAzureStorageContainerDelete/tAzureStorageContainerDelete_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tAzureStorageContainerDelete/tAzureStorageContainerDelete_main.javajet
@@ -28,7 +28,7 @@
 <%
 		if(isLog4jEnabled) {
 %>
-		log.info("<%=cid%> - Get the existed cloud storage account object from <%=azure_connection%>.");
+		log.debug("<%=cid%> - Get the existed cloud storage account object from <%=azure_connection%>.");
 <%
 		}
 	}else{
@@ -38,7 +38,7 @@
 <%
 		if(isLog4jEnabled) {
 %>
-		log.info("<%=cid%> - Create the cloud storage account object successfully.");
+		log.debug("<%=cid%> - Create the cloud storage account object successfully.");
 <%
 		}
 	}
@@ -57,9 +57,9 @@
 	if(isLog4jEnabled) {
 %>
 		if(result_<%=cid%>) {
-			log.info("<%=cid%> - Delete the container successfully.");
+			log.debug("<%=cid%> - Delete the container successfully.");
 		} else {
-			log.info("<%=cid%> - The container is not deleted successfully.");
+			log.debug("<%=cid%> - The container is not deleted successfully.");
 		}
 <%
 	}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tAzureStorageContainerExist/tAzureStorageContainerExist_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tAzureStorageContainerExist/tAzureStorageContainerExist_main.javajet
@@ -30,7 +30,7 @@
 <%
 		if(isLog4jEnabled) {
 %>
-		log.info("<%=cid%> - Get the existed cloud storage account object from <%=azure_connection%>.");
+		log.debug("<%=cid%> - Get the existed cloud storage account object from <%=azure_connection%>.");
 <%
 		}
 	}else{
@@ -40,7 +40,7 @@
 <%
 		if(isLog4jEnabled) {
 %>
-		log.info("<%=cid%> - Create the cloud storage account object successfully.");
+		log.debug("<%=cid%> - Create the cloud storage account object successfully.");
 <%
 		}
 	}
@@ -53,9 +53,9 @@
 	if(isLog4jEnabled) {
 %>
 		if(containerExist_<%=cid%>) {
-			log.info("<%=cid%> - The container already exists.");
+			log.debug("<%=cid%> - The container already exists.");
 		} else {
-			log.info("<%=cid%> - The container doesn't exist.");
+			log.debug("<%=cid%> - The container doesn't exist.");
 		}
 <%
 	}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tAzureStorageDelete/tAzureStorageDelete_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tAzureStorageDelete/tAzureStorageDelete_begin.javajet
@@ -34,7 +34,7 @@
 <%
 			if(isLog4jEnabled) {
 %>
-			log.info("<%=cid%> - Get the existed cloud storage account object from <%=connection%>.");
+			log.debug("<%=cid%> - Get the existed cloud storage account object from <%=connection%>.");
 <%
 			}
 		} else {
@@ -45,7 +45,7 @@
 <%
 			if(isLog4jEnabled) {
 %>
-			log.info("<%=cid%> - Create the cloud storage account object successfully.");
+			log.debug("<%=cid%> - Create the cloud storage account object successfully.");
 <%
 			}
 %>
@@ -80,9 +80,9 @@
 					if(isLog4jEnabled) {
 %>
 					if(result_<%=cid%>) {
-						log.info("<%=cid%> - Delete the blob : " + blob_<%=cid%>.getName() + " successfully.");
+						log.debug("<%=cid%> - Delete the blob : " + blob_<%=cid%>.getName() + " successfully.");
 					} else {
-						log.info("<%=cid%> - The blob : " + blob_<%=cid%>.getName() + " is not deleted successfully.");
+						log.debug("<%=cid%> - The blob : " + blob_<%=cid%>.getName() + " is not deleted successfully.");
 					}
 <%
 					}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tAzureStorageGet/tAzureStorageGet_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tAzureStorageGet/tAzureStorageGet_begin.javajet
@@ -34,7 +34,7 @@
 <%
 			if(isLog4jEnabled) {
 %>
-			log.info("<%=cid%> - Get the existed cloud storage account object from <%=connection%>.");
+			log.debug("<%=cid%> - Get the existed cloud storage account object from <%=connection%>.");
 <%
 			}
 		} else {
@@ -45,7 +45,7 @@
 <%
 			if(isLog4jEnabled) {
 %>
-			log.info("<%=cid%> - Create the cloud storage account object successfully.");
+			log.debug("<%=cid%> - Create the cloud storage account object successfully.");
 <%
 			}
 %>
@@ -81,7 +81,7 @@
 <%
 				if(isLog4jEnabled) {
 %>
-				log.info("<%=cid%> - Download the blob : " + blob_<%=cid%>.getName() + " successfully.");
+				log.debug("<%=cid%> - Download the blob : " + blob_<%=cid%>.getName() + " successfully.");
 <%
 				}
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tAzureStorageList/tAzureStorageList_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tAzureStorageList/tAzureStorageList_begin.javajet
@@ -34,7 +34,7 @@
 <%
 			if(isLog4jEnabled) {
 %>
-			log.info("<%=cid%> - Get the existed cloud storage account object from <%=connection%>.");
+			log.debug("<%=cid%> - Get the existed cloud storage account object from <%=connection%>.");
 <%
 			}
 		} else {
@@ -45,7 +45,7 @@
 <%
 			if(isLog4jEnabled) {
 %>
-			log.info("<%=cid%> - Create the cloud storage account object successfully.");
+			log.debug("<%=cid%> - Create the cloud storage account object successfully.");
 <%
 			}
 %>
@@ -83,7 +83,7 @@
 					com.microsoft.windowsazure.services.blob.client.CloudBlob blob_<%=cid%> = (com.microsoft.windowsazure.services.blob.client.CloudBlob) blobItem_<%=cid%>;
 					globalMap.put("<%=cid%>_CURRENT_BLOB", blob_<%=cid%>.getName());
 					<%if(isLog4jEnabled) {%>
-					log.info("<%=cid%> - The current blob : " + blob_<%=cid%>.getName());
+					log.debug("<%=cid%> - The current blob : " + blob_<%=cid%>.getName());
 	  				<%}%>
 				} else {
 					break;

--- a/main/plugins/org.talend.designer.components.localprovider/components/tAzureStoragePut/tAzureStoragePut_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tAzureStoragePut/tAzureStoragePut_begin.javajet
@@ -39,7 +39,7 @@
 <%
 			if(isLog4jEnabled) {
 %>
-			log.info("<%=cid%> - Get the existed cloud storage account object from <%=connection%>.");
+			log.debug("<%=cid%> - Get the existed cloud storage account object from <%=connection%>.");
 <%
 			}
 		} else {
@@ -50,7 +50,7 @@
 <%
 			if(isLog4jEnabled) {
 %>
-			log.info("<%=cid%> - Create the cloud storage account object successfully.");
+			log.debug("<%=cid%> - Create the cloud storage account object successfully.");
 <%
 			}
 %>
@@ -104,7 +104,7 @@
 <%
 			if(isLog4jEnabled) {
 %>
-			log.info("<%=cid%> - Upload the file : " + source_<%=cid%>.getName() + " successfully.");
+			log.debug("<%=cid%> - Upload the file : " + source_<%=cid%>.getName() + " successfully.");
 <%
 			}
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryBulkExec/tBigQueryBulkExec_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryBulkExec/tBigQueryBulkExec_begin.javajet
@@ -57,9 +57,9 @@
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Service Account Scopes [https://www.googleapis.com/auth/bigquery]");
-		log.info("<%=cid%> - Redirect uris [urn:ietf:wg:oauth:2.0:oob]");
-		log.info("<%=cid%> - Attempt to load existing refresh token");
+		log.debug("<%=cid%> - Service Account Scopes [https://www.googleapis.com/auth/bigquery]");
+		log.debug("<%=cid%> - Redirect uris [urn:ietf:wg:oauth:2.0:oob]");
+		log.debug("<%=cid%> - Attempt to load existing refresh token");
 	<%
 	}
 	%>
@@ -102,7 +102,7 @@
 		<%
 		if(isLog4jEnabled){
 		%>
-			log.info("<%=cid%> - An existing refresh token was loaded.");
+			log.debug("<%=cid%> - An existing refresh token was loaded.");
 		<%
 		}
 		%>
@@ -111,7 +111,7 @@
 		<%
 		if(isLog4jEnabled){
 		%>
-			log.info("<%=cid%> - The refresh token does not exist.");
+			log.debug("<%=cid%> - The refresh token does not exist.");
 		<%
 		}
 		%>
@@ -135,7 +135,7 @@
 			<%
 			if(isLog4jEnabled){
 			%>
-				log.info("<%=cid%> - Exchange the auth code for an access token and refesh token.");
+				log.debug("<%=cid%> - Exchange the auth code for an access token and refesh token.");
 			<%
 			}
 			%>
@@ -151,7 +151,7 @@
 			<%
 			if(isLog4jEnabled){
 			%>
-				log.info("<%=cid%> - Store the refresh token for future use.");
+				log.debug("<%=cid%> - Store the refresh token for future use.");
 			<%
 			}
 			%>
@@ -203,7 +203,7 @@
 		<%
 		if(isLog4jEnabled){
 		%>
-			log.info("<%=cid%> - Upload "+<%=localFilename%> + " to Google Service Bucket: "+<%=bucketName%>);
+			log.debug("<%=cid%> - Upload "+<%=localFilename%> + " to Google Service Bucket: "+<%=bucketName%>);
 		<%
 		}
 		%>
@@ -211,7 +211,7 @@
 		<%
 		if(isLog4jEnabled){
 		%>
-			log.info("<%=cid%> - Upload Done.");
+			log.debug("<%=cid%> - Upload Done.");
 		<%
 		}
 	}
@@ -222,7 +222,7 @@
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Starting build a job.");
+		log.debug("<%=cid%> - Starting build a job.");
 	<%
 	}
 	%>
@@ -236,7 +236,7 @@
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Table field schema:");
+		log.debug("<%=cid%> - Table field schema:");
 	<%
 	}
 	%>
@@ -319,8 +319,8 @@
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Build a job successfully.");
-		log.info("<%=cid%> - Starting load the job.");
+		log.debug("<%=cid%> - Build a job successfully.");
+		log.debug("<%=cid%> - Starting load the job.");
 	<%
 	}
 	%>
@@ -377,8 +377,8 @@
 		<%
 		if(isLog4jEnabled){
 		%>
-			log.info("<%=cid%> - Load Done: " + doneJob_<%=cid%>.toString());
-			log.info("<%=cid%> - " + nb_line_<%=cid%> + " records load successfully.");
+			log.debug("<%=cid%> - Load Done: " + doneJob_<%=cid%>.toString());
+			log.debug("<%=cid%> - " + nb_line_<%=cid%> + " records load successfully.");
 		<%
 		}
 		%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryInput/tBigQueryInput_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryInput/tBigQueryInput_begin.javajet
@@ -58,9 +58,9 @@
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Service Account Scopes [https://www.googleapis.com/auth/bigquery]");
-		log.info("<%=cid%> - Redirect uris [urn:ietf:wg:oauth:2.0:oob]");
-		log.info("<%=cid%> - Attempt to load existing refresh token.");
+		log.debug("<%=cid%> - Service Account Scopes [https://www.googleapis.com/auth/bigquery]");
+		log.debug("<%=cid%> - Redirect uris [urn:ietf:wg:oauth:2.0:oob]");
+		log.debug("<%=cid%> - Attempt to load existing refresh token.");
 	<%
 	}
 	%>
@@ -104,7 +104,7 @@
 		<%
 		if(isLog4jEnabled){
 		%>
-			log.info("<%=cid%> - An existing refresh token was loaded.");
+			log.debug("<%=cid%> - An existing refresh token was loaded.");
 		<%
 		}
 		%>
@@ -113,7 +113,7 @@
 		<%
 		if(isLog4jEnabled){
 		%>
-			log.info("<%=cid%> - The refresh token does not exist.");
+			log.debug("<%=cid%> - The refresh token does not exist.");
 		<%
 		}
 		%>
@@ -138,7 +138,7 @@
 			<%
 			if(isLog4jEnabled){
 			%>
-				log.info("<%=cid%> - Exchange the auth code for an access token and refesh token.");
+				log.debug("<%=cid%> - Exchange the auth code for an access token and refesh token.");
 			<%
 			}
 			%>
@@ -155,7 +155,7 @@
 			<%
 			if(isLog4jEnabled){
 			%>
-				log.info("<%=cid%> - Store the refresh token for future use.");
+				log.debug("<%=cid%> - Store the refresh token for future use.");
 			<%
 			}
 			%>
@@ -227,7 +227,7 @@
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Wait for query execution");
+		log.debug("<%=cid%> - Wait for query execution");
 	<%
 	}
 	%>
@@ -246,7 +246,7 @@
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Retrieving records from dataset.");
+		log.debug("<%=cid%> - Retrieving records from dataset.");
 	<%
 	}
 	%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryOutputBulk/tBigQueryOutputBulk_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryOutputBulk/tBigQueryOutputBulk_begin.javajet
@@ -62,7 +62,7 @@ imports="
 				<%
 				if(isLog4jEnabled){
 				%>
-					log.info("<%=cid%> - Creating directory for file '" + file_<%=cid%>.getCanonicalPath() +"', if the directory not exist.");
+					log.debug("<%=cid%> - Creating directory for file '" + file_<%=cid%>.getCanonicalPath() +"', if the directory not exist.");
 				<%
 				}
 				%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tChronometerStart/tChronometerStart_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tChronometerStart/tChronometerStart_begin.javajet
@@ -17,7 +17,7 @@ imports="
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Start time: "+currentTime<%=cid%>+" milliseconds");
+		log.debug("<%=cid%> - Start time: "+currentTime<%=cid%>+" milliseconds");
 	<%
 	}
 	%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tChronometerStop/tChronometerStop_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tChronometerStop/tChronometerStop_begin.javajet
@@ -21,7 +21,7 @@
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Stop time: "+System.currentTimeMillis()+" milliseconds");
+		log.debug("<%=cid%> - Stop time: "+System.currentTimeMillis()+" milliseconds");
 	<%
 	}
 	if (sinceStarter) {
@@ -30,7 +30,7 @@
 		<%
 		if(isLog4jEnabled){
 		%>
-			log.info("<%=cid%> - Duration since <%=starter%> start: "+time<%=cid%>+" milliseconds");
+			log.debug("<%=cid%> - Duration since <%=starter%> start: "+time<%=cid%>+" milliseconds");
 		<%
 		}
 	}else {
@@ -39,7 +39,7 @@
 		<%
 		if(isLog4jEnabled){
 		%>
-			log.info("<%=cid%> - Duration since job start: "+time<%=cid%>+" milliseconds");
+			log.debug("<%=cid%> - Duration since job start: "+time<%=cid%>+" milliseconds");
 		<%
 		}
 	}
@@ -57,7 +57,7 @@
 	  		<%
 	  		if(isLog4jEnabled){
 			%>
-				log.info("<%=cid%> - Readable duration : "+ time<%=cid%>/1000 + " seconds");
+				log.debug("<%=cid%> - Readable duration : "+ time<%=cid%>/1000 + " seconds");
 			<%
 			}
 	  	}
@@ -66,7 +66,7 @@
 	  	<%
   		if(isLog4jEnabled){
 		%>
-			log.info("<%=cid%> - "+ <%=caption%> + "  " + time<%=cid%> + " milliseconds");
+			log.debug("<%=cid%> - "+ <%=caption%> + "  " + time<%=cid%> + " milliseconds");
 		<%
 		}
 		%> 
@@ -78,7 +78,7 @@
 	<%
   	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Current time " + currentTime<%=cid%> + " milliseconds");
+		log.debug("<%=cid%> - Current time " + currentTime<%=cid%> + " milliseconds");
 	<%
 	}
 	%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tContextDump/tContextDump_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tContextDump/tContextDump_begin.javajet
@@ -32,7 +32,7 @@
         int nb_line_<%=cid %> = 0;
         java.util.List<String> assignList_<%=cid %> = new java.util.ArrayList<String>();
         <%if(isLog4jEnabled){%>
-        	log.info("<%=cid%> - Dumping context.");
+        	log.debug("<%=cid%> - Dumping context.");
         <%}%>
         for( java.util.Enumeration<?> en_<%=cid %> = context.propertyNames() ; en_<%=cid %>.hasMoreElements() ; ) {        
             nb_line_<%=cid %>++;

--- a/main/plugins/org.talend.designer.components.localprovider/components/tContextDump/tContextDump_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tContextDump/tContextDump_end.javajet
@@ -29,7 +29,7 @@
         }
         globalMap.put("<%=cid %>_NB_LINE",nb_line_<%=cid %>);
         <%if(isLog4jEnabled){%>
-        	log.info("<%=cid%> - Dumped contexts count: " + nb_line_<%=cid%> + ".");
+        	log.debug("<%=cid%> - Dumped contexts count: " + nb_line_<%=cid%> + ".");
         <%}%>
         <%
     }

--- a/main/plugins/org.talend.designer.components.localprovider/components/tContextLoad/tContextLoad_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tContextLoad/tContextLoad_end.javajet
@@ -87,6 +87,6 @@
 	
 	resumeUtil.addLog("NODE", "NODE:<%=cid %>", "", Thread.currentThread().getId() + "", "","","","",resumeUtil.convertToJsonText(context,parametersToEncrypt_<%=cid%>));    
     <%if(isLog4jEnabled){%>
-    	log.info("<%=cid%> - Loaded contexts count: " + nb_line_<%=cid %> + ".");
+    	log.debug("<%=cid%> - Loaded contexts count: " + nb_line_<%=cid %> + ".");
     <%}%>
     

--- a/main/plugins/org.talend.designer.components.localprovider/components/tCreateTable/tCreateTable_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tCreateTable/tCreateTable_main.javajet
@@ -2019,11 +2019,11 @@ if(columnList != null && columnList.size() > 0) {
             %>
             java.sql.Statement stmt_<%=cid%> = conn_<%=cid%>.createStatement();
             <%if(isLog4jEnabled){%>
-                log.info("<%=cid%> - Creating table '" + tableName_<%=cid%> + "'.");
+                log.debug("<%=cid%> - Creating table '" + tableName_<%=cid%> + "'.");
             <%}%>
             stmt_<%=cid%>.execute("<%=manager.getCreateTableSQL(columnList)%>");
             <%if(isLog4jEnabled){%>
-                log.info("<%=cid%> - Create table '" + tableName_<%=cid%> + "' has succeeded.");
+                log.debug("<%=cid%> - Create table '" + tableName_<%=cid%> + "' has succeeded.");
             <%}%>
             <%=createProjectionStr%>
             <%
@@ -2131,11 +2131,11 @@ if(columnList != null && columnList.size() > 0) {
                 if(!whetherExist_<%=cid%>) {
                     java.sql.Statement stmt_<%=cid%> = conn_<%=cid%>.createStatement();
                     <%if(isLog4jEnabled){%>
-                        log.info("<%=cid%> - Creating table '" + tableName_<%=cid%> + "'.");
+                        log.debug("<%=cid%> - Creating table '" + tableName_<%=cid%> + "'.");
                     <%}%>
                     stmt_<%=cid%>.execute("<%=manager.getCreateTableSQL(columnList)%>");                
                     <%if(isLog4jEnabled){%>
-                        log.info("<%=cid%> - Create table '" + tableName_<%=cid%> + "' has succeeded.");
+                        log.debug("<%=cid%> - Create table '" + tableName_<%=cid%> + "' has succeeded.");
                     <%}%>
 		            <%=createProjectionStr%>
                 }
@@ -2145,20 +2145,20 @@ if(columnList != null && columnList.size() > 0) {
                 if(whetherExist_<%=cid%>) {
                     java.sql.Statement stmtDrop_<%=cid%> = conn_<%=cid%>.createStatement();
                     <%if(isLog4jEnabled){%>
-                        log.info("<%=cid%> - Droping table '" + tableName_<%=cid%> + "'.");
+                        log.debug("<%=cid%> - Droping table '" + tableName_<%=cid%> + "'.");
                     <%}%>
                     stmtDrop_<%=cid%>.execute("<%=manager.getDropTableSQL()%>");
                     <%if(isLog4jEnabled){%>
-                        log.info("<%=cid%> - Drop table '" + tableName_<%=cid%> + "' has succeeded.");
+                        log.debug("<%=cid%> - Drop table '" + tableName_<%=cid%> + "' has succeeded.");
                     <%}%>
                 }
                 java.sql.Statement stmt_<%=cid%> = conn_<%=cid%>.createStatement();
                 <%if(isLog4jEnabled){%>
-                    log.info("<%=cid%> - Creating table '" + tableName_<%=cid%> + "'.");
+                    log.debug("<%=cid%> - Creating table '" + tableName_<%=cid%> + "'.");
                 <%}%>
                 stmt_<%=cid%>.execute("<%=manager.getCreateTableSQL(columnList)%>"); 
                 <%if(isLog4jEnabled){%>
-                    log.info("<%=cid%> - Create table '" + tableName_<%=cid%> + "' has succeeded.");
+                    log.debug("<%=cid%> - Create table '" + tableName_<%=cid%> + "' has succeeded.");
                 <%}%>
 	            <%=createProjectionStr%>
                 <%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tCreateTemporaryFile/tCreateTemporaryFile_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tCreateTemporaryFile/tCreateTemporaryFile_begin.javajet
@@ -44,7 +44,7 @@ globalMap.put("<%=cid %>_FILEPATH", file_<%=cid%>.getCanonicalPath());
 <%
 if(isLog4jEnabled) {
 %>
-	log.info("<%=cid%> - tmp file path : " + file_<%=cid%>.getCanonicalPath() + ".");
+	log.debug("<%=cid%> - tmp file path : " + file_<%=cid%>.getCanonicalPath() + ".");
 <%
 }
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tDB2BulkExec/tDB2BulkExec_begin_LOAD.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tDB2BulkExec/tDB2BulkExec_begin_LOAD.javajet
@@ -91,11 +91,11 @@ Character field_separator_<%=cid %> = (<%=field_separator%>).charAt(0);
             <%
             if(("INSERT").equals(action)){
             %>
-                log.info("<%=cid%> - Bulk inserting data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
+                log.debug("<%=cid%> - Bulk inserting data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
             <%
             }else if(("REPLACE").equals(action)){
             %>
-                log.info("<%=cid%> - Bulk replacing data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
+                log.debug("<%=cid%> - Bulk replacing data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
             <%
             }
         }
@@ -108,11 +108,11 @@ Character field_separator_<%=cid %> = (<%=field_separator%>).charAt(0);
         if(isLog4jEnabled_tableAction){
             if(("INSERT").equals(action)){
                 %>
-                log.info("<%=cid%> - Bulk insert data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
+                log.debug("<%=cid%> - Bulk insert data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
                 <%
             }else if(("REPLACE").equals(action)){
                 %>
-                log.info("<%=cid%> - Bulk replace data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
+                log.debug("<%=cid%> - Bulk replace data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
                 <%
             }
         }
@@ -135,12 +135,12 @@ Character field_separator_<%=cid %> = (<%=field_separator%>).charAt(0);
 
 
             <%if(isLog4jEnabled_tableAction){%>
-                log.info("<%=cid%> - Creating temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
+                log.debug("<%=cid%> - Creating temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
             <%}%>
             stmtCreateTmp_<%=cid%>.execute("<%=manager.getCreateTableSQL(stmtStructure)%>)");
             stmtCreateTmp_<%=cid%>.close();
             <%if(isLog4jEnabled_tableAction){%>
-                log.info("<%=cid%> - Create temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
+                log.debug("<%=cid%> - Create temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
             <%}%>
             java.sql.CallableStatement callStmt_<%=cid%> = null;
             String sql_<%=cid%> = "CALL SYSPROC.ADMIN_CMD(?)";
@@ -151,7 +151,7 @@ Character field_separator_<%=cid %> = (<%=field_separator%>).charAt(0);
             if(isLog4jEnabled_tableAction){
             %>
                 log.debug("<%=cid%> - Bulk SQL:CALL SYSPROC.ADMIN_CMD("+param_<%=cid%>+").");
-                log.info("<%=cid%> - Bulk inserting data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
+                log.debug("<%=cid%> - Bulk inserting data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
             <%
             }
             %>
@@ -160,13 +160,13 @@ Character field_separator_<%=cid %> = (<%=field_separator%>).charAt(0);
             callStmt_<%=cid%>.execute();
             callStmt_<%=cid%>.close();
             <%if(isLog4jEnabled_tableAction){%>
-                log.info("<%=cid%> - Bulk insert data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
+                log.debug("<%=cid%> - Bulk insert data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
             <%}%>
             tableName_<%=cid%> = tmpTableName_<%=cid%>;
             tmpTableName_<%=cid%> = "tmp_<%=cid%>"+ "_" + pid + Thread.currentThread().getId();
             java.sql.Statement stmtUpdateBulk_<%=cid%> = conn_<%=cid%>.createStatement();
             <%if(isLog4jEnabled_tableAction){%>
-                log.info("<%=cid%> - Updating <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> from <%=manager.getLProtectedChar()%>"+tmpTableName_<%=cid%>+"<%=manager.getRProtectedChar()%>.");
+                log.debug("<%=cid%> - Updating <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> from <%=manager.getLProtectedChar()%>"+tmpTableName_<%=cid%>+"<%=manager.getRProtectedChar()%>.");
             <%}%>
             stmtUpdateBulk_<%=cid%>.executeUpdate("<%=manager.getUpdateBulkSQL(columnList)%>");
             <%log4jCodeGenerateUtil.logInfo(node,"info",cid+" - Update has finished.");%>
@@ -174,11 +174,11 @@ Character field_separator_<%=cid %> = (<%=field_separator%>).charAt(0);
             tableName_<%=cid%> = "tmp_<%=cid%>" + "_" + pid + Thread.currentThread().getId();
             java.sql.Statement stmtTmpDrop_<%=cid%> = conn_<%=cid%>.createStatement();
             <%if(isLog4jEnabled_tableAction){%>
-                log.info("<%=cid%> - Droping temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
+                log.debug("<%=cid%> - Droping temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
             <%}%>
             stmtTmpDrop_<%=cid%>.execute("<%=manager.getDropTableSQL()%>");
             <%if(isLog4jEnabled_tableAction){%>
-                log.info("<%=cid%> - Drop temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%>+ "<%=manager.getRProtectedChar()%> has succeeded.");
+                log.debug("<%=cid%> - Drop temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%>+ "<%=manager.getRProtectedChar()%> has succeeded.");
             <%}%>
             stmtTmpDrop_<%=cid%>.close();
             <%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tDB2SP/tDB2SP_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tDB2SP/tDB2SP_main.javajet
@@ -211,11 +211,11 @@ if (canGenerate) {
 	  			<%
 			}
 		}
-		dbLog.info(dbLog.str("Try to execute store procedure:"),spName,dbLog.str("."));
+		dblog.debug(dbLog.str("Try to execute store procedure:"),spName,dbLog.str("."));
 		%>
 		statement_<%=cid%>.execute();
 		<%
-		dbLog.info(dbLog.str("The store procedure:"),spName,dbLog.str(" executed successfully."));
+		dblog.debug(dbLog.str("The store procedure:"),spName,dbLog.str(" executed successfully."));
 		List<? extends IConnection> outConnections = node.getOutgoingConnections();
 		IConnection firstOutConnection = null;
 		

--- a/main/plugins/org.talend.designer.components.localprovider/components/tDenormalizeOut/tDenormalizeOut_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tDenormalizeOut/tDenormalizeOut_begin.javajet
@@ -165,7 +165,7 @@ java.util.Map<<%=typesMap.get(groupColumns.get(i)) %>, DenormalizeStruct<%=cid %
 	}
 	if (isLog4jEnabled) {
 	%>
-		log.info("<%=cid%> - Start to denormalize the data from datasource.");
+		log.debug("<%=cid%> - Start to denormalize the data from datasource.");
 	<%
 	}
 }

--- a/main/plugins/org.talend.designer.components.localprovider/components/tDenormalizeOut/tDenormalizeOut_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tDenormalizeOut/tDenormalizeOut_end.javajet
@@ -211,7 +211,7 @@ globalMap.put("<%=cid %>_NB_LINE", result_list_<%=cid %>.size());
 <%
 if(isLog4jEnabled){
 %>
-	log.info("<%=cid%> - Generated records count: " + result_list_<%=cid %>.size() + " .");
+	log.debug("<%=cid%> - Generated records count: " + result_list_<%=cid %>.size() + " .");
 <%
 }
 	}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tDenormalizeSortedRow/tDenormalizeSortedRow_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tDenormalizeSortedRow/tDenormalizeSortedRow_begin.javajet
@@ -87,7 +87,7 @@ boolean  flag_<%=cid%> = true;//flag for the encounter of first row.
 	<%	
 	if (isLog4jEnabled) {
 	%>
-		log.info("<%=cid%> - Start to denormalize the data from datasource.");
+		log.debug("<%=cid%> - Start to denormalize the data from datasource.");
 	<%
 	}
 	//gen groups variable

--- a/main/plugins/org.talend.designer.components.localprovider/components/tDenormalizeSortedRow/tDenormalizeSortedRow_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tDenormalizeSortedRow/tDenormalizeSortedRow_end.javajet
@@ -23,7 +23,7 @@ if ((metadatas!=null)&&(metadatas.size()>0)) {
 		<%	
 		if(isLog4jEnabled){
 		%>
-		log.info("<%=cid%> - Generated records count: " + nb_line_<%=cid %> + " .");
+		log.debug("<%=cid%> - Generated records count: " + nb_line_<%=cid %> + " .");
 		<%
 		}
 	}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tELTGreenplumOutput/tELTGreenplumOutput_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tELTGreenplumOutput/tELTGreenplumOutput_main.javajet
@@ -366,7 +366,7 @@ if(isLog4jEnabled){
 	actionMap.put("UPDATE","updated");
 	actionMap.put("DELETE","deleted");
 	%>
-	log.info("<%=cid%> - Has <%=actionMap.get(dataAction)%> records count: " + nb_line_<%=actionMap.get(dataAction)%>_<%=cid%> + ".");
+	log.debug("<%=cid%> - Has <%=actionMap.get(dataAction)%> records count: " + nb_line_<%=actionMap.get(dataAction)%>_<%=cid%> + ".");
 <%
 }
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tELTJDBCOutput/tELTJDBCOutput_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tELTJDBCOutput/tELTJDBCOutput_main.javajet
@@ -361,7 +361,7 @@ if(isLog4jEnabled){
 	actionMap.put("UPDATE","updated");
 	actionMap.put("DELETE","deleted");
 	%>
-	log.info("<%=cid%> - Has <%=actionMap.get(dataAction)%> records count: " + nb_line_<%=actionMap.get(dataAction)%>_<%=cid%> + ".");
+	log.debug("<%=cid%> - Has <%=actionMap.get(dataAction)%> records count: " + nb_line_<%=actionMap.get(dataAction)%>_<%=cid%> + ".");
 <%
 }
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tELTMSSqlOutput/tELTMSSqlOutput_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tELTMSSqlOutput/tELTMSSqlOutput_main.javajet
@@ -396,7 +396,7 @@ if(isLog4jEnabled){
 	actionMap.put("UPDATE","updated");
 	actionMap.put("DELETE","deleted");
 	%>
-	log.info("<%=cid%> - Has <%=actionMap.get(dataAction)%> records count: " + nb_line_<%=actionMap.get(dataAction)%>_<%=cid%> + ".");
+	log.debug("<%=cid%> - Has <%=actionMap.get(dataAction)%> records count: " + nb_line_<%=actionMap.get(dataAction)%>_<%=cid%> + ".");
 <%
 }
 %> 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tELTMysqlOutput/tELTMysqlOutput_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tELTMysqlOutput/tELTMysqlOutput_main.javajet
@@ -356,7 +356,7 @@ if(isLog4jEnabled){
 	actionMap.put("UPDATE","updated");
 	actionMap.put("DELETE","deleted");
 	%>
-	log.info("<%=cid%> - Has <%=actionMap.get(dataAction)%> records count: " + nb_line_<%=actionMap.get(dataAction)%>_<%=cid%> + ".");
+	log.debug("<%=cid%> - Has <%=actionMap.get(dataAction)%> records count: " + nb_line_<%=actionMap.get(dataAction)%>_<%=cid%> + ".");
 <%
 }
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tELTNetezzaOutput/tELTNetezzaOutput_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tELTNetezzaOutput/tELTNetezzaOutput_main.javajet
@@ -346,7 +346,7 @@ if(isLog4jEnabled){
 	actionMap.put("UPDATE","updated");
 	actionMap.put("DELETE","deleted");
 	%>
-	log.info("<%=cid%> - Has <%=actionMap.get(dataAction)%> records count: " + nb_line_<%=actionMap.get(dataAction)%>_<%=cid%> + ".");
+	log.debug("<%=cid%> - Has <%=actionMap.get(dataAction)%> records count: " + nb_line_<%=actionMap.get(dataAction)%>_<%=cid%> + ".");
 <%
 }
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tELTOracleOutput/tELTOracleOutput_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tELTOracleOutput/tELTOracleOutput_main.javajet
@@ -617,7 +617,7 @@ if(isLog4jEnabled){
 	actionMap.put("DELETE","deleted");
 	actionMap.put("MERGE","merged");
 	%>
-	log.info("<%=cid%> - Has <%=actionMap.get(dataAction)%> records count: " + nb_line_<%=actionMap.get(dataAction)%>_<%=cid%> + ".");
+	log.debug("<%=cid%> - Has <%=actionMap.get(dataAction)%> records count: " + nb_line_<%=actionMap.get(dataAction)%>_<%=cid%> + ".");
 <%
 }
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tELTPostgresqlOutput/tELTPostgresqlOutput_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tELTPostgresqlOutput/tELTPostgresqlOutput_main.javajet
@@ -364,7 +364,7 @@ if(isLog4jEnabled){
 	actionMap.put("UPDATE","updated");
 	actionMap.put("DELETE","deleted");
 	%>
-	log.info("<%=cid%> - Has <%=actionMap.get(dataAction)%> records count: " + nb_line_<%=actionMap.get(dataAction)%>_<%=cid%> + ".");
+	log.debug("<%=cid%> - Has <%=actionMap.get(dataAction)%> records count: " + nb_line_<%=actionMap.get(dataAction)%>_<%=cid%> + ".");
 <%
 }
 %>  

--- a/main/plugins/org.talend.designer.components.localprovider/components/tELTSybaseOutput/tELTSybaseOutput_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tELTSybaseOutput/tELTSybaseOutput_main.javajet
@@ -350,7 +350,7 @@ if(isLog4jEnabled){
 	actionMap.put("UPDATE","updated");
 	actionMap.put("DELETE","deleted");
 	%>
-	log.info("<%=cid%> - Has <%=actionMap.get(dataAction)%> records count: " + nb_line_<%=actionMap.get(dataAction)%>_<%=cid%> + ".");
+	log.debug("<%=cid%> - Has <%=actionMap.get(dataAction)%> records count: " + nb_line_<%=actionMap.get(dataAction)%>_<%=cid%> + ".");
 <%
 }
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tELTTeradataOutput/tELTTeradataOutput_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tELTTeradataOutput/tELTTeradataOutput_main.javajet
@@ -369,7 +369,7 @@ if(isLog4jEnabled){
 	actionMap.put("UPDATE","updated");
 	actionMap.put("DELETE","deleted");
 	%>
-	log.info("<%=cid%> - Has <%=actionMap.get(dataAction)%> records count: " + nb_line_<%=actionMap.get(dataAction)%>_<%=cid%> + ".");
+	log.debug("<%=cid%> - Has <%=actionMap.get(dataAction)%> records count: " + nb_line_<%=actionMap.get(dataAction)%>_<%=cid%> + ".");
 <%
 }
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tELTVerticaOutput/tELTVerticaOutput_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tELTVerticaOutput/tELTVerticaOutput_main.javajet
@@ -369,7 +369,7 @@ imports="
 		actionMap.put("UPDATE","updated");
 		actionMap.put("DELETE","deleted");
 		%>
-		log.info("<%=cid%> - Has <%=actionMap.get(dataAction)%> records count: " + nb_line_<%=actionMap.get(dataAction)%>_<%=cid%> + ".");
+		log.debug("<%=cid%> - Has <%=actionMap.get(dataAction)%> records count: " + nb_line_<%=actionMap.get(dataAction)%>_<%=cid%> + ".");
 	<%
 	}
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tEXistConnection/tEXistConnection_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tEXistConnection/tEXistConnection_begin.javajet
@@ -19,9 +19,9 @@
 %>
 	Class cl_<%=cid%> = Class.forName(<%=driver%>);
 	<%dbLog.conn().logJDBCDriver(driver);%>
-	<% dbLog.info(dbLog.str("Try to create a database instance.")); %>
+	<% dblog.debug(dbLog.str("Try to create a database instance.")); %>
     org.xmldb.api.base.Database database_<%=cid%> = (org.xmldb.api.base.Database) cl_<%=cid%>.newInstance();
-    <% dbLog.info(dbLog.str("Create the instance successed.")); %>
+    <% dblog.debug(dbLog.str("Create the instance successed.")); %>
 
     database_<%=cid%>.setProperty("create-database", "true");
     org.xmldb.api.DatabaseManager.registerDatabase(database_<%=cid%>);
@@ -31,7 +31,7 @@
 	%>
 	
 	<%@ include file="@{org.talend.designer.components.localprovider}/components/templates/password.javajet"%>
-	<% dbLog.info(dbLog.str("Try to retrieve a Collection instance from the database for the given URI: "),uri,dbLog.str(".")); %>
+	<% dblog.debug(dbLog.str("Try to retrieve a Collection instance from the database for the given URI: "),uri,dbLog.str(".")); %>
     org.xmldb.api.base.Collection col_<%=cid%> = org.xmldb.api.DatabaseManager.getCollection(<%=uri%> + <%=collection%>,<%=user%>,decryptedPassword_<%=cid%>);
-    <% dbLog.info(dbLog.str("Retrieves a Collection instance from the database successed.")); %>
+    <% dblog.debug(dbLog.str("Retrieves a Collection instance from the database successed.")); %>
     globalMap.put("col_<%=cid%>",col_<%=cid%>);

--- a/main/plugins/org.talend.designer.components.localprovider/components/tEXistDelete/tEXistDelete_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tEXistDelete/tEXistDelete_begin.javajet
@@ -25,7 +25,7 @@
 
 	if(("true").equals(useExistingConn)){
 		String col= "col_" + connection;
-		dbLog.info(dbLog.str("uses an existing connection."));
+		dblog.debug(dbLog.str("uses an existing connection."));
 %>
 		org.xmldb.api.base.Collection col_<%=cid%> = (org.xmldb.api.base.Collection)globalMap.get("<%=col%>");
 <%
@@ -33,9 +33,9 @@
 %>
 		Class cl_<%=cid%> = Class.forName(<%=driver%>);
 		<%dbLog.conn().logJDBCDriver(driver);%>
-		<% dbLog.info(dbLog.str("Try to create a database instance.")); %>
+		<% dblog.debug(dbLog.str("Try to create a database instance.")); %>
 	    org.xmldb.api.base.Database database_<%=cid%> = (org.xmldb.api.base.Database) cl_<%=cid%>.newInstance();
-	    <% dbLog.info(dbLog.str("Create the instance successed.")); %>
+	    <% dblog.debug(dbLog.str("Create the instance successed.")); %>
 
 	    database_<%=cid%>.setProperty("create-database", "true");
 	    org.xmldb.api.DatabaseManager.registerDatabase(database_<%=cid%>);
@@ -45,9 +45,9 @@
 		%>
 		
 		<%@ include file="@{org.talend.designer.components.localprovider}/components/templates/password.javajet"%>
-	    <% dbLog.info(dbLog.str("Try to retrieve a Collection instance from the database for the given URI: "),uri,dbLog.str(".")); %>
+	    <% dblog.debug(dbLog.str("Try to retrieve a Collection instance from the database for the given URI: "),uri,dbLog.str(".")); %>
 	    org.xmldb.api.base.Collection col_<%=cid%> = org.xmldb.api.DatabaseManager.getCollection(<%=uri%> + <%=collection%>,<%=user%>,decryptedPassword_<%=cid%>);
-        <% dbLog.info(dbLog.str("Retrieves a Collection instance from the database successed.")); %>
+        <% dblog.debug(dbLog.str("Retrieves a Collection instance from the database successed.")); %>
 <%
 	}
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tEXistDelete/tEXistDelete_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tEXistDelete/tEXistDelete_end.javajet
@@ -22,7 +22,7 @@
 	dbLog = new DBLogUtil(node);
 %>
 }
-<% dbLog.info(dbLog.str("Try to close the connection to the collection.")); %>
+<% dblog.debug(dbLog.str("Try to close the connection to the collection.")); %>
 col_<%=cid%>.close();
-<% dbLog.info(dbLog.str("Connection closed successed.")); %>
+<% dblog.debug(dbLog.str("Connection closed successed.")); %>
 globalMap.put("<%=cid %>_NB_FILE",nb_file_<%=cid%>);

--- a/main/plugins/org.talend.designer.components.localprovider/components/tEXistDelete/tEXistDelete_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tEXistDelete/tEXistDelete_main.javajet
@@ -40,9 +40,9 @@
 			for(String resourceName_<%=cid%> : col_<%=cid%>.listResources()){
 				if(resourceName_<%=cid%>.matches(finalMask_<%=cid%>)){
 			        org.xmldb.api.base.Resource resource_<%=cid%> = col_<%=cid%>.getResource(resourceName_<%=cid%>);
-			        <% dbLog.info(dbLog.str("Try to remove resource '"),dbLog.var("resourceName"),dbLog.str("'.")); %>
+			        <% dblog.debug(dbLog.str("Try to remove resource '"),dbLog.var("resourceName"),dbLog.str("'.")); %>
 			        col_<%=cid%>.removeResource(resource_<%=cid%>);
-			        <% dbLog.info(dbLog.str("The resource removed successed.")); %>
+			        <% dblog.debug(dbLog.str("The resource removed successed.")); %>
 				}
 			}
 <%
@@ -50,9 +50,9 @@
 %>
 			for(String subCol_<%=cid%> : col_<%=cid%>.listChildCollections()){
 				if(subCol_<%=cid%>.matches(finalMask_<%=cid%>)){
-					<% dbLog.info(dbLog.str("Try to remove collection '"),dbLog.var("subCol"),dbLog.str("'.")); %>
+					<% dblog.debug(dbLog.str("Try to remove collection '"),dbLog.var("subCol"),dbLog.str("'.")); %>
 					mgtService_<%=cid%>.removeCollection(subCol_<%=cid%>);
-					<% dbLog.info(dbLog.str("The collection removed successed.")); %>
+					<% dblog.debug(dbLog.str("The collection removed successed.")); %>
 				}
 			}
 <%
@@ -61,16 +61,16 @@
 			for(String resourceName_<%=cid%> : col_<%=cid%>.listResources()){
 				if(resourceName_<%=cid%>.matches(finalMask_<%=cid%>)){
 			        org.xmldb.api.base.Resource resource_<%=cid%> = col_<%=cid%>.getResource(resourceName_<%=cid%>);
-			        <% dbLog.info(dbLog.str("Try to remove resource '"),dbLog.var("resourceName"),dbLog.str("'.")); %>
+			        <% dblog.debug(dbLog.str("Try to remove resource '"),dbLog.var("resourceName"),dbLog.str("'.")); %>
 			        col_<%=cid%>.removeResource(resource_<%=cid%>);
-			        <% dbLog.info(dbLog.str("The resource removed successed.")); %>
+			        <% dblog.debug(dbLog.str("The resource removed successed.")); %>
 				}
 			}
 			for(String subCol_<%=cid%> : col_<%=cid%>.listChildCollections()){
 				if(subCol_<%=cid%>.matches(finalMask_<%=cid%>)){
-					<% dbLog.info(dbLog.str("Try to remove collection '"),dbLog.var("subCol"),dbLog.str("'.")); %>
+					<% dblog.debug(dbLog.str("Try to remove collection '"),dbLog.var("subCol"),dbLog.str("'.")); %>
 					mgtService_<%=cid%>.removeCollection(subCol_<%=cid%>);
-					<% dbLog.info(dbLog.str("The collection removed successed.")); %>
+					<% dblog.debug(dbLog.str("The collection removed successed.")); %>
 				}
 			}
 <%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tEXistGet/tEXistGet_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tEXistGet/tEXistGet_begin.javajet
@@ -26,7 +26,7 @@
 
 	if(("true").equals(useExistingConn)){
 		String col= "col_" + connection;
-		dbLog.info(dbLog.str("uses an existing connection."));
+		dblog.debug(dbLog.str("uses an existing connection."));
 %>
 		org.xmldb.api.base.Collection col_<%=cid%> = (org.xmldb.api.base.Collection)globalMap.get("<%=col%>");
 <%
@@ -34,9 +34,9 @@
 %>
 		Class cl_<%=cid%> = Class.forName(<%=driver%>);
 		<%dbLog.conn().logJDBCDriver(driver);%>
-		<% dbLog.info(dbLog.str("Try to create a database instance.")); %>
+		<% dblog.debug(dbLog.str("Try to create a database instance.")); %>
 	    org.xmldb.api.base.Database database_<%=cid%> = (org.xmldb.api.base.Database) cl_<%=cid%>.newInstance();
-	    <% dbLog.info(dbLog.str("Create the instance successed.")); %>
+	    <% dblog.debug(dbLog.str("Create the instance successed.")); %>
 
 	    database_<%=cid%>.setProperty("create-database", "true");
 	    org.xmldb.api.DatabaseManager.registerDatabase(database_<%=cid%>);
@@ -46,9 +46,9 @@
 		%>
 		
 		<%@ include file="@{org.talend.designer.components.localprovider}/components/templates/password.javajet"%>
-	    <% dbLog.info(dbLog.str("Try to retrieve a Collection instance from the database for the given URI: "),uri,dbLog.str(".")); %>
+	    <% dblog.debug(dbLog.str("Try to retrieve a Collection instance from the database for the given URI: "),uri,dbLog.str(".")); %>
 	    org.xmldb.api.base.Collection col_<%=cid%> = org.xmldb.api.DatabaseManager.getCollection(<%=uri%> + <%=collection%>,<%=user%>,decryptedPassword_<%=cid%>);
-        <% dbLog.info(dbLog.str("Retrieves a Collection instance from the database successed.")); %>
+        <% dblog.debug(dbLog.str("Retrieves a Collection instance from the database successed.")); %>
 <%
 	}
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tEXistGet/tEXistGet_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tEXistGet/tEXistGet_end.javajet
@@ -22,7 +22,7 @@
 	dbLog = new DBLogUtil(node);
 %>
 }
-<% dbLog.info(dbLog.str("Try to close the connection to the collection.")); %>
+<% dblog.debug(dbLog.str("Try to close the connection to the collection.")); %>
 col_<%=cid%>.close();
-<% dbLog.info(dbLog.str("Connection closed successed.")); %>
+<% dblog.debug(dbLog.str("Connection closed successed.")); %>
 globalMap.put("<%=cid %>_NB_FILE",nb_file_<%=cid%>);

--- a/main/plugins/org.talend.designer.components.localprovider/components/tEXistGet/tEXistGet_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tEXistGet/tEXistGet_main.javajet
@@ -40,7 +40,7 @@
 		
 		for(String resourceName_<%=cid%> : col_<%=cid%>.listResources()){
 			if(resourceName_<%=cid%>.matches(finalMask_<%=cid%>)){
-				<% dbLog.info(dbLog.str("Try to get file '"),dbLog.var("resourceName"),dbLog.str("' to local dir: '"),dbLog.var("localdir"),dbLog.str("'.")); %>
+				<% dblog.debug(dbLog.str("Try to get file '"),dbLog.var("resourceName"),dbLog.str("' to local dir: '"),dbLog.var("localdir"),dbLog.str("'.")); %>
 		    	java.io.File localFile_<%=cid%> = new java.io.File(localdir_<%=cid%> + "/" + resourceName_<%=cid%>);
 		        org.xmldb.api.base.Resource resource_<%=cid%> = col_<%=cid%>.getResource(resourceName_<%=cid%>);
 		        if("org.exist.xmldb.RemoteXMLResource".equals(resource_<%=cid%>.getClass().getName())){
@@ -52,7 +52,7 @@
 			        org.exist.xmldb.RemoteBinaryResource remoteBinaryResource_<%=cid%> = (org.exist.xmldb.RemoteBinaryResource)resource_<%=cid%>;
 			        remoteBinaryResource_<%=cid%>.getContentIntoAFile(localFile_<%=cid%>);
 		        }
-		        <% dbLog.info(dbLog.str("Get file successed.")); %>
+		        <% dblog.debug(dbLog.str("Get file successed.")); %>
 			}
 		}
 		nb_file_<%=cid%>++;

--- a/main/plugins/org.talend.designer.components.localprovider/components/tEXistList/tEXistList_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tEXistList/tEXistList_begin.javajet
@@ -25,7 +25,7 @@
 	
 	if(("true").equals(useExistingConn)){
 		String col= "col_" + connection;
-		dbLog.info(dbLog.str("uses an existing connection."));
+		dblog.debug(dbLog.str("uses an existing connection."));
 %>
 		org.xmldb.api.base.Collection col_<%=cid%> = (org.xmldb.api.base.Collection)globalMap.get("<%=col%>");
 <%
@@ -33,9 +33,9 @@
 %>
 		Class cl_<%=cid%> = Class.forName(<%=driver%>);
 		<%dbLog.conn().logJDBCDriver(driver);%>
-		<% dbLog.info(dbLog.str("Try to create a database instance.")); %>
+		<% dblog.debug(dbLog.str("Try to create a database instance.")); %>
 	    org.xmldb.api.base.Database database_<%=cid%> = (org.xmldb.api.base.Database) cl_<%=cid%>.newInstance();
-		<% dbLog.info(dbLog.str("Create the instance successed.")); %>
+		<% dblog.debug(dbLog.str("Create the instance successed.")); %>
 
 	    database_<%=cid%>.setProperty("create-database", "true");
 	    org.xmldb.api.DatabaseManager.registerDatabase(database_<%=cid%>);
@@ -45,9 +45,9 @@
 		%>
 		
 		<%@ include file="@{org.talend.designer.components.localprovider}/components/templates/password.javajet"%>
-	    <% dbLog.info(dbLog.str("Try to retrieve a Collection instance from the database for the given URI: "),uri,dbLog.str(".")); %>
+	    <% dblog.debug(dbLog.str("Try to retrieve a Collection instance from the database for the given URI: "),uri,dbLog.str(".")); %>
 	    org.xmldb.api.base.Collection col_<%=cid%> = org.xmldb.api.DatabaseManager.getCollection(<%=uri%> + <%=collection%>,<%=user%>,decryptedPassword_<%=cid%>);
-        <% dbLog.info(dbLog.str("Retrieves a Collection instance from the database successed.")); %>
+        <% dblog.debug(dbLog.str("Retrieves a Collection instance from the database successed.")); %>
 <%
 	}
 %>
@@ -63,7 +63,7 @@
 <%
 	}
 %>	
-		<% dbLog.info(dbLog.str("Try to list file which matches the filemask.")); %>
+		<% dblog.debug(dbLog.str("Try to list file which matches the filemask.")); %>
 		for(java.util.Map<String, String> map_<%=cid%> : list_<%=cid%>){
 		
 		   	java.util.Set<String> keySet_<%=cid%> = map_<%=cid%>.keySet();

--- a/main/plugins/org.talend.designer.components.localprovider/components/tEXistList/tEXistList_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tEXistList/tEXistList_end.javajet
@@ -23,8 +23,8 @@
 			} <% /* "for String contentName" end */ %>
 	} <% /* "for String key_" end */ %>
 } <% /* "for java.util.Map" end */ %>
-<% dbLog.info(dbLog.str("List file done.")); %>
-<% dbLog.info(dbLog.str("Try to close the connection to the collection.")); %>
+<% dblog.debug(dbLog.str("List file done.")); %>
+<% dblog.debug(dbLog.str("Try to close the connection to the collection.")); %>
 col_<%=cid%>.close();
-<% dbLog.info(dbLog.str("Connection closed successed.")); %>
+<% dblog.debug(dbLog.str("Connection closed successed.")); %>
 globalMap.put("<%=cid %>_NB_FILE",nb_file_<%=cid%>);

--- a/main/plugins/org.talend.designer.components.localprovider/components/tEXistPut/tEXistPut_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tEXistPut/tEXistPut_begin.javajet
@@ -25,7 +25,7 @@
 
 	if(("true").equals(useExistingConn)){
 		String col= "col_" + connection;
-		dbLog.info(dbLog.str("uses an existing connection."));
+		dblog.debug(dbLog.str("uses an existing connection."));
 %>
 		
 		org.xmldb.api.base.Collection col_<%=cid%> = (org.xmldb.api.base.Collection)globalMap.get("<%=col%>");
@@ -34,9 +34,9 @@
 %>
 		Class cl_<%=cid%> = Class.forName(<%=driver%>);
 		<%dbLog.conn().logJDBCDriver(driver);%>
-		<% dbLog.info(dbLog.str("Try to create a database instance.")); %>
+		<% dblog.debug(dbLog.str("Try to create a database instance.")); %>
 	    org.xmldb.api.base.Database database_<%=cid%> = (org.xmldb.api.base.Database) cl_<%=cid%>.newInstance();
-	    <% dbLog.info(dbLog.str("Create the instance successed.")); %>
+	    <% dblog.debug(dbLog.str("Create the instance successed.")); %>
 
 	    database_<%=cid%>.setProperty("create-database", "true");
 	    org.xmldb.api.DatabaseManager.registerDatabase(database_<%=cid%>);
@@ -46,9 +46,9 @@
 		%>
 		
 		<%@ include file="@{org.talend.designer.components.localprovider}/components/templates/password.javajet"%>
-	    <% dbLog.info(dbLog.str("Try to retrieve a Collection instance from the database for the given URI: "),uri,dbLog.str(".")); %>
+	    <% dblog.debug(dbLog.str("Try to retrieve a Collection instance from the database for the given URI: "),uri,dbLog.str(".")); %>
 	    org.xmldb.api.base.Collection col_<%=cid%> = org.xmldb.api.DatabaseManager.getCollection(<%=uri%> + <%=collection%>,<%=user%>,decryptedPassword_<%=cid%>);
-        <% dbLog.info(dbLog.str("Retrieves a Collection instance from the database successed.")); %>
+        <% dblog.debug(dbLog.str("Retrieves a Collection instance from the database successed.")); %>
 <%
 	}
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tEXistPut/tEXistPut_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tEXistPut/tEXistPut_end.javajet
@@ -22,7 +22,7 @@
 	dbLog = new DBLogUtil(node);
 %>
 }
-<% dbLog.info(dbLog.str("Try to close the connection to the collection.")); %>
+<% dblog.debug(dbLog.str("Try to close the connection to the collection.")); %>
 col_<%=cid%>.close();
-<% dbLog.info(dbLog.str("Connection closed successed.")); %>
+<% dblog.debug(dbLog.str("Connection closed successed.")); %>
 globalMap.put("<%=cid %>_NB_FILE",nb_file_<%=cid%>);

--- a/main/plugins/org.talend.designer.components.localprovider/components/tEXistXQuery/tEXistXQuery_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tEXistXQuery/tEXistXQuery_begin.javajet
@@ -22,7 +22,7 @@
 
     if(("true").equals(useExistingConn)){
         String col= "col_" + connection;
-        dbLog.info(dbLog.str("uses an existing connection."));
+        dblog.debug(dbLog.str("uses an existing connection."));
 %>
         org.xmldb.api.base.Collection col_<%=cid%> = (org.xmldb.api.base.Collection)globalMap.get("<%=col%>");
 <%
@@ -30,9 +30,9 @@
 %>
         Class cl_<%=cid%> = Class.forName(<%=driver%>);
         <%dbLog.conn().logJDBCDriver(driver);%>
-        <% dbLog.info(dbLog.str("Try to create a database instance.")); %>
+        <% dblog.debug(dbLog.str("Try to create a database instance.")); %>
         org.xmldb.api.base.Database database_<%=cid%> = (org.xmldb.api.base.Database) cl_<%=cid%>.newInstance();
-        <% dbLog.info(dbLog.str("Create the instance successed.")); %>
+        <% dblog.debug(dbLog.str("Create the instance successed.")); %>
 
         database_<%=cid%>.setProperty("create-database", "true");
         org.xmldb.api.DatabaseManager.registerDatabase(database_<%=cid%>);
@@ -42,9 +42,9 @@
         %>
         
         <%@ include file="@{org.talend.designer.components.localprovider}/components/templates/password.javajet"%>
-        <% dbLog.info(dbLog.str("Try to retrieve a Collection instance from the database for the given URI: "),uri,dbLog.str(".")); %>
+        <% dblog.debug(dbLog.str("Try to retrieve a Collection instance from the database for the given URI: "),uri,dbLog.str(".")); %>
         org.xmldb.api.base.Collection col_<%=cid%> = org.xmldb.api.DatabaseManager.getCollection(<%=uri%> + <%=collection%>,<%=user%>,decryptedPassword_<%=cid%>);
-        <% dbLog.info(dbLog.str("Retrieves a Collection instance from the database successed.")); %>
+        <% dblog.debug(dbLog.str("Retrieves a Collection instance from the database successed.")); %>
 <%
     }
 %>
@@ -61,9 +61,9 @@
     service_<%=cid%>.setProperty(javax.xml.transform.OutputKeys.ENCODING, "UTF-8");
     org.xmldb.api.base.CompiledExpression compiled_<%=cid%> = service_<%=cid%>.compile(query_<%=cid%>);
 
-    <% dbLog.info(dbLog.str("Try to execute query.")); %>
+    <% dblog.debug(dbLog.str("Try to execute query.")); %>
     org.xmldb.api.base.ResourceSet result_<%=cid%> = service_<%=cid%>.execute(compiled_<%=cid%>);
-    <% dbLog.info(dbLog.str("Execute query successed.")); %>
+    <% dblog.debug(dbLog.str("Execute query successed.")); %>
 
     java.util.Properties outputProperties_<%=cid%> = new java.util.Properties();
     outputProperties_<%=cid%>.setProperty(javax.xml.transform.OutputKeys.INDENT, "yes");

--- a/main/plugins/org.talend.designer.components.localprovider/components/tEXistXUpdate/tEXistXUpdate_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tEXistXUpdate/tEXistXUpdate_begin.javajet
@@ -21,7 +21,7 @@
 
 	if(("true").equals(useExistingConn)){
 		String col= "col_" + connection;
-		dbLog.info(dbLog.str("uses an existing connection."));
+		dblog.debug(dbLog.str("uses an existing connection."));
 %>
 		org.xmldb.api.base.Collection col_<%=cid%> = (org.xmldb.api.base.Collection)globalMap.get("<%=col%>");
 <%
@@ -29,9 +29,9 @@
 %>
 		Class cl_<%=cid%> = Class.forName(<%=driver%>);
 		<%dbLog.conn().logJDBCDriver(driver);%>
-		<% dbLog.info(dbLog.str("Try to create a database instance.")); %>
+		<% dblog.debug(dbLog.str("Try to create a database instance.")); %>
 	    org.xmldb.api.base.Database database_<%=cid%> = (org.xmldb.api.base.Database) cl_<%=cid%>.newInstance();
-	    <% dbLog.info(dbLog.str("Create the instance successed.")); %>
+	    <% dblog.debug(dbLog.str("Create the instance successed.")); %>
 
 	    database_<%=cid%>.setProperty("create-database", "true");
 	    org.xmldb.api.DatabaseManager.registerDatabase(database_<%=cid%>);
@@ -41,9 +41,9 @@
 		%>
 		
 		<%@ include file="@{org.talend.designer.components.localprovider}/components/templates/password.javajet"%>
-	    <% dbLog.info(dbLog.str("Try to retrieve a Collection instance from the database for the given URI: "),uri,dbLog.str(".")); %>
+	    <% dblog.debug(dbLog.str("Try to retrieve a Collection instance from the database for the given URI: "),uri,dbLog.str(".")); %>
 	    org.xmldb.api.base.Collection col_<%=cid%> = org.xmldb.api.DatabaseManager.getCollection(<%=uri%> + <%=collection%>,<%=user%>,decryptedPassword_<%=cid%>);
-        <% dbLog.info(dbLog.str("Retrieves a Collection instance from the database successed.")); %>
+        <% dblog.debug(dbLog.str("Retrieves a Collection instance from the database successed.")); %>
 <%
 	}
 %>
@@ -55,6 +55,6 @@
 	br_<%=cid%>.close();
 	String xUpdateModifications_<%=cid%> = new String(characters_<%=cid%>);
 	<% dbLog.debug(dbLog.str("The raw update string is '"),dbLog.var("xUpdateModifications"),dbLog.str("'.")); %>
-	<% dbLog.info(dbLog.str("Try to update xmldb.")); %>
+	<% dblog.debug(dbLog.str("Try to update xmldb.")); %>
 	service_<%=cid%>.update(xUpdateModifications_<%=cid%>);
-	<% dbLog.info(dbLog.str("Update the xmldb successed.")); %>
+	<% dblog.debug(dbLog.str("Update the xmldb successed.")); %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPConnection/tFTPConnection_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPConnection/tFTPConnection_begin.javajet
@@ -68,7 +68,7 @@ if (!sftp && !ftps) { // *** ftp *** //
 	<%}%>
 	ftp_<%=cid %>.setControlEncoding(<%=sEncoding%>);
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" +<%=user %>+ "'.");
+		log.debug("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" +<%=user %>+ "'.");
 	<%}%>
 	ftp_<%=cid %>.connect();  
 	
@@ -80,7 +80,7 @@ if (!sftp && !ftps) { // *** ftp *** //
    	
 	ftp_<%=cid %>.login(<%=user %>, decryptedPassword_<%=cid%>);  
   	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
+		log.debug("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
 	<%}%>
 	globalMap.put("conn_<%=cid%>",ftp_<%=cid %>);
 <%
@@ -129,7 +129,7 @@ if (!sftp && !ftps) { // *** ftp *** //
 
 	<%if (("PUBLICKEY").equals(authMethod)){%>
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - SFTP authentication using a public key.");
+			log.debug("<%=cid%> - SFTP authentication using a public key.");
 			log.debug("<%=cid%> - Private key: '" + <%=privateKey%> + "'.");
 		<%}%>
 		jsch_<%=cid%>.addIdentity(<%=privateKey %>, defaultUserInfo_<%=cid%>.getPassphrase());
@@ -140,7 +140,7 @@ if (!sftp && !ftps) { // *** ftp *** //
 	
 	<%if (("PASSWORD").equals(authMethod)) {%> 
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - SFTP authentication using a password.");
+			log.debug("<%=cid%> - SFTP authentication using a password.");
 		<%}%>
 	        
 		<%
@@ -163,13 +163,13 @@ if (!sftp && !ftps) { // *** ftp *** //
 		}
 	<%}%>
   	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Attempt to connect to  '" + <%=host %> + "' with username '" + <%=user%> + "'.");
+		log.debug("<%=cid%> - Attempt to connect to  '" + <%=host %> + "' with username '" + <%=user%> + "'.");
 	<%}%>
 	session_<%=cid%>.connect();
 	com.jcraft.jsch. Channel channel_<%=cid%> = session_<%=cid%>.openChannel("sftp"); 
 	channel_<%=cid%>.connect();
   	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
+		log.debug("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
 	<%}%>
 	com.jcraft.jsch.ChannelSftp c_<%=cid%> = (com.jcraft.jsch.ChannelSftp)channel_<%=cid%>;
 	
@@ -231,12 +231,12 @@ if (!sftp && !ftps) { // *** ftp *** //
 		}
 %>
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> -FTPS security Mode is <%=securityMode%>.");
-			log.info("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" + <%=user %>+ "'.");
+			log.debug("<%=cid%> -FTPS security Mode is <%=securityMode%>.");
+			log.debug("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" + <%=user %>+ "'.");
 		<%}%>
     	ftp_<%=cid %>.connect(<%=host %>,<%=port %>);
   		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
+			log.debug("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
 		<%}%>
 	        
 		<%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPDelete/tFTPDelete_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPDelete/tFTPDelete_begin.javajet
@@ -116,7 +116,7 @@ int nb_file_<%=cid%> = 0;
 
 			<%if (("PUBLICKEY").equals(authMethod)) {%>
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - SFTP authentication using a public key.");
+					log.debug("<%=cid%> - SFTP authentication using a public key.");
 					log.debug("<%=cid%> - Private key: '" + <%=privateKey%> + "'.");
 	  			<%}%>
       			jsch_<%=cid%>.addIdentity(<%=privateKey %>, defaultUserInfo_<%=cid%>.getPassphrase());
@@ -127,7 +127,7 @@ int nb_file_<%=cid%> = 0;
 
 		    <%if (("PASSWORD").equals(authMethod)){ %>
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - SFTP authentication using a password.");
+					log.debug("<%=cid%> - SFTP authentication using a password.");
 				<%}%>
 				
 				<%
@@ -149,13 +149,13 @@ int nb_file_<%=cid%> = 0;
 			  	}
 			<%}%>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username: '" + <%=user%> + "'.");
+				log.debug("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username: '" + <%=user%> + "'.");
 			<%}%>
 		    session_<%=cid%>.connect();
 		    com.jcraft.jsch. Channel channel_<%=cid%>=session_<%=cid%>.openChannel("sftp");
 		    channel_<%=cid%>.connect();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
+				log.debug("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
 			<%}%>
 		    com.jcraft.jsch.ChannelSftp c_<%=cid%>=(com.jcraft.jsch.ChannelSftp)channel_<%=cid%>;
 		    
@@ -168,7 +168,7 @@ int nb_file_<%=cid%> = 0;
 			com.jcraft.jsch.ChannelSftp c_<%=cid%> = (com.jcraft.jsch.ChannelSftp)globalMap.get("<%=conn %>");
 			<%if(isLog4jEnabled){%>
 				if(c_<%=cid%>!=null && c_<%=cid%>.getSession()!=null) {
-					log.info("<%=cid%> - Uses an existing connection. Connection username: " + c_<%=cid%>.getSession().getUserName() + ", Connection hostname: " + c_<%=cid%>.getSession().getHost() + ", Connection port: " + c_<%=cid%>.getSession().getPort() + "."); 
+					log.debug("<%=cid%> - Uses an existing connection. Connection username: " + c_<%=cid%>.getSession().getUserName() + ", Connection hostname: " + c_<%=cid%>.getSession().getHost() + ", Connection port: " + c_<%=cid%>.getSession().getPort() + "."); 
 				}
 			<%}%>
 		    if(c_<%=cid%>.getHome()!=null && !c_<%=cid%>.getHome().equals(c_<%=cid%>.pwd())){
@@ -187,9 +187,9 @@ int nb_file_<%=cid%> = 0;
 
 		<%if(isLog4jEnabled){%>
 			<%if("FILE".equals(targetType)){%>
-				log.info("<%=cid%> - Deleting file from server.");
+				log.debug("<%=cid%> - Deleting file from server.");
 			<%}else{%>
-				log.info("<%=cid%> - Deleting directory from server.");
+				log.debug("<%=cid%> - Deleting directory from server.");
 			<%}%>
 		<%}%>
 		for (java.util.Map<String, String> map<%=cid %> : list<%=cid %>) {
@@ -203,7 +203,7 @@ int nb_file_<%=cid%> = 0;
     		ftp_<%=cid %> = (com.enterprisedt.net.ftp.FTPClient)globalMap.get("<%=conn %>");
 			<%if(isLog4jEnabled){%>
 				if(ftp_<%=cid %>!=null) {
-					log.info("<%=cid%> - Uses an existing connection. Connection hostname: " + ftp_<%=cid %>.getRemoteHost() + ",Connection port: " + ftp_<%=cid %>.getRemotePort() + "."); 
+					log.debug("<%=cid%> - Uses an existing connection. Connection hostname: " + ftp_<%=cid %>.getRemoteHost() + ",Connection port: " + ftp_<%=cid %>.getRemotePort() + "."); 
 				}
 			<%}%>
 		  	<%if(!moveToCurrentDir){%>
@@ -223,7 +223,7 @@ int nb_file_<%=cid%> = 0;
 		    <%}%>
 		    ftp_<%=cid %>.setControlEncoding(<%=encoding%>);
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username: '" +<%=user %>+ "'.");
+				log.debug("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username: '" +<%=user %>+ "'.");
 			<%}%>
 		    ftp_<%=cid %>.connect();  
 		    
@@ -235,7 +235,7 @@ int nb_file_<%=cid%> = 0;
 		    
 		    ftp_<%=cid %>.login(<%=user %>, decryptedPassword_<%=cid%>);
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
+				log.debug("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
 			<%}%>  
   		<%}%>  
   		java.util.List<java.util.Map<String,String>> list<%=cid %> = new java.util.ArrayList<java.util.Map<String,String>>();  
@@ -253,9 +253,9 @@ int nb_file_<%=cid%> = 0;
 
 		<%if(isLog4jEnabled){%>
 			<%if("FILE".equals(targetType)){%>
-				log.info("<%=cid%> - Deleting file from server.");
+				log.debug("<%=cid%> - Deleting file from server.");
 			<%}else{%>
-				log.info("<%=cid%> - Deleting directory from server.");
+				log.debug("<%=cid%> - Deleting directory from server.");
 			<%}%>
 		<%}%>
 			for (java.util.Map<String, String> map<%=cid %> : list<%=cid %>) {

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPDelete/tFTPDelete_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPDelete/tFTPDelete_end.javajet
@@ -33,11 +33,11 @@
 		if(!("true").equals(useExistingConn)){
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Closing the connection to the server.");
+				log.debug("<%=cid%> - Closing the connection to the server.");
 			<%}%>
     		session_<%=cid%>.disconnect(); 
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Connection to the server closed.");
+				log.debug("<%=cid%> - Connection to the server closed.");
 			<%}%>  
 <%
 		}
@@ -51,11 +51,11 @@
 %>
 				try{
 					<%if(isLog4jEnabled){%>
-						log.info("<%=cid%> - Closing the connection to the server.");
+						log.debug("<%=cid%> - Closing the connection to the server.");
 					<%}%>
 					ftp_<%=cid %>.quit();
 					<%if(isLog4jEnabled){%>
-						log.info("<%=cid%> - Connection to the server closed.");
+						log.debug("<%=cid%> - Connection to the server closed.");
 					<%}%>  
 				}catch(java.net.SocketException se_<%=cid%>){
 					//ignore failure
@@ -67,11 +67,11 @@
 			}else{
 %>
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Closing the connection to the server.");
+					log.debug("<%=cid%> - Closing the connection to the server.");
 				<%}%>
 				ftp_<%=cid %>.quit();
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Connection to the server closed.");
+					log.debug("<%=cid%> - Connection to the server closed.");
 				<%}%>  
 <%
 			}
@@ -88,5 +88,5 @@
 globalMap.put("<%=cid %>_NB_FILE",nb_file_<%=cid%>);
 
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - Deleted files count: " + nb_file_<%=cid%>  + ".");
+	log.debug("<%=cid%> - Deleted files count: " + nb_file_<%=cid%>  + ".");
 <%}%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPFileExist/tFTPFileExist_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPFileExist/tFTPFileExist_begin.javajet
@@ -120,7 +120,7 @@ if (sftp) {
 
     	<%if (("PUBLICKEY").equals(authMethod)) {%>
 	  		<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - SFTP authentication using a public key.");
+				log.debug("<%=cid%> - SFTP authentication using a public key.");
 				log.debug("<%=cid%> - Private key: '" + <%=privateKey %> + "'.");
 	  		<%}%>
       		jsch_<%=cid%>.addIdentity(<%=privateKey %>, defaultUserInfo_<%=cid%>.getPassphrase());
@@ -131,7 +131,7 @@ if (sftp) {
 
     	<%if (("PASSWORD").equals(authMethod)) {%> 
 	  		<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - SFTP authentication using a password.");
+				log.debug("<%=cid%> - SFTP authentication using a password.");
 	  		<%}%>
 	  		
 			<%
@@ -153,13 +153,13 @@ if (sftp) {
   			}
 		<%}%>
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" + <%=user%> + "'.");
+			log.debug("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" + <%=user%> + "'.");
 		<%}%>
     	session_<%=cid%>.connect();
 		com.jcraft.jsch. Channel channel_<%=cid%>=session_<%=cid%>.openChannel("sftp");
     	channel_<%=cid%>.connect();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connect to '" + <%=host%> + "' has succeeded.");
+			log.debug("<%=cid%> - Connect to '" + <%=host%> + "' has succeeded.");
 		<%}%>
     	com.jcraft.jsch.ChannelSftp c_<%=cid%>=(com.jcraft.jsch.ChannelSftp)channel_<%=cid%>;
     	
@@ -172,7 +172,7 @@ if (sftp) {
 	    com.jcraft.jsch.ChannelSftp c_<%=cid%> = (com.jcraft.jsch.ChannelSftp)globalMap.get("<%=conn %>");
 		<%if(isLog4jEnabled){%>
 			if(c_<%=cid%>!=null && c_<%=cid%>.getSession()!=null) {
-				log.info("<%=cid%> - Use an existing connection.  Connection username: " + c_<%=cid%>.getSession().getUserName() + ", Connection hostname: " + c_<%=cid%>.getSession().getHost() + ", Connection port: " + c_<%=cid%>.getSession().getPort() + "."); 
+				log.debug("<%=cid%> - Use an existing connection.  Connection username: " + c_<%=cid%>.getSession().getUserName() + ", Connection hostname: " + c_<%=cid%>.getSession().getHost() + ", Connection port: " + c_<%=cid%>.getSession().getPort() + "."); 
 			}
 		<%}%>
 	    if(c_<%=cid%>.getHome()!=null && !c_<%=cid%>.getHome().equals(c_<%=cid%>.pwd())){
@@ -187,7 +187,7 @@ if (sftp) {
 		ftp_<%=cid %> = (com.enterprisedt.net.ftp.FTPClient)globalMap.get("<%=conn %>");
 		<%if(isLog4jEnabled){%>
 			if(ftp_<%=cid %>!=null) {
-				log.info("<%=cid%> - Use an existing connection. Connection hostname: " + ftp_<%=cid %>.getRemoteHost() + ", Connection port: " + ftp_<%=cid %>.getRemotePort() + "."); 
+				log.debug("<%=cid%> - Use an existing connection. Connection hostname: " + ftp_<%=cid %>.getRemoteHost() + ", Connection port: " + ftp_<%=cid %>.getRemotePort() + "."); 
 			}
 		<%}%>
   	<%} else {%>    
@@ -206,7 +206,7 @@ if (sftp) {
 	    <%}%>
 	    ftp_<%=cid %>.setControlEncoding(<%=encoding%>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username: '" +<%=username %>+ "'.");
+			log.debug("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username: '" +<%=username %>+ "'.");
 		<%}%>
 	    ftp_<%=cid %>.connect();  
 	    
@@ -218,7 +218,7 @@ if (sftp) {
 
 	    ftp_<%=cid %>.login(<%=username %>, decryptedPassword_<%=cid%>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connect to '" + <%=host%>  + "' has succeeded.");
+			log.debug("<%=cid%> - Connect to '" + <%=host%>  + "' has succeeded.");
 		<%}%>
 	  <%  
 	}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPFileExist/tFTPFileExist_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPFileExist/tFTPFileExist_end.javajet
@@ -32,11 +32,11 @@ if (("true").equals(useExistingConn)) {
 if (sftp && !("true").equals(useExistingConn)) {
 %>
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Closing the connection to the server.");
+		log.debug("<%=cid%> - Closing the connection to the server.");
 	<%}%>
 	session_<%=cid%>.disconnect(); 
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection to the server closed.");
+		log.debug("<%=cid%> - Connection to the server closed.");
 	<%}%>
 <%
 } else {
@@ -45,11 +45,11 @@ if (sftp && !("true").equals(useExistingConn)) {
     %>
 			try {
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Closing the connection to the server.");
+					log.debug("<%=cid%> - Closing the connection to the server.");
 				<%}%>
 				ftp_<%=cid %>.quit();
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Connection to the server closed.");
+					log.debug("<%=cid%> - Connection to the server closed.");
 				<%}%>
       		} catch(java.net.SocketException se_<%=cid%>) {
 				<%if(isLog4jEnabled){%>
@@ -61,11 +61,11 @@ if (sftp && !("true").equals(useExistingConn)) {
     	} else {
     %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Closing the connection to the server.");
+				log.debug("<%=cid%> - Closing the connection to the server.");
 			<%}%>
       		ftp_<%=cid %>.quit();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Connection to the server closed.");
+				log.debug("<%=cid%> - Connection to the server closed.");
 			<%}%>
     <%
 		}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPFileList/tFTPFileList_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPFileList/tFTPFileList_begin.javajet
@@ -138,7 +138,7 @@ if (sftp) {// *** sftp *** //
 
 		<%if (("PUBLICKEY").equals(authMethod)) {%>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - SFTP authentication using a public key.");
+				log.debug("<%=cid%> - SFTP authentication using a public key.");
 				log.debug("<%=cid%> - Private key: '" + <%=privateKey%> + "'.");
 			<%}%>
 			jsch_<%=cid%>.addIdentity(<%=privateKey %>, defaultUserInfo_<%=cid%>.getPassphrase());
@@ -149,7 +149,7 @@ if (sftp) {// *** sftp *** //
 
 		<%if (("PASSWORD").equals(authMethod)) {%>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - SFTP authentication using a password.");
+				log.debug("<%=cid%> - SFTP authentication using a password.");
 	  		<%}%> 
 	  		
 	  		<%
@@ -171,13 +171,13 @@ if (sftp) {// *** sftp *** //
   		}
 		<%}%>
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" + <%=user%> + "'.");
+			log.debug("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" + <%=user%> + "'.");
 		<%}%>
 		session_<%=cid%>.connect();
 		com.jcraft.jsch. Channel channel_<%=cid%>=session_<%=cid%>.openChannel("sftp");
 		channel_<%=cid%>.connect();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
+			log.debug("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
 		<%}%>
 		com.jcraft.jsch.ChannelSftp c_<%=cid%>=(com.jcraft.jsch.ChannelSftp)channel_<%=cid%>;
 		
@@ -191,7 +191,7 @@ if (sftp) {// *** sftp *** //
     	com.jcraft.jsch.ChannelSftp c_<%=cid%> = (com.jcraft.jsch.ChannelSftp)globalMap.get("<%=conn %>");
 		<%if(isLog4jEnabled){%>
 			if(c_<%=cid%>!=null && c_<%=cid%>.getSession()!=null) {
-				log.info("<%=cid%> - Use an existing connection. Connection username: " + c_<%=cid%>.getSession().getUserName() + ", Connection hostname: " + c_<%=cid%>.getSession().getHost() + ", Connection port: " + c_<%=cid%>.getSession().getPort() + "."); 
+				log.debug("<%=cid%> - Use an existing connection. Connection username: " + c_<%=cid%>.getSession().getUserName() + ", Connection hostname: " + c_<%=cid%>.getSession().getHost() + ", Connection port: " + c_<%=cid%>.getSession().getPort() + "."); 
 			}
 		<%}%>
 	    if(c_<%=cid%>.getHome()!=null && !c_<%=cid%>.getHome().equals(c_<%=cid%>.pwd())){
@@ -217,7 +217,7 @@ if (sftp) {// *** sftp *** //
   	}    
 
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Listing files from server.");
+		log.debug("<%=cid%> - Listing files from server.");
 	<%}%>
 	for (String sftpFile_<%=cid %> : fileListTemp_<%=cid %>) {
 
@@ -243,7 +243,7 @@ if (sftp) {// *** sftp *** //
 	    ftp_<%=cid %> = (com.enterprisedt.net.ftp.FTPClient)globalMap.get("<%=conn %>");
 		<%if(isLog4jEnabled){%>
 			if(ftp_<%=cid %>!=null) {
-				log.info("<%=cid%> - Use an existing connection. Connection hostname: " + ftp_<%=cid %>.getRemoteHost() + ", Connection port: " + ftp_<%=cid %>.getRemotePort() + "."); 
+				log.debug("<%=cid%> - Use an existing connection. Connection hostname: " + ftp_<%=cid %>.getRemoteHost() + ", Connection port: " + ftp_<%=cid %>.getRemotePort() + "."); 
 			}
 		<%}%>
 	  	<%if(!moveToCurrentDir){%>
@@ -263,7 +263,7 @@ if (sftp) {// *** sftp *** //
 	      ftp_<%=cid %>.setConnectMode(com.enterprisedt.net.ftp.FTPConnectMode.PASV);
 	    <%}%>
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" +<%=user %>+ "'.");
+			log.debug("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" +<%=user %>+ "'.");
 		<%}%>
 	    ftp_<%=cid %>.setControlEncoding(<%=encoding%>);
 	    ftp_<%=cid %>.connect();  
@@ -276,7 +276,7 @@ if (sftp) {// *** sftp *** //
 		
 	    ftp_<%=cid %>.login(<%=user %>, decryptedPassword_<%=cid%>); 
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
+			log.debug("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
 		<%}%>  
 	<%}%>      
 	String remotedir_<%=cid %> = <%=remotedir%>;
@@ -311,7 +311,7 @@ if (sftp) {// *** sftp *** //
 	int i_<%=cid %> = -1;
 
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Listing files from server.");
+		log.debug("<%=cid%> - Listing files from server.");
 	<%}%> 
 	while (++i_<%=cid %> < fileListTemp_<%=cid %>.size()) {
 	    String currentFileName_<%=cid%> = fileListTemp_<%=cid %>.get(i_<%=cid %>); 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPFileList/tFTPFileList_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPFileList/tFTPFileList_end.javajet
@@ -32,11 +32,11 @@ if (("true").equals(useExistingConn)) {
 if (sftp && !("true").equals(useExistingConn)) {// *** sftp *** //
 %>
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Closing the connection to the server.");
+		log.debug("<%=cid%> - Closing the connection to the server.");
 	<%}%>
 	session_<%=cid%>.disconnect(); 
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection to the server closed.");
+		log.debug("<%=cid%> - Connection to the server closed.");
 	<%}%>  
 <%
 } else {// *** ftp *** //
@@ -46,11 +46,11 @@ if (sftp && !("true").equals(useExistingConn)) {// *** sftp *** //
     %>
 			try {
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Closing the connection to the server.");
+					log.debug("<%=cid%> - Closing the connection to the server.");
 				<%}%>      
         		ftp_<%=cid %>.quit();
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Connection to the server closed.");
+					log.debug("<%=cid%> - Connection to the server closed.");
 				<%}%>
 			} catch (java.net.SocketException se_<%=cid%>) {
 	        //ignore failure
@@ -62,11 +62,11 @@ if (sftp && !("true").equals(useExistingConn)) {// *** sftp *** //
 		} else {
     %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Closing the connection to the server.");
+				log.debug("<%=cid%> - Closing the connection to the server.");
 			<%}%>    
 			ftp_<%=cid %>.quit();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Connection to the server closed.");
+				log.debug("<%=cid%> - Connection to the server closed.");
 			<%}%>
     <%
     	}
@@ -76,5 +76,5 @@ if (sftp && !("true").equals(useExistingConn)) {// *** sftp *** //
 globalMap.put("<%=cid %>_NB_FILE",nb_file_<%=cid%>);
 
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - Listed files count: " + nb_file_<%=cid%>  + ".");
+	log.debug("<%=cid%> - Listed files count: " + nb_file_<%=cid%>  + ".");
 <%}%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPFileProperties/tFTPFileProperties_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPFileProperties/tFTPFileProperties_begin.javajet
@@ -140,7 +140,7 @@ if (sftp) {  // *** sftp *** //
 
 	    <%if (("PUBLICKEY").equals(authMethod)) {%>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - SFTP authentication using a public key.");
+				log.debug("<%=cid%> - SFTP authentication using a public key.");
 				log.debug("<%=cid%> - Private key: '" + <%=privateKey%> + "'.");
 	  		<%}%>
 	      jsch_<%=cid%>.addIdentity(<%=privateKey %>, defaultUserInfo_<%=cid%>.getPassphrase());
@@ -151,7 +151,7 @@ if (sftp) {  // *** sftp *** //
 
 	    <%if (("PASSWORD").equals(authMethod)) {%> 
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - SFTP authentication using a password.");
+				log.debug("<%=cid%> - SFTP authentication using a password.");
 			<%}%>
 			
         	<%
@@ -173,13 +173,13 @@ if (sftp) {  // *** sftp *** //
 	  	}
 		<%}%>
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" + <%=user%> + "'.");
+			log.debug("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" + <%=user%> + "'.");
 		<%}%>
 	    session_<%=cid%>.connect();
 	    com.jcraft.jsch. Channel channel_<%=cid%>=session_<%=cid%>.openChannel("sftp");
 	    channel_<%=cid%>.connect();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
+			log.debug("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
 		<%}%>
 	    com.jcraft.jsch.ChannelSftp c_<%=cid%>=(com.jcraft.jsch.ChannelSftp)channel_<%=cid%>;
 	    
@@ -191,7 +191,7 @@ if (sftp) {  // *** sftp *** //
 		com.jcraft.jsch.ChannelSftp c_<%=cid%> = (com.jcraft.jsch.ChannelSftp)globalMap.get("<%=conn %>");
 		<%if(isLog4jEnabled){%>
 			if(c_<%=cid%>!=null && c_<%=cid%>.getSession()!=null) {
-				log.info("<%=cid%> - Use an existing connection. Connection username: " + c_<%=cid%>.getSession().getUserName() + ", Connection hostname: " + c_<%=cid%>.getSession().getHost() + ", Connection port: " + c_<%=cid%>.getSession().getPort() + "."); 
+				log.debug("<%=cid%> - Use an existing connection. Connection username: " + c_<%=cid%>.getSession().getUserName() + ", Connection hostname: " + c_<%=cid%>.getSession().getHost() + ", Connection port: " + c_<%=cid%>.getSession().getPort() + "."); 
 			}
 		<%}%>
 		if(c_<%=cid%>.getHome()!=null && !c_<%=cid%>.getHome().equals(c_<%=cid%>.pwd())){
@@ -223,7 +223,7 @@ if (sftp) {  // *** sftp *** //
 	      }
 	      <%=outputConnName %>.md5 =String.format("%032x", new java.math.BigInteger(1, dgs_<%=cid %>.digest()));
 	      <%if(isLog4jEnabled){%>
-				log.info("<%= cid %> - md5 message is : '"+ <%=outputConnName %>.md5 + "'."); 
+				log.debug("<%= cid %> - md5 message is : '"+ <%=outputConnName %>.md5 + "'."); 
 		  <%}%>
 	      is_<%=cid %>.close();
 		<%}%>
@@ -237,7 +237,7 @@ if (sftp) {  // *** sftp *** //
 		ftp_<%=cid %> = (com.enterprisedt.net.ftp.FTPClient)globalMap.get("<%=conn %>");
 		<%if(isLog4jEnabled){%>
 			if(ftp_<%=cid %>!=null) {
-				log.info("<%=cid%> - Use an existing connection. Connection hostname: " + ftp_<%=cid %>.getRemoteHost() + ", Connection port: " + ftp_<%=cid %>.getRemotePort() + "."); 
+				log.debug("<%=cid%> - Use an existing connection. Connection hostname: " + ftp_<%=cid %>.getRemoteHost() + ", Connection port: " + ftp_<%=cid %>.getRemotePort() + "."); 
 			}
 		<%}%>
 	<%} else {%>
@@ -255,7 +255,7 @@ if (sftp) {  // *** sftp *** //
 	    <%}%>
 		ftp_<%=cid %>.setControlEncoding(<%=encoding%>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" +<%=user %>+ "'.");
+			log.debug("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" +<%=user %>+ "'.");
 		<%}%>
 	    ftp_<%=cid %>.connect();
 	    
@@ -267,7 +267,7 @@ if (sftp) {  // *** sftp *** //
     		
 	    ftp_<%=cid %>.login(<%=username %>, decryptedPassword_<%=cid%>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
+			log.debug("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
 		<%}%>  
 	<%}%>
 	<%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPFileProperties/tFTPFileProperties_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPFileProperties/tFTPFileProperties_end.javajet
@@ -51,11 +51,11 @@ if (bUseExistingConn) {
 if (sftp && !bUseExistingConn) { // *** sftp *** //
 %>
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Closing the connection to the server.");
+		log.debug("<%=cid%> - Closing the connection to the server.");
 	<%}%>
 	session_<%=cid%>.disconnect(); 
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection to the server closed.");
+		log.debug("<%=cid%> - Connection to the server closed.");
 	<%}%>  
 <%
 } else {// *** ftp *** //
@@ -64,11 +64,11 @@ if (sftp && !bUseExistingConn) { // *** sftp *** //
     %>
 			try {
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Closing the connection to the server.");
+					log.debug("<%=cid%> - Closing the connection to the server.");
 				<%}%>
     		    ftp_<%=cid %>.quit();
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Connection to the server closed.");
+					log.debug("<%=cid%> - Connection to the server closed.");
 				<%}%>  
 			} catch (java.net.SocketException se_<%=cid%>) {
 				<%if(isLog4jEnabled){%>
@@ -78,11 +78,11 @@ if (sftp && !bUseExistingConn) { // *** sftp *** //
 			}
 		<%} else {%>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Closing the connection to the server.");
+				log.debug("<%=cid%> - Closing the connection to the server.");
 			<%}%>
 			ftp_<%=cid %>.quit();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Connection to the server closed.");
+				log.debug("<%=cid%> - Connection to the server closed.");
 			<%}%>  
     <%
 		}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPGet/tFTPGet_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPGet/tFTPGet_begin.javajet
@@ -261,7 +261,7 @@ if (sftp) { // *** sftp *** //
 				com.jcraft.jsch.ChannelSftp c_<%=cid%> = (com.jcraft.jsch.ChannelSftp)globalMap.get("<%=conn %>");
 				<%if(isLog4jEnabled){%>
 					if(c_<%=cid%>!=null && c_<%=cid%>.getSession()!=null) {
-						log.info("<%=cid%> - Use an existing connection.Connection username: " + c_<%=cid%>.getSession().getUserName() + ", Connection hostname: " + c_<%=cid%>.getSession().getHost() + ", Connection port: " + c_<%=cid%>.getSession().getPort() + "."); 
+						log.debug("<%=cid%> - Use an existing connection.Connection username: " + c_<%=cid%>.getSession().getUserName() + ", Connection hostname: " + c_<%=cid%>.getSession().getHost() + ", Connection port: " + c_<%=cid%>.getSession().getPort() + "."); 
 					}
 				<%}%>
 				if(c_<%=cid%>.getHome()!=null && !c_<%=cid%>.getHome().equals(c_<%=cid%>.pwd())){
@@ -274,7 +274,7 @@ if (sftp) { // *** sftp *** //
 
 				<%if ("PUBLICKEY".equals(authMethod)){%>
 					<%if(isLog4jEnabled){%>
-						log.info("<%=cid%> - SFTP authentication using a public key.");
+						log.debug("<%=cid%> - SFTP authentication using a public key.");
 						log.debug("<%=cid%> - Private key: '" + <%=privateKey%> + "'.");
 					  <%}%>
     				jsch_<%=cid%>.addIdentity(<%=privateKey %>, defaultUserInfo_<%=cid%>.getPassphrase());
@@ -285,7 +285,7 @@ if (sftp) { // *** sftp *** //
 
 			    <%if("PASSWORD".equals(authMethod)){%>
 					<%if(isLog4jEnabled){%>
-						log.info("<%=cid%> - SFTP authentication using a password.");
+						log.debug("<%=cid%> - SFTP authentication using a password.");
 					<%}%>
 					
         			<%
@@ -308,13 +308,13 @@ if (sftp) { // *** sftp *** //
 				  	}
 				<%}%>
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username: '" + <%=user%> + "'.");
+					log.debug("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username: '" + <%=user%> + "'.");
 				<%}%>
 			    session_<%=cid%>.connect();
 			    com.jcraft.jsch. Channel channel_<%=cid%>=session_<%=cid%>.openChannel("sftp");
 			    channel_<%=cid%>.connect();
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
+					log.debug("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
 				<%}%>
 			    com.jcraft.jsch.ChannelSftp c_<%=cid%>=(com.jcraft.jsch.ChannelSftp)channel_<%=cid%>;
 			    
@@ -477,7 +477,7 @@ if (sftp) { // *** sftp *** //
             			globalMap.put("<%=cid %>_CURRENT_STATUS", "File transfer OK.");
 					} else { 
                         <%if(isLog4jEnabled){%>
-                               log.info("<%= cid %> - file ["+ remoteFileName +"] exit transmission.");
+                               log.debug("<%= cid %> - file ["+ remoteFileName +"] exit transmission.");
                         <%}%>
 						msg_<%=cid%>.add("file ["+ remoteFileName +"] exit transmission.");
 			            globalMap.put("<%=cid %>_CURRENT_STATUS", "No file transfered.");
@@ -512,7 +512,7 @@ if (sftp) { // *** sftp *** //
 							globalMap.put("<%=cid %>_CURRENT_STATUS", "File transfer OK.");
 			            } else {
 			                 <%if(isLog4jEnabled){%>
-                                    log.info("<%= cid %> - file ["+ remoteFileName +"] exit transmission.");
+                                    log.debug("<%= cid %> - file ["+ remoteFileName +"] exit transmission.");
                              <%}%>
             				msg_<%=cid%>.add("file ["+ remoteFileName +"] exit transmission.");
 							globalMap.put("<%=cid %>_CURRENT_STATUS", "No file transfered.");
@@ -551,7 +551,7 @@ if (sftp) { // *** sftp *** //
 	  	<%}%>
 		<%if(isLog4jEnabled){%>
 			if(ftp_<%=cid %>!=null) {
-				log.info("<%=cid%> - Uses an existing connection. Connection hostname: " + ftp_<%=cid %>.getRemoteHost() + ", Connection port: " + ftp_<%=cid %>.getRemotePort() + "."); 
+				log.debug("<%=cid%> - Uses an existing connection. Connection hostname: " + ftp_<%=cid %>.getRemoteHost() + ", Connection port: " + ftp_<%=cid %>.getRemotePort() + "."); 
 			}
 		<%}%>
 	<%} else {%>    
@@ -574,7 +574,7 @@ if (sftp) { // *** sftp *** //
     %>
 	    ftp_<%=cid %>.setControlEncoding(<%=encoding%>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" +<%=user %>+ "'.");
+			log.debug("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" +<%=user %>+ "'.");
 		<%}%>
 	    ftp_<%=cid %>.connect();
 	    
@@ -586,7 +586,7 @@ if (sftp) { // *** sftp *** //
 	    
     	ftp_<%=cid %>.login(<%=user %>, decryptedPassword_<%=cid%>);  
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
+			log.debug("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
 		<%}%>  
 	<%} %>
 	msg_<%=cid%>.clearAll();
@@ -742,8 +742,8 @@ if (sftp) { // *** sftp *** //
 				}
 %>
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - FTPS security Mode is (<%=securityMode%>).");
-					log.info("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username: '" + <%=user %>+ "'.");
+					log.debug("<%=cid%> - FTPS security Mode is (<%=securityMode%>).");
+					log.debug("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username: '" + <%=user %>+ "'.");
 				<%}%>
 				ftp_<%=cid %>.connect(<%=host %>,<%=port %>);
 				
@@ -755,7 +755,7 @@ if (sftp) { // *** sftp *** //
             	
 				ftp_<%=cid %>.login(<%=user %>, decryptedPassword_<%=cid%>);
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
+					log.debug("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
 				<%}%>
     <%  
     		} else {
@@ -767,7 +767,7 @@ if (sftp) { // *** sftp *** //
 				<%}%>
 				<%if(isLog4jEnabled){%>
 					if(ftp_<%=cid %>!=null) {
-						log.info("<%=cid%> - Use an existing connection.Connection username: " + ftp_<%=cid %>.getUsername() + ", Connection hostname: " + ftp_<%=cid %>.getHost() + ", Connection port: " + ftp_<%=cid %>.getPort() + "."); 
+						log.debug("<%=cid%> - Use an existing connection.Connection username: " + ftp_<%=cid %>.getUsername() + ", Connection hostname: " + ftp_<%=cid %>.getHost() + ", Connection port: " + ftp_<%=cid %>.getPort() + "."); 
 					}
 				<%}%>
     <%  
@@ -834,6 +834,6 @@ if (!dirHandle_<%=cid %>.exists()) {
 String root_<%=cid %> = getter_<%=cid %>.pwd();
 
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - Downloading files from the server.");
+	log.debug("<%=cid%> - Downloading files from the server.");
 <%}%>
 for (String maskStr_<%=cid%> : maskList_<%=cid%>) { 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPGet/tFTPGet_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPGet/tFTPGet_end.javajet
@@ -46,11 +46,11 @@ nb_file_<%=cid%> = getter_<%=cid %>.count;
 
 	<%if (!("true").equals(useExistingConn)) {%>
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Closing the connection to the server.");
+			log.debug("<%=cid%> - Closing the connection to the server.");
 		<%}%>
 		session_<%=cid%>.disconnect(); 
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection to the server closed.");
+			log.debug("<%=cid%> - Connection to the server closed.");
 		<%}%>
 	<%}%>    
 <%} else if (!ftps) {%>
@@ -72,11 +72,11 @@ nb_file_<%=cid%> = getter_<%=cid %>.count;
     %>
 			try {
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Closing the connection to the server.");
+					log.debug("<%=cid%> - Closing the connection to the server.");
 				<%}%>
         		ftp_<%=cid %>.quit();
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Connection to the server closed.");
+					log.debug("<%=cid%> - Connection to the server closed.");
 				<%}%>
     		} catch(java.net.SocketException se_<%=cid%>) {
 				<%if(isLog4jEnabled){%>
@@ -88,11 +88,11 @@ nb_file_<%=cid%> = getter_<%=cid %>.count;
 		} else {
     %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Closing the connection to the server.");
+				log.debug("<%=cid%> - Closing the connection to the server.");
 			<%}%>
       		ftp_<%=cid %>.quit();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Connection to the server closed.");
+				log.debug("<%=cid%> - Connection to the server closed.");
 			<%}%>
     <%
 		}
@@ -108,11 +108,11 @@ nb_file_<%=cid%> = getter_<%=cid %>.count;
 	if (!("true").equals(useExistingConn)){
   %>
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Closing the connection to the server.");
+			log.debug("<%=cid%> - Closing the connection to the server.");
 		<%}%>
     	ftp_<%=cid%>.disconnect(true);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection to the server closed.");
+			log.debug("<%=cid%> - Connection to the server closed.");
 		<%}%>
   <%
   	}else{
@@ -126,6 +126,6 @@ nb_file_<%=cid%> = getter_<%=cid %>.count;
 %>
 	globalMap.put("<%=cid %>_NB_FILE",nb_file_<%=cid%>);
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - Downloaded files count: " + nb_file_<%=cid%>  + ".");
+	log.debug("<%=cid%> - Downloaded files count: " + nb_file_<%=cid%>  + ".");
 <%}%>
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPPut/tFTPPut_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPPut/tFTPPut_begin.javajet
@@ -94,7 +94,7 @@ int nb_file_<%=cid%> = 0;
     	com.jcraft.jsch.ChannelSftp c_<%=cid%> = (com.jcraft.jsch.ChannelSftp)globalMap.get("<%=conn %>");
 		<%if(isLog4jEnabled){%>
 			if(c_<%=cid%>!=null && c_<%=cid%>.getSession()!=null) {
-				log.info("<%=cid%> - Uses an existing connection. Connection username " + c_<%=cid%>.getSession().getUserName() + ", Connection hostname: " + c_<%=cid%>.getSession().getHost() + ", Connection port: " + c_<%=cid%>.getSession().getPort() + "."); 
+				log.debug("<%=cid%> - Uses an existing connection. Connection username " + c_<%=cid%>.getSession().getUserName() + ", Connection hostname: " + c_<%=cid%>.getSession().getHost() + ", Connection port: " + c_<%=cid%>.getSession().getPort() + "."); 
 			}
 		<%}%>
     	if(c_<%=cid%>.getHome()!=null && !c_<%=cid%>.getHome().equals(c_<%=cid%>.pwd())){
@@ -138,7 +138,7 @@ int nb_file_<%=cid%> = 0;
 
 		<%if (("PUBLICKEY").equals(authMethod)) {%>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - SFTP authentication using a public key.");
+				log.debug("<%=cid%> - SFTP authentication using a public key.");
 				log.debug("<%=cid%> - Private key: '" + <%=privateKey%> + "'.");
 	 		 <%}%>
       		jsch_<%=cid%>.addIdentity(<%=privateKey %>, defaultUserInfo_<%=cid%>.getPassphrase());
@@ -149,7 +149,7 @@ int nb_file_<%=cid%> = 0;
 
 		<%if (("PASSWORD").equals(authMethod)) {%>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - SFTP authentication using a password.");
+				log.debug("<%=cid%> - SFTP authentication using a password.");
 			<%}%>
 			
         	<%
@@ -171,13 +171,13 @@ int nb_file_<%=cid%> = 0;
 		}
 		<%}%>
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" + <%=user%> + "'.");
+			log.debug("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" + <%=user%> + "'.");
 		<%}%>
     	session_<%=cid%>.connect();
     	com.jcraft.jsch. Channel channel_<%=cid%>=session_<%=cid%>.openChannel("sftp");
     	channel_<%=cid%>.connect();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connect to '" + <%=host %> + " has succeeded." );
+			log.debug("<%=cid%> - Connect to '" + <%=host %> + " has succeeded." );
 		<%}%>
     	com.jcraft.jsch.ChannelSftp c_<%=cid%>=(com.jcraft.jsch.ChannelSftp)channel_<%=cid%>;
     	
@@ -203,7 +203,7 @@ int nb_file_<%=cid%> = 0;
   %>  
 	String localdir<%=cid %> = <%=localdir%>;
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Putting file to the server.");
+		log.debug("<%=cid%> - Putting file to the server.");
 	<%}%>
 	for (java.util.Map<String, String> map<%=cid %> : list<%=cid %>) {
 
@@ -220,7 +220,7 @@ int nb_file_<%=cid%> = 0;
 	  		<%}%>
 			<%if(isLog4jEnabled){%>
 				if(ftp_<%=cid %>!=null) {
-					log.info("<%=cid%> - Uses an existing connection. Connection hostname: " + ftp_<%=cid %>.getRemoteHost() + ", Connection port: " + ftp_<%=cid %>.getRemotePort() + "."); 
+					log.debug("<%=cid%> - Uses an existing connection. Connection hostname: " + ftp_<%=cid %>.getRemoteHost() + ", Connection port: " + ftp_<%=cid %>.getRemotePort() + "."); 
 				}
 			<%}%>
   		<%} else {%>
@@ -239,7 +239,7 @@ int nb_file_<%=cid%> = 0;
 		    <%}%>
     		ftp_<%=cid %>.setControlEncoding(<%=encoding%>);
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" +<%=user %>+ "'.");
+				log.debug("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" +<%=user %>+ "'.");
 			<%}%>
 		    ftp_<%=cid %>.connect();  
 		    
@@ -251,7 +251,7 @@ int nb_file_<%=cid%> = 0;
 		    
 		    ftp_<%=cid %>.login(<%=user %>, decryptedPassword_<%=cid%>);
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Connect to '" + <%=host %> +  "' has succeeded.");
+				log.debug("<%=cid%> - Connect to '" + <%=host %> +  "' has succeeded.");
 			<%}%> 
 		<%}%>  
 
@@ -281,7 +281,7 @@ int nb_file_<%=cid%> = 0;
 		String localdir<%=cid %>  = <%=localdir%>;
 
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Uploading files to the server.");
+			log.debug("<%=cid%> - Uploading files to the server.");
 		<%}%>
 		for (java.util.Map<String, String> map<%=cid %> : list<%=cid %>) {
 <%
@@ -347,12 +347,12 @@ int nb_file_<%=cid%> = 0;
 					    } 
 					%>  
 				  	<%if(isLog4jEnabled){%>
-						log.info("<%=cid%> - FTPS security Mode is (<%=securityMode%>).");
-						log.info("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" + <%=user %>+ "'.");
+						log.debug("<%=cid%> - FTPS security Mode is (<%=securityMode%>).");
+						log.debug("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" + <%=user %>+ "'.");
 					<%}%>
 	                ftp_<%=cid %>.connect(<%=host %>,<%=port %>); 
 					<%if(isLog4jEnabled){%>
-						log.info("<%=cid%> - Connect to '" + <%=host %> +  "' has succeeded.");
+						log.debug("<%=cid%> - Connect to '" + <%=host %> +  "' has succeeded.");
 					<%}%> 
 					
 			        <%
@@ -369,7 +369,7 @@ int nb_file_<%=cid%> = 0;
                 ftp_<%=cid %> = (it.sauronsoftware.ftp4j.FTPClient)globalMap.get("<%=conn %>"); 
 				<%if(isLog4jEnabled){%>
 					if(ftp_<%=cid %>!=null) {
-						log.info("<%=cid%> - Uses an existing connection. Connection hostname: " + ftp_<%=cid %>.getHost() + ", Connection port: " + ftp_<%=cid %>.getPort() + "."); 
+						log.debug("<%=cid%> - Uses an existing connection. Connection hostname: " + ftp_<%=cid %>.getHost() + ", Connection port: " + ftp_<%=cid %>.getPort() + "."); 
 					}
 				<%}%>
 <%       
@@ -413,7 +413,7 @@ int nb_file_<%=cid%> = 0;
   			%>  
 			String localdir<%=cid %> = <%=localdir%>;
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Uploading files to the server.");
+				log.debug("<%=cid%> - Uploading files to the server.");
 			<%}%>
 	     	for (java.util.Map<String, String> map<%=cid %> : list<%=cid %>) {
 <%}%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPPut/tFTPPut_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPPut/tFTPPut_end.javajet
@@ -37,11 +37,11 @@ if(sftp){ // *** sftp *** //
 	if(!("true").equals(useExistingConn)){
 %>
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Closing the connection to the server.");
+			log.debug("<%=cid%> - Closing the connection to the server.");
 		<%}%>
     	session_<%=cid%>.disconnect(); 
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection to the server closed.");
+			log.debug("<%=cid%> - Connection to the server closed.");
 		<%}%>
 <%
 	}
@@ -74,11 +74,11 @@ if(sftp){ // *** sftp *** //
 %>
 				try{
 					<%if(isLog4jEnabled){%>
-						log.info("<%=cid%> - Closing the connection to the server.");
+						log.debug("<%=cid%> - Closing the connection to the server.");
 					<%}%>
 					ftp_<%=cid %>.quit();
 					<%if(isLog4jEnabled){%>
-						log.info("<%=cid%> - Connection to the server closed.");
+						log.debug("<%=cid%> - Connection to the server closed.");
 					<%}%>
 				}catch(java.net.SocketException se_<%=cid%>){
 					<%if(isLog4jEnabled){%>
@@ -90,11 +90,11 @@ if(sftp){ // *** sftp *** //
 			}else{
 %>
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Closing the connection to the server.");
+					log.debug("<%=cid%> - Closing the connection to the server.");
 				<%}%>
 				ftp_<%=cid %>.quit();
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Connection to the server closed.");
+					log.debug("<%=cid%> - Connection to the server closed.");
 				<%}%>
 <%
 			}
@@ -112,11 +112,11 @@ if(sftp){ // *** sftp *** //
     if(!("true").equals(useExistingConn)){ 
 %> 
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Closing the connection to the server.");
+			log.debug("<%=cid%> - Closing the connection to the server.");
 		<%}%>
         ftp_<%=cid%>.disconnect(true); 
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection to the server closed.");
+			log.debug("<%=cid%> - Connection to the server closed.");
 		<%}%>
 <% 
   	}else{
@@ -132,6 +132,6 @@ if(sftp){ // *** sftp *** //
 	
 globalMap.put("<%=cid %>_NB_FILE",nb_file_<%=cid%>);
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - Uploaded files count: " + nb_file_<%=cid%> +  ".");
+	log.debug("<%=cid%> - Uploaded files count: " + nb_file_<%=cid%> +  ".");
 <%}%>
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPRename/tFTPRename_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPRename/tFTPRename_begin.javajet
@@ -117,7 +117,7 @@ if (sftp) {  // *** sftp *** //
 
 		<%if (("PUBLICKEY").equals(authMethod)) {%>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - SFTP authentication using a public key.");
+				log.debug("<%=cid%> - SFTP authentication using a public key.");
 				log.debug("<%=cid%> - Private key: '" + <%=privateKey%> + "'.");
 	  		<%}%>
 			jsch_<%=cid%>.addIdentity(<%=privateKey %>, defaultUserInfo_<%=cid%>.getPassphrase());
@@ -128,7 +128,7 @@ if (sftp) {  // *** sftp *** //
 
     	<%if (("PASSWORD").equals(authMethod)) {%> 
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - SFTP authentication using a password.");
+				log.debug("<%=cid%> - SFTP authentication using a password.");
 			<%}%>
 			
 			<%
@@ -151,13 +151,13 @@ if (sftp) {  // *** sftp *** //
 				}
 		<%}%>
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" + <%=user%> + "'.");
+			log.debug("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" + <%=user%> + "'.");
 		<%}%>
 		session_<%=cid%>.connect();
 		com.jcraft.jsch. Channel channel_<%=cid%>=session_<%=cid%>.openChannel("sftp");
 		channel_<%=cid%>.connect();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
+			log.debug("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
 		<%}%>
     	com.jcraft.jsch.ChannelSftp c_<%=cid%>=(com.jcraft.jsch.ChannelSftp)channel_<%=cid%>;
     	
@@ -171,7 +171,7 @@ if (sftp) {  // *** sftp *** //
 	    com.jcraft.jsch.ChannelSftp c_<%=cid%> = (com.jcraft.jsch.ChannelSftp)globalMap.get("<%=conn %>");
 		<%if(isLog4jEnabled){%>
 			if(c_<%=cid%>!=null && c_<%=cid%>.getSession()!=null) {
-				log.info("<%=cid%> - Use an existing connection.Connection username: " + c_<%=cid%>.getSession().getUserName() + ", Connection hostname: " + c_<%=cid%>.getSession().getHost() + ", Connection port: " + c_<%=cid%>.getSession().getPort() + "."); 
+				log.debug("<%=cid%> - Use an existing connection.Connection username: " + c_<%=cid%>.getSession().getUserName() + ", Connection hostname: " + c_<%=cid%>.getSession().getHost() + ", Connection port: " + c_<%=cid%>.getSession().getPort() + "."); 
 			}
 		<%}%>
 	    if(c_<%=cid%>.getHome()!=null && !c_<%=cid%>.getHome().equals(c_<%=cid%>.pwd())){
@@ -194,7 +194,7 @@ if (sftp) {  // *** sftp *** //
 %>
 
     <%if(isLog4jEnabled){%>
-    	log.info("<%=cid%> - Renaming file from server.");
+    	log.debug("<%=cid%> - Renaming file from server.");
     <%}%>
 	for (java.util.Map<String, String> map<%=cid %> : list<%=cid %>) {
 
@@ -207,7 +207,7 @@ if (sftp) {  // *** sftp *** //
     	ftp_<%=cid %> = (com.enterprisedt.net.ftp.FTPClient)globalMap.get("<%=conn %>");
 		<%if(isLog4jEnabled){%>
 			if(ftp_<%=cid %>!=null) {
-				log.info("<%=cid%> - Use an existing connection. Connection hostname: " + ftp_<%=cid %>.getRemoteHost() + ", Connection port: " + ftp_<%=cid %>.getRemotePort() + "."); 
+				log.debug("<%=cid%> - Use an existing connection. Connection hostname: " + ftp_<%=cid %>.getRemoteHost() + ", Connection port: " + ftp_<%=cid %>.getRemotePort() + "."); 
 			}
 		<%}%>
 	  	<%if(!moveToCurrentDir){%>
@@ -228,7 +228,7 @@ if (sftp) {  // *** sftp *** //
 		<%}%>
 		ftp_<%=cid %>.setControlEncoding(<%=encoding%>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" +<%=user %>+ "'.");
+			log.debug("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" +<%=user %>+ "'.");
 		<%}%>
 		ftp_<%=cid %>.connect();  
 		
@@ -240,7 +240,7 @@ if (sftp) {  // *** sftp *** //
 			
 		ftp_<%=cid %>.login(<%=user %>, decryptedPassword_<%=cid%>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
+			log.debug("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
 		<%}%>   
 	<%}%>
 	java.util.List<java.util.Map<String,String>> list<%=cid %> = new java.util.ArrayList<java.util.Map<String,String>>();
@@ -259,7 +259,7 @@ if (sftp) {  // *** sftp *** //
 	ftp_<%=cid %>.chdir(remotedir<%=cid %>);
 
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Renaming file from server.");
+		log.debug("<%=cid%> - Renaming file from server.");
 	<%}%>
 	for (java.util.Map<String, String> map<%=cid %> : list<%=cid %>) { 
 <%}%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPRename/tFTPRename_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPRename/tFTPRename_end.javajet
@@ -33,11 +33,11 @@
 		if(!("true").equals(useExistingConn)){
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Closing the connection to the server.");
+				log.debug("<%=cid%> - Closing the connection to the server.");
 			<%}%>
     		session_<%=cid%>.disconnect(); 
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Connection to the server closed.");
+				log.debug("<%=cid%> - Connection to the server closed.");
 			<%}%>  
 <%
 		}
@@ -50,11 +50,11 @@
 %>
 				try{
 					<%if(isLog4jEnabled){%>
-						log.info("<%=cid%> - Closing the connection to the server.");
+						log.debug("<%=cid%> - Closing the connection to the server.");
 					<%}%>
 					ftp_<%=cid %>.quit();
 					<%if(isLog4jEnabled){%>
-						log.info("<%=cid%> - Connection to the server closed.");
+						log.debug("<%=cid%> - Connection to the server closed.");
 					<%}%>  
 				}catch(java.net.SocketException se_<%=cid%>){
 					<%if(isLog4jEnabled){%>
@@ -66,11 +66,11 @@
 			}else{
 %>
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Closing the connection to the server.");
+					log.debug("<%=cid%> - Closing the connection to the server.");
 				<%}%>
 				ftp_<%=cid %>.quit();
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Connection to the server closed.");
+					log.debug("<%=cid%> - Connection to the server closed.");
 				<%}%>  
 <%
 			}
@@ -87,5 +87,5 @@
 globalMap.put("<%=cid %>_NB_FILE",nb_file_<%=cid%>);
 
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - Renamed files count: " + nb_file_<%=cid%>  + ".");
+	log.debug("<%=cid%> - Renamed files count: " + nb_file_<%=cid%>  + ".");
 <%}%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPTruncate/tFTPTruncate_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPTruncate/tFTPTruncate_begin.javajet
@@ -118,7 +118,7 @@ if (sftp) {// *** sftp *** //
 
 		<%if (("PUBLICKEY").equals(authMethod)) {%>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - SFTP authentication using a public key.");
+				log.debug("<%=cid%> - SFTP authentication using a public key.");
 				log.debug("<%=cid%> - Private key: '" + <%=privateKey%> + "'.");
 			<%}%>
 			jsch_<%=cid%>.addIdentity(<%=privateKey %>, defaultUserInfo_<%=cid%>.getPassphrase());
@@ -129,7 +129,7 @@ if (sftp) {// *** sftp *** //
 
 		<%if (("PASSWORD").equals(authMethod)) {%> 
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - SFTP authentication using a password.");
+				log.debug("<%=cid%> - SFTP authentication using a password.");
 			<%}%>
 			
 			<%
@@ -151,13 +151,13 @@ if (sftp) {// *** sftp *** //
 			}
 		<%}%>
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" + <%=user%> + "'.");
+			log.debug("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" + <%=user%> + "'.");
 		<%}%>
 	    session_<%=cid%>.connect();
 	    com.jcraft.jsch. Channel channel_<%=cid%>=session_<%=cid%>.openChannel("sftp");
 	    channel_<%=cid%>.connect();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
+			log.debug("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
 		<%}%>
 	    com.jcraft.jsch.ChannelSftp c_<%=cid%>=(com.jcraft.jsch.ChannelSftp)channel_<%=cid%>;
 	    
@@ -170,7 +170,7 @@ if (sftp) {// *** sftp *** //
 	    com.jcraft.jsch.ChannelSftp c_<%=cid%> = (com.jcraft.jsch.ChannelSftp)globalMap.get("<%=conn %>");
 		<%if(isLog4jEnabled){%>
 			if(c_<%=cid%>!=null && c_<%=cid%>.getSession()!=null) {
-				log.info("<%=cid%> - Use an existing connection.Connection username: " + c_<%=cid%>.getSession().getUserName() + ", Connection hostname: " + c_<%=cid%>.getSession().getHost() + ", Connection port: " + c_<%=cid%>.getSession().getPort() + "."); 
+				log.debug("<%=cid%> - Use an existing connection.Connection username: " + c_<%=cid%>.getSession().getUserName() + ", Connection hostname: " + c_<%=cid%>.getSession().getHost() + ", Connection port: " + c_<%=cid%>.getSession().getPort() + "."); 
 			}
 		<%}%>
 	    if(c_<%=cid%>.getHome()!=null && !c_<%=cid%>.getHome().equals(c_<%=cid%>.pwd())){
@@ -190,7 +190,7 @@ if (sftp) {// *** sftp *** //
 	<%}%>
 
     <%if(isLog4jEnabled){%>
-    	log.info("<%=cid%> - Truncating file from the server.");
+    	log.debug("<%=cid%> - Truncating file from the server.");
     <%}%>
 	for (java.util.Map<String, String> map<%=cid %> : list<%=cid %>) {
 
@@ -203,7 +203,7 @@ if (sftp) {// *** sftp *** //
 		ftp_<%=cid %> = (com.enterprisedt.net.ftp.FTPClient)globalMap.get("<%=conn %>");
 		<%if(isLog4jEnabled){%>
 			if(ftp_<%=cid %>!=null) {
-				log.info("<%=cid%> - Use an existing connection. Connection hostname: " + ftp_<%=cid %>.getRemoteHost() + ", Connection port: " + ftp_<%=cid %>.getRemotePort() + "."); 
+				log.debug("<%=cid%> - Use an existing connection. Connection hostname: " + ftp_<%=cid %>.getRemoteHost() + ", Connection port: " + ftp_<%=cid %>.getRemotePort() + "."); 
 			}
 		<%}%>
 		<%if(!moveToCurrentDir){%>
@@ -224,7 +224,7 @@ if (sftp) {// *** sftp *** //
 	    <%}%>
     	ftp_<%=cid %>.setControlEncoding(<%=encoding%>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" +<%=user %>+ "'.");
+			log.debug("<%=cid%> - Attempt to connect to '" + <%=host %> + "' with username '" +<%=user %>+ "'.");
 		<%}%>
 	    ftp_<%=cid %>.connect();
 	    
@@ -236,7 +236,7 @@ if (sftp) {// *** sftp *** //
 			
 	    ftp_<%=cid %>.login(<%=user %>, decryptedPassword_<%=cid%>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
+			log.debug("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
 		<%}%>   
   	<%}%> 
 	java.util.List<java.util.Map<String,String>> list<%=cid %> = new java.util.ArrayList<java.util.Map<String,String>>();
@@ -253,7 +253,7 @@ if (sftp) {// *** sftp *** //
 	String root<%=cid %> = ftp_<%=cid %>.pwd();
 
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Truncating file from the server.");
+		log.debug("<%=cid%> - Truncating file from the server.");
 	<%}%>
 	for (java.util.Map<String, String> map<%=cid %> : list<%=cid %>) {
 <%}%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPTruncate/tFTPTruncate_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPTruncate/tFTPTruncate_end.javajet
@@ -33,11 +33,11 @@
 		if(!("true").equals(useExistingConn)){
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Closing the connection to the server.");
+				log.debug("<%=cid%> - Closing the connection to the server.");
 			<%}%>
     		session_<%=cid%>.disconnect(); 
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Connection to the server closed.");
+				log.debug("<%=cid%> - Connection to the server closed.");
 			<%}%>  
 <%
 		}
@@ -52,11 +52,11 @@
 %>
 				try{
 					<%if(isLog4jEnabled){%>
-						log.info("<%=cid%> - Closing the connection to the server.");
+						log.debug("<%=cid%> - Closing the connection to the server.");
 					<%}%>
 					ftp_<%=cid %>.quit();
 					<%if(isLog4jEnabled){%>
-						log.info("<%=cid%> - Connection to the server closed.");
+						log.debug("<%=cid%> - Connection to the server closed.");
 					<%}%>  
 				}catch(java.net.SocketException se_<%=cid%>){
 					<%if(isLog4jEnabled){%>
@@ -68,11 +68,11 @@
 			}else{
 %>
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Closing the connection to the server.");
+					log.debug("<%=cid%> - Closing the connection to the server.");
 				<%}%>
 				ftp_<%=cid %>.quit();
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Connection to the server closed.");
+					log.debug("<%=cid%> - Connection to the server closed.");
 				<%}%>  
 <%
 			}
@@ -89,5 +89,5 @@
 globalMap.put("<%=cid %>_NB_FILE",nb_file_<%=cid%>);
 
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - Truncated files count: " + nb_file_<%=cid%>  + ".");
+	log.debug("<%=cid%> - Truncated files count: " + nb_file_<%=cid%>  + ".");
 <%}%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileCompare/tFileCompare_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileCompare/tFileCompare_main.javajet
@@ -112,7 +112,7 @@ if (print) {
 
 if(isLog4jEnabled) {
 %>
-	log.info("<%=cid%> - Compare result : " + message<%=cid %> + ".");
+	log.debug("<%=cid%> - Compare result : " + message<%=cid %> + ".");
 <%
 }
 
@@ -129,7 +129,7 @@ for (IConnection conn : node.getOutgoingConnections()) {
 <%
 		if(isLog4jEnabled) {
 %>
-			log.info("<%=cid%> - Compare date : " + routines.system.FormatterUtils.format_Date(<%=conn.getName() %>.moment,"dd-MM-yyyy HH:mm:ss") + ".");
+			log.debug("<%=cid%> - Compare date : " + routines.system.FormatterUtils.format_Date(<%=conn.getName() %>.moment,"dd-MM-yyyy HH:mm:ss") + ".");
 <%
 		}
 	}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileCopy/tFileCopy_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileCopy/tFileCopy_main.javajet
@@ -172,7 +172,7 @@
 				if(isLog4jEnabled) {
 %>
 				else {
-					log.info("<%=cid%> - The source file \"" + srcFileName_<%=cid %> + "\" is deleted.");
+					log.debug("<%=cid%> - The source file \"" + srcFileName_<%=cid %> + "\" is deleted.");
 				}
 <%
 				}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileDelete/tFileDelete_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileDelete/tFileDelete_main.javajet
@@ -71,7 +71,7 @@ if(either){
 <%
 				if(isLog4jEnabled) {
 %>
-				log.info("<%=cid%> - File : "+ path_<%=cid%>.getAbsolutePath() + " is deleted.");
+				log.debug("<%=cid%> - File : "+ path_<%=cid%>.getAbsolutePath() + " is deleted.");
 <%
 				}
 %>
@@ -80,7 +80,7 @@ if(either){
 <%
 				if(isLog4jEnabled) {
 %>
-				log.info("<%=cid%> - Fail to delete file : "+ path_<%=cid%>.getAbsolutePath());
+				log.debug("<%=cid%> - Fail to delete file : "+ path_<%=cid%>.getAbsolutePath());
 <%
 				}
 %>
@@ -92,7 +92,7 @@ if(either){
 <%
 				if(isLog4jEnabled) {
 %>
-				log.info("<%=cid%> - Directory : "+ path_<%=cid%>.getAbsolutePath() + " is deleted.");
+				log.debug("<%=cid%> - Directory : "+ path_<%=cid%>.getAbsolutePath() + " is deleted.");
 <%
 				}
 %>
@@ -101,7 +101,7 @@ if(either){
 <%
 				if(isLog4jEnabled) {
 %>
-				log.info("<%=cid%> - Fail to delete directory : "+ path_<%=cid%>.getAbsolutePath());
+				log.debug("<%=cid%> - Fail to delete directory : "+ path_<%=cid%>.getAbsolutePath());
 <%
 				}
 %>
@@ -135,7 +135,7 @@ if(either){
 <%
 			if(isLog4jEnabled) {
 %>
-    		log.info("<%=cid%> - Directory : "+ file<%=cid%>.getAbsolutePath() + " is deleted.");
+    		log.debug("<%=cid%> - Directory : "+ file<%=cid%>.getAbsolutePath() + " is deleted.");
 <%
 			}
 %>
@@ -144,7 +144,7 @@ if(either){
 <%
 			if(isLog4jEnabled) {
 %>
-    		log.info("<%=cid%> - Fail to delete directory : "+ file<%=cid%>.getAbsolutePath());
+    		log.debug("<%=cid%> - Fail to delete directory : "+ file<%=cid%>.getAbsolutePath());
 <%
 			}
 %>
@@ -174,7 +174,7 @@ if(either){
 <%
 			if(isLog4jEnabled) {
 %>
-    		log.info("<%=cid%> - File : "+ file_<%=cid%>.getAbsolutePath() + " is deleted.");
+    		log.debug("<%=cid%> - File : "+ file_<%=cid%>.getAbsolutePath() + " is deleted.");
 <%
 			}
 %>
@@ -183,7 +183,7 @@ if(either){
 <%
 			if(isLog4jEnabled) {
 %>
-    		log.info("<%=cid%> - Fail to delete file : "+ file_<%=cid%>.getAbsolutePath());
+    		log.debug("<%=cid%> - Fail to delete file : "+ file_<%=cid%>.getAbsolutePath());
 <%
 			}
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileExist/tFileExist_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileExist/tFileExist_main.javajet
@@ -24,12 +24,12 @@ java.io.File file_<%=cid%> = new java.io.File(<%=fileName%>);
 if (!file_<%=cid%>.exists()) {
     globalMap.put("<%=cid %>_EXISTS",false);
     <%if(isLog4jEnabled) {%>
-    log.info("<%=cid%> - Directory or file : " + file_<%=cid%>.getAbsolutePath() + " doesn't exist.");
+    log.debug("<%=cid%> - Directory or file : " + file_<%=cid%>.getAbsolutePath() + " doesn't exist.");
     <%}%>
 }else{
 	globalMap.put("<%=cid %>_EXISTS",true);
     <%if(isLog4jEnabled) {%>
-    log.info("<%=cid%> - Directory or file : " + file_<%=cid%>.getAbsolutePath() + " exists.");
+    log.debug("<%=cid%> - Directory or file : " + file_<%=cid%>.getAbsolutePath() + " exists.");
     <%}%>
 }
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileFetch/tFileFetch_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileFetch/tFileFetch_main.javajet
@@ -134,11 +134,11 @@ if ("http".equals(protocol) || "https".equals(protocol)) {
 	<%}%>
 	org.apache.commons.httpclient.HttpClient client_<%=cid %> = new org.apache.commons.httpclient.HttpClient();
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection attempt to '" + <%=uri %>);
+		log.debug("<%=cid%> - Connection attempt to '" + <%=uri %>);
 	<%}%>
 	client_<%=cid %>.getHttpConnectionManager().getParams().setConnectionTimeout(<%=timeout %>);
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection to '" +  <%=uri %> + "' has succeeded.");
+		log.debug("<%=cid%> - Connection to '" +  <%=uri %> + "' has succeeded.");
 	<%}%>
 	client_<%=cid %>.getParams().setCookiePolicy(org.apache.commons.httpclient.cookie.CookiePolicy.<%=cookiePolicy %>);
 	<%if(singleCookie){%>
@@ -299,11 +299,11 @@ if ("http".equals(protocol) || "https".equals(protocol)) {
 						|| (status_<%=cid%> == org.apache.commons.httpclient.HttpStatus.SC_SEE_OTHER) 
 							|| (status_<%=cid%> == org.apache.commons.httpclient.HttpStatus.SC_TEMPORARY_REDIRECT)) {
 					<%if(isLog4jEnabled){%>
-						log.info("<%=cid%> - Closing the connection to the server.");
+						log.debug("<%=cid%> - Closing the connection to the server.");
 					<%}%>
 					method_<%=cid%>.releaseConnection();
 					<%if(isLog4jEnabled){%>
-						log.info("<%=cid%> - Connection to the server closed.");
+						log.debug("<%=cid%> - Connection to the server closed.");
 					<%}%>
 
 					if (method_<%=cid%>.getResponseHeader("location").getValue().startsWith("http")) {
@@ -432,11 +432,11 @@ if ("http".equals(protocol) || "https".equals(protocol)) {
 			in_<%=cid %>.close();   
 			out_<%=cid %>.close(); 
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Closing the connection to the server.");
+				log.debug("<%=cid%> - Closing the connection to the server.");
 			<%}%>
 			method_<%=cid%>.releaseConnection();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Connection to the server closed.");
+				log.debug("<%=cid%> - Connection to the server closed.");
 			<%}%>   
 		<%}%>    
 	} // B_01
@@ -468,11 +468,11 @@ if ("http".equals(protocol) || "https".equals(protocol)) {
 	//open url stream
 	java.net.URL url_<%=cid %> = new java.net.URL(<%=uri %>);    
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection attempt to '" + <%=uri %>);
+		log.debug("<%=cid%> - Connection attempt to '" + <%=uri %>);
 	<%}%>
 	java.net.URLConnection conn_<%=cid %> = url_<%=cid %>.openConnection();
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection to '" +  <%=uri %> + "' has succeeded.");
+		log.debug("<%=cid%> - Connection to '" +  <%=uri %> + "' has succeeded.");
 	<%}%>
 
 	<%if (bUseCache) {%>
@@ -504,11 +504,11 @@ if ("http".equals(protocol) || "https".equals(protocol)) {
 		try {
 			java.io.File testfile_<%=cid%> = new java.io.File(dir_<%=cid %>, fileName_<%=cid %>);
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Creating directory '" + testfile_<%=cid%>.getParentFile().getCanonicalPath());
+				log.debug("<%=cid%> - Creating directory '" + testfile_<%=cid%>.getParentFile().getCanonicalPath());
 			<%}%>
 			testfile_<%=cid%>.getParentFile().mkdirs();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Create directory '" + testfile_<%=cid%>.getParentFile().getCanonicalPath()+ "' has succeeded.");
+				log.debug("<%=cid%> - Create directory '" + testfile_<%=cid%>.getParentFile().getCanonicalPath()+ "' has succeeded.");
 			<%}%>
 
 			if (testfile_<%=cid%>.createNewFile()) {

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileInputDelimited/tFileInputDelimited_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileInputDelimited/tFileInputDelimited_begin.javajet
@@ -508,7 +508,7 @@
 					}
 					%>
 				    <%if(isLog4jEnabled){%>
-				    	log.info("<%=cid%> - Retrieving records from the datasource.");
+				    	log.debug("<%=cid%> - Retrieving records from the datasource.");
 				    <%}%>
 					while (fid_<%=cid %>!=null && fid_<%=cid %>.nextRecord()) {
 						rowstate_<%=cid%>.reset();
@@ -1220,7 +1220,7 @@
 	    		}//TD110 end
 	        
 			    <%if(isLog4jEnabled){%>
-			    	log.info("<%=cid%> - Retrieving records from the datasource.");
+			    	log.debug("<%=cid%> - Retrieving records from the datasource.");
 			    <%}%>
 	        	while ( limit<%=cid%> != 0 && csvReader<%=cid %>!=null && csvReader<%=cid %>.readNext() ) { 
 	        		rowstate_<%=cid%>.reset();

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileInputDelimited/tFileInputDelimited_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileInputDelimited/tFileInputDelimited_end.javajet
@@ -61,7 +61,7 @@
             	globalMap.put("<%=cid %>_NB_LINE", nb_line_<%=cid%>);
             }
 					<%if(isLog4jEnabled){%>
-						log.info("<%=cid%>- Retrieved records count: "+ nb_line_<%=cid%> + ".");
+						log.debug("<%=cid%>- Retrieved records count: "+ nb_line_<%=cid%> + ".");
 					<%}%>
         }
 <%
@@ -78,7 +78,7 @@
                 if(fid_<%=cid %>!=null){
                 	globalMap.put("<%=cid %>_NB_LINE", fid_<%=cid %>.getRowNumber());
 					<%if(isLog4jEnabled){%>
-						log.info("<%=cid%> - Retrieved records count: "+ fid_<%=cid %>.getRowNumber() + ".");
+						log.debug("<%=cid%> - Retrieved records count: "+ fid_<%=cid %>.getRowNumber() + ".");
 					<%}%>
                 }
 			}
@@ -115,7 +115,7 @@
     				globalMap.put("<%=cid %>_NB_LINE",nb_line_<%=cid %>);
     			}
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Retrieved records count: "+ nb_line_<%=cid %> + ".");
+					log.debug("<%=cid%> - Retrieved records count: "+ nb_line_<%=cid %> + ".");
 				<%}%>
 			}
 <%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileInputJSON/jsonpath.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileInputJSON/jsonpath.javajet
@@ -72,7 +72,7 @@ com.jayway.jsonpath.JsonPath compiledJsonPath_<%=cid%> = null;
 
 Object value_<%=cid%> = null;
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - Retrieving records from data.");
+	log.debug("<%=cid%> - Retrieving records from data.");
 <%}%>
 for(Object row_<%=cid%> : resultset_<%=cid%>) {
 	nb_line_<%=cid%>++;

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileInputJSON/jsonpath_javascript_api.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileInputJSON/jsonpath_javascript_api.javajet
@@ -203,7 +203,7 @@ recordMaxSize_<%=cid%>=jsonUtil_<%=cid%>.getData(<%=query%>,invocableEngine_<%=c
 	}
 }
     <%if(isLog4jEnabled){%>
-    	log.info("<%=cid%> - Retrieving records from data.");
+    	log.debug("<%=cid%> - Retrieving records from data.");
     <%}%>
 	for(int nbResultArray_<%=cid%> = 0; nbResultArray_<%=cid%> < recordMaxSize_<%=cid%>; nbResultArray_<%=cid%>++){
 	

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileInputMail/tFileInputMail_MIME.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileInputMail/tFileInputMail_MIME.javajet
@@ -206,7 +206,7 @@
 						}
 	                    path<%=cid%> = path<%=cid%> + attachfileName<%=cid%>;
 	                    <% if(isLog4jEnabled){ %>
-		                    	log.info("<%= cid %> - Extracted attachment: '"+attachfileName<%=cid%>+"'.");
+		                    	log.debug("<%= cid %> - Extracted attachment: '"+attachfileName<%=cid%>+"'.");
 	                    <% } %>
 	                    java.io.File attachFile  = new java.io.File(path<%=cid%>);
 	                    out<%=cid%> = new java.io.BufferedOutputStream(new java.io.FileOutputStream(attachFile));

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileList/tFileList_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileList/tFileList_begin.javajet
@@ -401,7 +401,7 @@
     %>
     
     <%if(isLog4jEnabled) {%>
-		log.info("<%=cid%> - Start to list files");
+		log.debug("<%=cid%> - Start to list files");
 	<%}%>
     for (int i_<%=cid%> = 0; i_<%=cid%> < list_<%=cid%>.size(); i_<%=cid%>++){
       java.io.File files_<%=cid%> = list_<%=cid%>.get(i_<%=cid%>);
@@ -430,5 +430,5 @@
       globalMap.put("<%=cid%>_NB_FILE", NB_FILE<%=cid%>);
       
       <%if(isLog4jEnabled) {%>
-		log.info("<%=cid%> - Current file or directory path : " + currentFilePath_<%=cid%>);
+		log.debug("<%=cid%> - Current file or directory path : " + currentFilePath_<%=cid%>);
 	  <%}%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileList/tFileList_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileList/tFileList_end.javajet
@@ -19,7 +19,7 @@
   globalMap.put("<%=cid%>_NB_FILE", NB_FILE<%=cid%>);
   
   <%if(isLog4jEnabled) {%>
-    log.info("<%=cid%> - File or directory count : " + NB_FILE<%=cid%>);
+    log.debug("<%=cid%> - File or directory count : " + NB_FILE<%=cid%>);
   <%}%>
 
   <%if (generateError){%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileOutputDelimited/tFileOutputDelimited_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileOutputDelimited/tFileOutputDelimited_begin.javajet
@@ -400,11 +400,11 @@ if(("false").equals(ElementParameterParser.getValue(node,"__CSV_OPTION__"))) {
                         java.io.File dir_<%=cid%> = new java.io.File(directory_<%=cid%>);
                         if(!dir_<%=cid%>.exists()) {
                             <%if(isLog4jEnabled){%>
-                                log.info("<%=cid%> - Creating directory '" + dir_<%=cid%>.getCanonicalPath() +"'.");
+                                log.debug("<%=cid%> - Creating directory '" + dir_<%=cid%>.getCanonicalPath() +"'.");
                             <%}%>
                             dir_<%=cid%>.mkdirs();
                             <%if(isLog4jEnabled){%>
-                                log.info("<%=cid%> - The directory '"+ dir_<%=cid%>.getCanonicalPath() + "' has been created successfully.");
+                                log.debug("<%=cid%> - The directory '"+ dir_<%=cid%>.getCanonicalPath() + "' has been created successfully.");
                             <%}%>
                         }
                     }
@@ -748,11 +748,11 @@ if(("false").equals(ElementParameterParser.getValue(node,"__CSV_OPTION__"))) {
                         java.io.File dir_<%=cid%> = new java.io.File(directory_<%=cid%>);
                         if(!dir_<%=cid%>.exists()) {
                             <%if(isLog4jEnabled){%>
-                                log.info("<%=cid%> - Creating directory '" +dir_<%=cid%>.getCanonicalPath() +"'.");
+                                log.debug("<%=cid%> - Creating directory '" +dir_<%=cid%>.getCanonicalPath() +"'.");
                             <%}%>
                             dir_<%=cid%>.mkdirs();
                             <%if(isLog4jEnabled){%>
-                                log.info("<%=cid%> - The directory '" + dir_<%=cid%>.getCanonicalPath() + "' has been created successfully.");
+                                log.debug("<%=cid%> - The directory '" + dir_<%=cid%>.getCanonicalPath() + "' has been created successfully.");
                             <%}%>
                         }
                     }

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileOutputExcel/tFileOutputExcel_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileOutputExcel/tFileOutputExcel_begin.javajet
@@ -365,11 +365,11 @@ if ((metadatas!=null)&&(metadatas.size()>0)) {
           java.io.File parentFile_<%=cid %> = file_<%=cid %>.getParentFile();
           if (parentFile_<%=cid %> != null && !parentFile_<%=cid %>.exists()) {
         	<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Creating directory '" +parentFile_<%=cid %>.getCanonicalPath() + "'.");
+				log.debug("<%=cid%> - Creating directory '" +parentFile_<%=cid %>.getCanonicalPath() + "'.");
 			<%}%>
              parentFile_<%=cid %>.mkdirs();
         	<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Create directory '"+parentFile_<%=cid %>.getCanonicalPath()+"' has succeeded.");
+				log.debug("<%=cid%> - Create directory '"+parentFile_<%=cid %>.getCanonicalPath()+"' has succeeded.");
 			<%}%>
           }
 <%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileOutputExcel/tFileOutputExcel_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileOutputExcel/tFileOutputExcel_end.javajet
@@ -160,11 +160,11 @@
 	%>
 		if(isFileGenerated_<%=cid %> && nb_line_<%=cid %> == 0){
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Creating directory '" + file_<%=cid %>.getCanonicalPath() + "'.");
+				log.debug("<%=cid%> - Creating directory '" + file_<%=cid %>.getCanonicalPath() + "'.");
 			<%}%>
 			file_<%=cid %>.delete();
 	    	<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Create directory '"+ file_<%=cid %>.getCanonicalPath() + "' has succeeded.");
+				log.debug("<%=cid%> - Create directory '"+ file_<%=cid %>.getCanonicalPath() + "' has succeeded.");
 			<%}%>
 		}		
 	<%}
@@ -293,11 +293,11 @@
 	%>
 		if(isFileGenerated_<%=cid %> && nb_line_<%=cid %> == 0){
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Creating directory '" + file_<%=cid %>.getCanonicalPath() + "'.");
+				log.debug("<%=cid%> - Creating directory '" + file_<%=cid %>.getCanonicalPath() + "'.");
 			<%}%>
 			file_<%=cid %>.delete();
 	    	<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Create directory '"+ file_<%=cid %>.getCanonicalPath() + "' has succeeded.");
+				log.debug("<%=cid%> - Create directory '"+ file_<%=cid %>.getCanonicalPath() + "' has succeeded.");
 			<%}%>
 		}		
 	<%}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileOutputXML/tFileOutputXML_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileOutputXML/tFileOutputXML_begin.javajet
@@ -131,11 +131,11 @@ imports="
 %>
 	//create directory only if not exists
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Creating directory '" + file_<%=cid %>.getParentFile() + "'.");
+		log.debug("<%=cid%> - Creating directory '" + file_<%=cid %>.getParentFile() + "'.");
 	<%}%>
 	file_<%=cid %>.getParentFile().mkdirs();
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Directory '" + file_<%=cid %>.getParentFile() + "' created successfully.");
+		log.debug("<%=cid%> - Directory '" + file_<%=cid %>.getParentFile() + "' created successfully.");
 	<%}%>
 <%
 			}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileProperties/tFileProperties_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileProperties/tFileProperties_begin.javajet
@@ -74,7 +74,7 @@ if(file_<%=cid %>.exists()) {
     if(isLog4jEnabled) {
 %>
 	else {
-		log.info("<%=cid%> - File : " + file_<%=cid %>.getAbsolutePath() + " doesn't exist.");
+		log.debug("<%=cid%> - File : " + file_<%=cid %>.getAbsolutePath() + " doesn't exist.");
 	}
 <%
     }

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileRowCount/tFileRowCount_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileRowCount/tFileRowCount_main.javajet
@@ -121,7 +121,7 @@ if ("true".equals(ElementParameterParser.getValue(node, "__IGNORE_EMPTY_ROW__"))
 <%
 if(isLog4jEnabled) {
 %>
-    log.info("<%=cid%> - File : " + <%=filename%> + " row count is " + lineCount_<%=cid %>);
+    log.debug("<%=cid%> - File : " + <%=filename%> + " row count is " + lineCount_<%=cid %>);
 <%
 }
 %> 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileTouch/tFileTouch_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileTouch/tFileTouch_main.javajet
@@ -33,13 +33,13 @@
         //if file already exists, modify the last-modified-time of the file
         if (!result<%=cid %>) {
             <%if(isLog4jEnabled) {%>
-    		log.info("<%=cid%> - File : " + file_<%=cid %>.getAbsolutePath() + " already exist, only modify the last-modified-time of the file.");
+    		log.debug("<%=cid%> - File : " + file_<%=cid %>.getAbsolutePath() + " already exist, only modify the last-modified-time of the file.");
     		<%}%>
         	file_<%=cid %>.setLastModified((new Date()).getTime());
         }
         <%if(isLog4jEnabled) {%>
         else {
-        	log.info("<%=cid%> - File : " + file_<%=cid %>.getAbsolutePath() + " is created successfully");
+        	log.debug("<%=cid%> - File : " + file_<%=cid %>.getAbsolutePath() + " is created successfully");
         }
   		<%}%>
   		      

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFilterRow/tFilterRow_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFilterRow/tFilterRow_end.javajet
@@ -24,7 +24,7 @@ if (metadatas != null && metadatas.size() > 0) {
     globalMap.put("<%=cid %>_NB_LINE_REJECT", nb_line_reject_<%=cid%>);
     
     <%if(isLog4jEnabled){%>
-    	log.info("<%=cid%> - Processed records count:" + nb_line_<%=cid%> + ". Matched records count:" + nb_line_ok_<%=cid%> + ". Rejected records count:" + nb_line_reject_<%=cid%> + ".");
+    	log.debug("<%=cid%> - Processed records count:" + nb_line_<%=cid%> + ". Matched records count:" + nb_line_ok_<%=cid%> + ". Rejected records count:" + nb_line_reject_<%=cid%> + ".");
     <%}%>
   <%
   }

--- a/main/plugins/org.talend.designer.components.localprovider/components/tGSBucketCreate/tGSBucketCreate_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tGSBucketCreate/tGSBucketCreate_main.javajet
@@ -34,7 +34,7 @@
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Get an free connection from " + "<%=connection%>" + ".");
+			log.debug("<%=cid%> - Get an free connection from " + "<%=connection%>" + ".");
 		<%
 		}
 	}else{

--- a/main/plugins/org.talend.designer.components.localprovider/components/tGSBucketDelete/tGSBucketDelete_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tGSBucketDelete/tGSBucketDelete_main.javajet
@@ -29,7 +29,7 @@
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Get an free connection from " + "<%=connection%>" + ".");
+			log.debug("<%=cid%> - Get an free connection from " + "<%=connection%>" + ".");
 		<%
 		}
 	}else{

--- a/main/plugins/org.talend.designer.components.localprovider/components/tGSBucketExist/tGSBucketExist_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tGSBucketExist/tGSBucketExist_main.javajet
@@ -30,7 +30,7 @@
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Get an free connection from " + "<%=connection%>" + ".");
+			log.debug("<%=cid%> - Get an free connection from " + "<%=connection%>" + ".");
 		<%
 		}
 	}else{

--- a/main/plugins/org.talend.designer.components.localprovider/components/tGSBucketList/tGSBucketList_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tGSBucketList/tGSBucketList_begin.javajet
@@ -29,7 +29,7 @@ imports="
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Get an free connection from " + "<%=connection%>" + ".");
+			log.debug("<%=cid%> - Get an free connection from " + "<%=connection%>" + ".");
 		<%
 		}
 	}else{

--- a/main/plugins/org.talend.designer.components.localprovider/components/tGSCopy/tGSCopy_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tGSCopy/tGSCopy_main.javajet
@@ -36,7 +36,7 @@
 			<%
 			if(isLog4jEnabled){
 			%>	
-				log.info("<%=cid%> - Get an free connection from " + "<%=connection%>" + ".");
+				log.debug("<%=cid%> - Get an free connection from " + "<%=connection%>" + ".");
 			<%
 			}
 		}else{

--- a/main/plugins/org.talend.designer.components.localprovider/components/tGSDelete/tGSDelete_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tGSDelete/tGSDelete_begin.javajet
@@ -34,7 +34,7 @@
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Get an free connection from " + "<%=connection%>" + ".");
+			log.debug("<%=cid%> - Get an free connection from " + "<%=connection%>" + ".");
 		<%
 		}
 	}else{

--- a/main/plugins/org.talend.designer.components.localprovider/components/tGSGet/tGSGet_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tGSGet/tGSGet_begin.javajet
@@ -38,7 +38,7 @@ imports="
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Get an free connection from " + "<%=connection%>" + ".");
+			log.debug("<%=cid%> - Get an free connection from " + "<%=connection%>" + ".");
 		<%
 		}
 	}else{

--- a/main/plugins/org.talend.designer.components.localprovider/components/tGSList/tGSList_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tGSList/tGSList_begin.javajet
@@ -34,7 +34,7 @@ imports="
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Get an free connection from " + "<%=connection%>" + ".");
+			log.debug("<%=cid%> - Get an free connection from " + "<%=connection%>" + ".");
 		<%
 		}
 	}else{

--- a/main/plugins/org.talend.designer.components.localprovider/components/tGSPut/tGSPut_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tGSPut/tGSPut_main.javajet
@@ -38,7 +38,7 @@
 			<%
 			if(isLog4jEnabled){
 			%>	
-				log.info("<%=cid%> - Get an free connection from " + "<%=connection%>" + ".");
+				log.debug("<%=cid%> - Get an free connection from " + "<%=connection%>" + ".");
 			<%
 			}
 		}else{

--- a/main/plugins/org.talend.designer.components.localprovider/components/tGreenplumBulkExec/tGreenplumBulkExec_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tGreenplumBulkExec/tGreenplumBulkExec_begin.javajet
@@ -167,28 +167,28 @@ if((columnList != null && columnList.size() > 0) || "CLEAR".equals(tableAction) 
 	        tableName_<%=cid%> = "tmp_<%=cid%>_" + pid + Thread.currentThread().getId();
 	        java.sql.Statement stmtCreateTmp_<%=cid%> = conn_<%=cid%>.createStatement();
 			<%if(isLog4jEnabled_tableAction){%>
-				log.info("<%=cid%> - Creating temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
+				log.debug("<%=cid%> - Creating temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
 			<%}%>
 	        stmtCreateTmp_<%=cid%>.execute("<%=manager.getCreateTableSQL(stmtStructure)%>)");
 			<%if(isLog4jEnabled_tableAction){%>
-				log.info("<%=cid%> - Create temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
+				log.debug("<%=cid%> - Create temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
 			<%}%>
 	        stmtCreateTmp_<%=cid%>.close();
 			<%log4jCodeGenerateUtil.logInfo(node,"debug",cid+" - Bulk SQL:\"+bulkSQL_"+cid+"+\"");%>
 			<%if(isLog4jEnabled_tableAction){%>
-				log.info("<%=cid%> - Bulk inserting data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
+				log.debug("<%=cid%> - Bulk inserting data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
 			<%}%>
 	        java.sql.Statement stmtTmpBulk_<%=cid%> = conn_<%=cid%>.createStatement();
 	        stmtTmpBulk_<%=cid%>.execute(bulkSQL_<%=cid%>);
 	        stmtTmpBulk_<%=cid%>.close();
 			<%if(isLog4jEnabled_tableAction){%>
-				log.info("<%=cid%> - Bulk insert data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
+				log.debug("<%=cid%> - Bulk insert data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
 			<%}%>
 	        tableName_<%=cid%> = tmpTableName_<%=cid%>;
 	        tmpTableName_<%=cid%> = "tmp_<%=cid%>_" + pid + Thread.currentThread().getId();
 	        java.sql.Statement stmtUpdateBulk_<%=cid%> = conn_<%=cid%>.createStatement();
 			<%if(isLog4jEnabled_tableAction){%>
-				log.info("<%=cid%> - Updating <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> from <%=manager.getLProtectedChar()%>"+tmpTableName_<%=cid%>+"<%=manager.getRProtectedChar()%>.");
+				log.debug("<%=cid%> - Updating <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> from <%=manager.getLProtectedChar()%>"+tmpTableName_<%=cid%>+"<%=manager.getRProtectedChar()%>.");
 			<%}%>
 	        stmtUpdateBulk_<%=cid%>.executeUpdate("<%=manager.getUpdateBulkSQL(columnList)%>");
 			<%log4jCodeGenerateUtil.logInfo(node,"info",cid+" - Update has finished.");%>
@@ -196,11 +196,11 @@ if((columnList != null && columnList.size() > 0) || "CLEAR".equals(tableAction) 
 	        tableName_<%=cid%> = tmpTableName_<%=cid%>;
 	        java.sql.Statement stmtTmpDrop_<%=cid%> = conn_<%=cid%>.createStatement();
 			<%if(isLog4jEnabled_tableAction){%>
-				log.info("<%=cid%> - Droping temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
+				log.debug("<%=cid%> - Droping temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
 			<%}%>
 	        stmtTmpDrop_<%=cid%>.execute("<%=manager.getDropTableSQL()%>");
 			<%if(isLog4jEnabled_tableAction){%>
-				log.info("<%=cid%> - Drop temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%>+ "<%=manager.getRProtectedChar()%> has succeeded.");
+				log.debug("<%=cid%> - Drop temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%>+ "<%=manager.getRProtectedChar()%> has succeeded.");
 			<%}%>
 	        stmtTmpDrop_<%=cid%>.close();
 	        <%
@@ -208,14 +208,14 @@ if((columnList != null && columnList.size() > 0) || "CLEAR".equals(tableAction) 
 	} else if(("INSERT").equals(dataAction)) {
 	    if(isLog4jEnabled_tableAction){%>
 	    	log.debug("<%=cid%> - Bulk SQL:"+bulkSQL_<%=cid%>+".");
-			log.info("<%=cid%> - Bulk inserting data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
+			log.debug("<%=cid%> - Bulk inserting data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
 		<%}%>
 	    java.sql.Statement stmtBulk_<%=cid %> = conn_<%=cid %>.createStatement();
 	    //stmt.execute("SET client_encoding to 'UNICODE'");
 	    stmtBulk_<%=cid %>.execute(bulkSQL_<%=cid%>);
 	    stmtBulk_<%=cid %>.close();
 		<%if(isLog4jEnabled_tableAction){%>
-			log.info("<%=cid%> - Bulk insert data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
+			log.debug("<%=cid%> - Bulk insert data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
 		<%
 		}
 	}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tGreenplumGPLoad/tGreenplumGPLoad_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tGreenplumGPLoad/tGreenplumGPLoad_begin.javajet
@@ -156,21 +156,21 @@ skeleton="../templates/db_output_bulk.skeleton"
             %>
 			java.sql.Statement stmtDrop_<%=cid%> = conn_<%=cid%>.createStatement();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Droping table '" + tableName_<%=cid%> + "'.");
+				log.debug("<%=cid%> - Droping table '" + tableName_<%=cid%> + "'.");
 			<%}%>
 			stmtDrop_<%=cid%>.execute("<%=manager.getDropTableSQL()%>");
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Drop table '" + tableName_<%=cid%> + "' has succeeded." );
+				log.debug("<%=cid%> - Drop table '" + tableName_<%=cid%> + "' has succeeded." );
 			<%}%>
 			java.sql.Statement stmtCreate_<%=cid%> =  null;
 			try{
 				stmtCreate_<%=cid%> = conn_<%=cid%>.createStatement();
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Creating table '" + tableName_<%=cid%> + "'.");
+					log.debug("<%=cid%> - Creating table '" + tableName_<%=cid%> + "'.");
 				<%}%>
 				stmtCreate_<%=cid%>.execute("<%=manager.getCreateTableSQL(stmtStructure)%>)");
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Create table '" + tableName_<%=cid%> + "' has succeeded." );
+					log.debug("<%=cid%> - Create table '" + tableName_<%=cid%> + "' has succeeded." );
 				<%}%>
 			}catch(java.sql.SQLException e){
 				if(<%=dieOnError%>){
@@ -189,11 +189,11 @@ skeleton="../templates/db_output_bulk.skeleton"
 			try{
 				stmtCreate_<%=cid%> = conn_<%=cid%>.createStatement();
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Creating table '" + tableName_<%=cid%> + "'.");
+					log.debug("<%=cid%> - Creating table '" + tableName_<%=cid%> + "'.");
 				<%}%>
 				stmtCreate_<%=cid%>.execute("<%=manager.getCreateTableSQL(stmtStructure)%>)");
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Create table '" + tableName_<%=cid%> + "' has succeeded." );
+					log.debug("<%=cid%> - Create table '" + tableName_<%=cid%> + "' has succeeded." );
 				<%}%>
 			}catch(java.sql.SQLException e){
 				if(<%=dieOnError%>){
@@ -237,11 +237,11 @@ skeleton="../templates/db_output_bulk.skeleton"
 					try{
 						stmtCreate_<%=cid%> = conn_<%=cid%>.createStatement();
 						<%if(isLog4jEnabled){%>
-							log.info("<%=cid%> - Creating table '" + tableName_<%=cid%> + "'.");
+							log.debug("<%=cid%> - Creating table '" + tableName_<%=cid%> + "'.");
 						<%}%>
 						stmtCreate_<%=cid%>.execute("<%=manager.getCreateTableSQL(stmtStructure)%>)");
 						<%if(isLog4jEnabled){%>
-							log.info("<%=cid%> - Create table '" + tableName_<%=cid%> + "' has succeeded." );
+							log.debug("<%=cid%> - Create table '" + tableName_<%=cid%> + "' has succeeded." );
 						<%}%> 
 					}catch(java.sql.SQLException e){
 						if(<%=dieOnError%>){
@@ -263,11 +263,11 @@ skeleton="../templates/db_output_bulk.skeleton"
                     try{
                     	stmtDrop_<%=cid%> = conn_<%=cid%>.createStatement();
 						<%if(isLog4jEnabled){%>
-							log.info("<%=cid%> - Droping table '" + tableName_<%=cid%> + "'.");
+							log.debug("<%=cid%> - Droping table '" + tableName_<%=cid%> + "'.");
 						<%}%>
                     	stmtDrop_<%=cid%>.execute("<%=manager.getDropTableSQL()%>");
 						<%if(isLog4jEnabled){%>
-							log.info("<%=cid%> - Drop table '" + tableName_<%=cid%> + "' has succeeded.");
+							log.debug("<%=cid%> - Drop table '" + tableName_<%=cid%> + "' has succeeded.");
 						<%}%>
                     }catch(java.sql.SQLException e){
                     	if(<%=dieOnError%>){
@@ -284,11 +284,11 @@ skeleton="../templates/db_output_bulk.skeleton"
                 try{
                 stmtCreate_<%=cid%> = conn_<%=cid%>.createStatement();
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Creating table '" + tableName_<%=cid%> + "'.");
+					log.debug("<%=cid%> - Creating table '" + tableName_<%=cid%> + "'.");
 				<%}%>
                 stmtCreate_<%=cid%>.execute("<%=manager.getCreateTableSQL(stmtStructure)%>)");
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Create table '" + tableName_<%=cid%> + "' has succeeded." );
+					log.debug("<%=cid%> - Create table '" + tableName_<%=cid%> + "' has succeeded." );
 				<%}%>           
                 }catch(java.sql.SQLException e){
                 	if(<%=dieOnError%>){
@@ -308,11 +308,11 @@ skeleton="../templates/db_output_bulk.skeleton"
             java.sql.ResultSet rsClearCount_<%=cid%> = stmtClearCount_<%=cid%>.executeQuery("<%=manager.getSelectionSQL()%>");
             java.sql.Statement stmtClear_<%=cid%> = conn_<%=cid%>.createStatement();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Truncating table '" + tableName_<%=cid%> + "'.");
+				log.debug("<%=cid%> - Truncating table '" + tableName_<%=cid%> + "'.");
 			<%}%>
             stmtClear_<%=cid%>.executeUpdate("<%=manager.getTruncateTableSQL()%>");
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Truncate table '" + tableName_<%=cid%> + "' has succeeded." );
+				log.debug("<%=cid%> - Truncate table '" + tableName_<%=cid%> + "' has succeeded." );
 			<%}%>
             while(rsClearCount_<%=cid%>.next()) {
                 deletedCount_<%=cid%> = rsClearCount_<%=cid%>.getInt(1);
@@ -324,11 +324,11 @@ skeleton="../templates/db_output_bulk.skeleton"
             try{
             	stmtClear_<%=cid%> = conn_<%=cid%>.createStatement();
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Clearing table '" + tableName_<%=cid%> + "'.");
+					log.debug("<%=cid%> - Clearing table '" + tableName_<%=cid%> + "'.");
 				<%}%>
             	deletedCount_<%=cid%> = stmtClear_<%=cid%>.executeUpdate("<%=manager.getDeleteTableSQL()%>");
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%>- Clear table '" + tableName_<%=cid%> +  "' has succeeded." );
+					log.debug("<%=cid%>- Clear table '" + tableName_<%=cid%> +  "' has succeeded." );
 				<%}%>
             	stmtClear_<%=cid%>.close();
             }catch(java.sql.SQLException e){
@@ -525,15 +525,15 @@ skeleton="../templates/db_output_bulk.skeleton"
 	} else { // no input connections
 %>
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Executing '"+command_<%=cid %>.toString()+"'.");
+			log.debug("<%=cid%> - Executing '"+command_<%=cid %>.toString()+"'.");
 		<%}%>
 	gploadThread_<%=cid%>.start();
 	gploadThread_<%=cid%>.join(0);
 	globalMap.put("<%=cid%>_GPLOAD_OUTPUT", gploadOutput_<%=cid%>.toString());
 	globalMap.put("<%=cid%>_NB_LINE", insertedCount_<%=cid%>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Execute '"+command_<%=cid %>.toString()+"' has finished.");
-			log.info("<%=cid%> - Loaded records count:" + insertedCount_<%=cid%> + ".");
+			log.debug("<%=cid%> - Execute '"+command_<%=cid %>.toString()+"' has finished.");
+			log.debug("<%=cid%> - Loaded records count:" + insertedCount_<%=cid%> + ".");
 		<%}%>
 <%
 	}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tGreenplumGPLoad/tGreenplumGPLoad_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tGreenplumGPLoad/tGreenplumGPLoad_end.javajet
@@ -52,7 +52,7 @@ skeleton="../templates/db_output_bulk.skeleton"
 		outputStream_<%=cid%>.flush();
 		outputStream_<%=cid%>.close();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Executing '"+command_<%=cid %>.toString()+"'");
+				log.debug("<%=cid%> - Executing '"+command_<%=cid %>.toString()+"'");
 			<%}%>
 	<%
 		if (useNamedPiped) { // wait for gpload thread to finish
@@ -66,8 +66,8 @@ skeleton="../templates/db_output_bulk.skeleton"
 			<%
 		}
 			if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Execute '"+command_<%=cid %>.toString()+"' has finished.");
-				log.info("<%=cid%> - Loaded records count:"+insertedCount_<%=cid%> + ".");
+				log.debug("<%=cid%> - Execute '"+command_<%=cid %>.toString()+"' has finished.");
+				log.debug("<%=cid%> - Loaded records count:"+insertedCount_<%=cid%> + ".");
 			<%}
 	}
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tHiveRow/tHiveRow_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tHiveRow/tHiveRow_end.javajet
@@ -53,11 +53,11 @@ imports="
             if(commitEvery_<%=cid%> > commitCounter_<%=cid%>) {
             
 					<%if(isLog4jEnabled){%>
-						log.info("<%=cid%> - Starting to commit.");
+						log.debug("<%=cid%> - Starting to commit.");
 					<%}%>
 	            	conn_<%=cid%>.commit();
 					<%if(isLog4jEnabled){%>
-						log.info("<%=cid%> - Commit has succeeded.");
+						log.debug("<%=cid%> - Commit has succeeded.");
 					<%}%>
             	
             	commitCounter_<%=cid%> = 0;
@@ -67,11 +67,11 @@ imports="
 			}
     		%>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Closing the connection to the database.");
+				log.debug("<%=cid%> - Closing the connection to the database.");
 			<%}%>
 	    	conn_<%=cid %> .close();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Connection to the database closed.");
+				log.debug("<%=cid%> - Connection to the database closed.");
 			<%}%>
 	    	<%
 		}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tHiveRow/tHiveRow_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tHiveRow/tHiveRow_main.javajet
@@ -270,11 +270,11 @@ if(hiveDistrib.isExecutedThroughWebHCat()) {
 	        if(commitEvery_<%=cid%> <= commitCounter_<%=cid%>) {
 	        
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Starting to commit.");
+					log.debug("<%=cid%> - Starting to commit.");
 				<%}%>
 	        	conn_<%=cid%>.commit();
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Commit has succeeded.");
+					log.debug("<%=cid%> - Commit has succeeded.");
 				<%}%>
 	        	
 	        	commitCounter_<%=cid%>=0;

--- a/main/plugins/org.talend.designer.components.localprovider/components/tHttpRequest/tHttpRequest_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tHttpRequest/tHttpRequest_main.javajet
@@ -70,11 +70,11 @@ java.net.URL url_<%=cid%> = new java.net.URL(<%=sURI%>);
   }});
 <%}%>
     <%if(isLog4jEnabled){%>
-        log.info("<%=cid%> - Connection attempt to '" + <%=sURI%>);
+        log.debug("<%=cid%> - Connection attempt to '" + <%=sURI%>);
     <%}%>
 java.net.HttpURLConnection urlConn_<%=cid%> = (java.net.HttpURLConnection) url_<%=cid%>.openConnection();
     <%if(isLog4jEnabled){%>
-        log.info("<%=cid%> - Connection to '" +  <%=sURI%> + "' has succeeded.");
+        log.debug("<%=cid%> - Connection to '" +  <%=sURI%> + "' has succeeded.");
     <%}%>
 urlConn_<%=cid%>.setRequestMethod("<%=sMethod%>");
 urlConn_<%=cid%>.setDoOutput(true);
@@ -184,11 +184,11 @@ try{
     }
 %>
 <%if(isLog4jEnabled){%>
-    log.info("<%=cid%> - Closing the connection to the server.");
+    log.debug("<%=cid%> - Closing the connection to the server.");
 <%}%>
     urlConn_<%=cid%>.disconnect();
 <%if(isLog4jEnabled){%>
-    log.info("<%=cid%> - Connection to the server closed.");
+    log.debug("<%=cid%> - Connection to the server closed.");
 <%}%>
 }catch(Exception e){
     <%if(!dieOnError){%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tInformixBulkExec/tInformixBulkExec_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tInformixBulkExec/tInformixBulkExec_begin.javajet
@@ -212,7 +212,7 @@ if(columnList != null && columnList.size() > 0) {
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Executing '"+command_<%=cid %>.toString()+"'.");
+		log.debug("<%=cid%> - Executing '"+command_<%=cid %>.toString()+"'.");
 	<%
 	}
 	%>
@@ -301,7 +301,7 @@ error_<%=cid%>.interrupt();
     <%
     if(isLog4jEnabled){
     %>
-        log.info("<%=cid%> - Execute '"+command_<%=cid %>.toString()+"' has finished。");
+        log.debug("<%=cid%> - Execute '"+command_<%=cid %>.toString()+"' has finished。");
     <%
     }
     %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tInformixSP/tInformixSP_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tInformixSP/tInformixSP_main.javajet
@@ -210,11 +210,11 @@ if (canGenerate) {
 	  			<%
 			}
 		}
-		dbLog.info(dbLog.str("Try to execute store procedure:"),spName,dbLog.str("."));
+		dblog.debug(dbLog.str("Try to execute store procedure:"),spName,dbLog.str("."));
 		%>
 		statement_<%=cid%>.execute();
 		<%
-		dbLog.info(dbLog.str("The store procedure:"),spName,dbLog.str(" executed successfully."));
+		dblog.debug(dbLog.str("The store procedure:"),spName,dbLog.str(" executed successfully."));
 		List<? extends IConnection> outConnections = node.getOutgoingConnections();
 		IConnection firstOutConnection = null;
 		

--- a/main/plugins/org.talend.designer.components.localprovider/components/tIngresBulkExec/tIngresBulkExec_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tIngresBulkExec/tIngresBulkExec_begin.javajet
@@ -339,7 +339,7 @@
 		<%
 		if(isLog4jEnabled){
 		%>
-			log.info("<%=cid%> - Bulk loading.");
+			log.debug("<%=cid%> - Bulk loading.");
 		<%
 		}
 		%>
@@ -487,7 +487,7 @@
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Bulk load has finished.");
+		log.debug("<%=cid%> - Bulk load has finished.");
 	<%
 	}
 	if (deleteWorkingFiles){

--- a/main/plugins/org.talend.designer.components.localprovider/components/tJDBCColumnList/tJDBCColumnList_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tJDBCColumnList/tJDBCColumnList_begin.javajet
@@ -70,7 +70,7 @@ stmt2_<%=cid%> = conn_<%=cid%>.createStatement();
 <%
 if(isLog4jEnabled){
 %>
-    log.info("<%=cid%> - Query:'"+"SELECT * from " + tableName_<%=cid%> + " where 1<>1'.");
+    log.debug("<%=cid%> - Query:'"+"SELECT * from " + tableName_<%=cid%> + " where 1<>1'.");
 <%
 }
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tJDBCSP/tJDBCSP_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tJDBCSP/tJDBCSP_main.javajet
@@ -211,11 +211,11 @@ if (canGenerate) {
 	  			<%
 			}
 		}
-		dbLog.info(dbLog.str("Try to execute store procedure:"),spName,dbLog.str("."));
+		dblog.debug(dbLog.str("Try to execute store procedure:"),spName,dbLog.str("."));
 		%>
 		statement_<%=cid%>.execute();
 		<%
-		dbLog.info(dbLog.str("The store procedure:"),spName,dbLog.str(" executed successfully."));
+		dblog.debug(dbLog.str("The store procedure:"),spName,dbLog.str(" executed successfully."));
 		List<? extends IConnection> outConnections = node.getOutgoingConnections();
 		IConnection firstOutConnection = null;
 		

--- a/main/plugins/org.talend.designer.components.localprovider/components/tJDBCTableList/tJDBCTableList_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tJDBCTableList/tJDBCTableList_begin.javajet
@@ -72,7 +72,7 @@ if(dbschema_<%=cid%> != null && dbschema_<%=cid%>.trim().length() > 0){
 <%
 if(isLog4jEnabled){
 %>
-    log.info("<%=cid%> - Query:'"+query_<%=cid %>+"'.");
+    log.debug("<%=cid%> - Query:'"+query_<%=cid %>+"'.");
 <%
 }
 %>
@@ -92,7 +92,7 @@ if(dbschema_<%=cid%> != null && dbschema_<%=cid%>.trim().length() > 0){
 <%
 if(isLog4jEnabled){
 %>
-    log.info("<%=cid%> - Query:'"+query_<%=cid %>+"'.");
+    log.debug("<%=cid%> - Query:'"+query_<%=cid %>+"'.");
 <%
 }
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tJMSInput/tJMSInput_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tJMSInput/tJMSInput_begin.javajet
@@ -95,8 +95,8 @@ if(advProps.size() > 0){
 
 	System.out.println("Ready to receive message");
 	System.out.println("Waiting...");
-	<%log.info(log.str("Ready to receive message."));%>
-	<%log.info(log.str("Waiting..."));%>
+	<%log.debug(log.str("Ready to receive message."));%>
+	<%log.debug(log.str("Waiting..."));%>
 
 	javax.jms.Message message_<%=cid%>;
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tJMSInput/tJMSInput_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tJMSInput/tJMSInput_end.javajet
@@ -24,5 +24,5 @@ String maxMsg=ElementParameterParser.getValue(node, "__MAX_MSG__");
 consumer_<%=cid%>.close();
 session_<%=cid%>.close();
 connection_<%=cid%>.close();
-<%log.info(log.str("Retrieved records count: "), log.var("nbline"), log.str("."));%>
+<%log.debug(log.str("Retrieved records count: "), log.var("nbline"), log.str("."));%>
 globalMap.put("<%=cid %>_NB_LINE", nbline_<%=cid%>);

--- a/main/plugins/org.talend.designer.components.localprovider/components/tJMSOutput/tJMSOutput_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tJMSOutput/tJMSOutput_end.javajet
@@ -15,7 +15,7 @@ producer_<%=cid %>.close();
 session_<%=cid %>.close();
 connection_<%=cid %>.close();
 globalMap.put("<%=cid %>_NB_LINE", nbline_<%=cid%>);
-<%log.info(log.str("Sent messages count: "), log.var("nbline"), log.str("."));%>
+<%log.debug(log.str("Sent messages count: "), log.var("nbline"), log.str("."));%>
 
 
             

--- a/main/plugins/org.talend.designer.components.localprovider/components/tLDAPAttributesInput/tLDAPAttributesInput_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLDAPAttributesInput/tLDAPAttributesInput_begin.javajet
@@ -87,14 +87,14 @@ imports="
 							if(alwaysTrust) {
 %>
 								<%if(isLog4jEnabled){%>
-									log.info("<%=cid%> - Adnanced CA trusting all certs.");
+									log.debug("<%=cid%> - Adnanced CA trusting all certs.");
 								<%}%>
 								talend.ssl.AdvancedSocketFactory.alwaysTrust();
 <%
 							} else {
 %>
 								<%if(isLog4jEnabled){%>
-									log.info("<%=cid%> - Advanced CA using a store CA file and Keystore password.");
+									log.debug("<%=cid%> - Advanced CA using a store CA file and Keystore password.");
 									log.debug("Store CA : '" + <%=storepath %> + "'.");
 								<%}%>
 								talend.ssl.AdvancedSocketFactory.setCertStorePath(<%=storepath%>);
@@ -120,7 +120,7 @@ imports="
 					}
 %>
 					<%if(isLog4jEnabled){%>
-						log.info("<%=cid%> - Connection attempt to '"+ <%=host%> + "'.");
+						log.debug("<%=cid%> - Connection attempt to '"+ <%=host%> + "'.");
 					<%}%>
 					javax.naming.ldap.InitialLdapContext ctx_<%=cid%> = new javax.naming.ldap.InitialLdapContext(env_<%=cid%>, null);
 <%
@@ -133,7 +133,7 @@ imports="
 					}
 %>
 					<%if(isLog4jEnabled){%>
-						log.info("<%=cid%> - Connection to '"+<%=host%>+"' has succeeded.");
+						log.debug("<%=cid%> - Connection to '"+<%=host%>+"' has succeeded.");
 					<%}%>
 <%
 				}else{
@@ -141,7 +141,7 @@ imports="
 					javax.naming.ldap.InitialLdapContext ctx_<%=cid%> = (javax.naming.ldap.InitialLdapContext)globalMap.get("<%=exConn%>");
 					<%if(isLog4jEnabled){%>
 						if(ctx_<%=cid%>!=null) {
-							log.info("<%=cid%> - Uses an existing connection ,connection URL is: '" + ctx_<%=cid%>.getEnvironment().get(javax.naming.Context.PROVIDER_URL) + "'."); 
+							log.debug("<%=cid%> - Uses an existing connection ,connection URL is: '" + ctx_<%=cid%>.getEnvironment().get(javax.naming.Context.PROVIDER_URL) + "'."); 
 						}
 					<%}%>
 					baseDN_<%=cid%> = (String)globalMap.get("<%=exConnBaseDN%>");
@@ -204,7 +204,7 @@ imports="
 						java.util.Set<String> optionalAttributes_<%=cid%> = new java.util.HashSet<String>();
 						
 						<%if(isLog4jEnabled){%>
-							log.info("<%=cid%> - Retrieving records from the service.");
+							log.debug("<%=cid%> - Retrieving records from the service.");
 						<%}%>
 					while (answer_<%=cid%> .hasMoreElements()) {//a
 						

--- a/main/plugins/org.talend.designer.components.localprovider/components/tLDAPAttributesInput/tLDAPAttributesInput_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLDAPAttributesInput/tLDAPAttributesInput_end.javajet
@@ -44,18 +44,18 @@ rootSchema_<%=cid%>.close();
 if(("false").equals(useExistingConn)){
 %>
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Closing the connection to the server.");
+		log.debug("<%=cid%> - Closing the connection to the server.");
 	<%}%>
 	ctx_<%=cid%>.close();
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection to the server closed.");
+		log.debug("<%=cid%> - Connection to the server closed.");
 	<%}%>
 <%
 }
 %>
 globalMap.put("<%=cid%>_NB_LINE", <%=cid%>_NB_LINE);
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - Retrieved records count: " + <%=cid%>_NB_LINE +  " .");
+	log.debug("<%=cid%> - Retrieved records count: " + <%=cid%>_NB_LINE +  " .");
 <%}%>
 <%
  }

--- a/main/plugins/org.talend.designer.components.localprovider/components/tLDAPClose/tLDAPClose_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLDAPClose/tLDAPClose_main.javajet
@@ -18,10 +18,10 @@ imports="
 	if(ctx_<%=cid%> != null)
 	{
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Closing the connection to the server.");
+			log.debug("<%=cid%> - Closing the connection to the server.");
 		<%}%>
 		ctx_<%=cid%>.close();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection to the server closed.");
+			log.debug("<%=cid%> - Connection to the server closed.");
 		<%}%>
 	}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tLDAPConnection/tLDAPConnection_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLDAPConnection/tLDAPConnection_begin.javajet
@@ -33,7 +33,7 @@ env_<%=cid%>.put(javax.naming.Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.lda
 env_<%=cid%>.put(javax.naming.Context.SECURITY_AUTHENTICATION, "simple");// "none","simple","strong"
 <%if(useAuth){%>
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Authentication using username and password.");
+		log.debug("<%=cid%> - Authentication using username and password.");
 	<%}%>
 	env_<%=cid%>.put(javax.naming.Context.SECURITY_PRINCIPAL, <%=user%>);
 	
@@ -61,14 +61,14 @@ if(("LDAPS").equals(protocol) || ("TLS").equals(protocol)){
 		if(alwaysTrust) {
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Adnanced CA trusting all certs.");
+				log.debug("<%=cid%> - Adnanced CA trusting all certs.");
 			<%}%>
 			talend.ssl.AdvancedSocketFactory.alwaysTrust();
 <%
 		} else {
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Advanced CA using a store CA file and Keystore password.");
+				log.debug("<%=cid%> - Advanced CA using a store CA file and Keystore password.");
 				log.debug("Store CA : '" + <%=storepath %> + "'.");
 			<%}%>
 			talend.ssl.AdvancedSocketFactory.setCertStorePath(<%=storepath%>);
@@ -93,7 +93,7 @@ if(("LDAPS").equals(protocol) || ("TLS").equals(protocol)){
 }
 %>
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - Connection attempt to '"+ <%=host%> + "'.");
+	log.debug("<%=cid%> - Connection attempt to '"+ <%=host%> + "'.");
 <%}%>
 javax.naming.ldap.InitialLdapContext ctx_<%=cid%> = new javax.naming.ldap.InitialLdapContext(env_<%=cid%>, null);
 globalMap.put("conn_<%=cid%>",ctx_<%=cid%>);
@@ -108,5 +108,5 @@ if(("TLS").equals(protocol)){
 }
 %>
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - Connection to '"+<%=host%> + "' has succeeded.");
+	log.debug("<%=cid%> - Connection to '"+<%=host%> + "' has succeeded.");
 <%}%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tLDAPInput/tLDAPInput_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLDAPInput/tLDAPInput_begin.javajet
@@ -101,14 +101,14 @@ if(("false").equals(useExistingConn)){
 			if(alwaysTrust) {
 %>
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Adnanced CA trusting all certs.");
+					log.debug("<%=cid%> - Adnanced CA trusting all certs.");
 				<%}%>
 				talend.ssl.AdvancedSocketFactory.alwaysTrust();
 <%
 			} else {
 %>
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Advanced CA using a store CA file and Keystore password.");
+					log.debug("<%=cid%> - Advanced CA using a store CA file and Keystore password.");
 					log.debug("Store CA : '" + <%=storepath %> + "'.");
 				<%}%>
 				talend.ssl.AdvancedSocketFactory.setCertStorePath(<%=storepath%>);
@@ -136,7 +136,7 @@ if(("false").equals(useExistingConn)){
    	javax.naming.ldap.InitialLdapContext ctx_<%=cid%> = null;
 	try{
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection attempt to '"+ <%=host%> + "'.");
+		log.debug("<%=cid%> - Connection attempt to '"+ <%=host%> + "'.");
 	<%}%>
 	ctx_<%=cid%> = new javax.naming.ldap.InitialLdapContext(env_<%=cid%>, null);
 <%
@@ -148,7 +148,7 @@ if(("false").equals(useExistingConn)){
 <%
 	}
 	if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection to '"+<%=host%>+"' has succeeded.");
+		log.debug("<%=cid%> - Connection to '"+<%=host%>+"' has succeeded.");
 	<%}
 }else{
 %>
@@ -156,7 +156,7 @@ if(("false").equals(useExistingConn)){
 	javax.naming.ldap.InitialLdapContext ctx_<%=cid%> = (javax.naming.ldap.InitialLdapContext)globalMap.get("<%=exConn%>");
 	<%if(isLog4jEnabled){%>
 		if(ctx_<%=cid%>!=null) {
-			log.info("<%=cid%> - Uses an existing connection ,connection URL is: '" + ctx_<%=cid%>.getEnvironment().get(javax.naming.Context.PROVIDER_URL) + "'."); 
+			log.debug("<%=cid%> - Uses an existing connection ,connection URL is: '" + ctx_<%=cid%>.getEnvironment().get(javax.naming.Context.PROVIDER_URL) + "'."); 
 		}
 	<%}%>
 	baseDN_<%=cid%> = (String)globalMap.get("<%=exConnBaseDN%>");
@@ -250,7 +250,7 @@ if(("false").equals(useExistingConn)){
     	javax.naming.directory.Attributes attrsDyn_<%=cid%> = null;
     	javax.naming.NamingEnumeration answerDyn_<%=cid%> = ctx_<%=cid%>.search(<%if(("false").equals(useExistingConn)){%>baseDN_<%=cid%><%}else{%>""<%}%>, <%=filter%>, searchCtls_<%=cid%>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Retrieving records from the service.");
+			log.debug("<%=cid%> - Retrieving records from the service.");
 		<%}%>
     	while (answerDyn_<%=cid%> .hasMoreElements()) {
     		javax.naming.directory.SearchResult srDyn_<%=cid%>  = (javax.naming.directory.SearchResult) answerDyn_<%=cid%>.next();
@@ -318,7 +318,7 @@ do {
 
     javax.naming.NamingEnumeration answer_<%=cid%> = ctx_<%=cid%>.search(<%if(("false").equals(useExistingConn)){%>baseDN_<%=cid%><%}else{%>""<%}%>, <%=filter%>, searchCtls_<%=cid%>);
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Retrieving records from the service.");
+		log.debug("<%=cid%> - Retrieving records from the service.");
 	<%}%>
     while (answer_<%=cid%> .hasMoreElements()) {//a
 <%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tLDAPInput/tLDAPInput_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLDAPInput/tLDAPInput_end.javajet
@@ -61,11 +61,11 @@ if(("false").equals(useExistingConn)){
 %>  
 		if(ctx_<%=cid%>!=null){
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Closing the connection to the server.");
+				log.debug("<%=cid%> - Closing the connection to the server.");
 			<%}%>
 			ctx_<%=cid%>.close();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Connection to the server closed.");
+				log.debug("<%=cid%> - Connection to the server closed.");
 			<%}%>
 		}
 <%
@@ -74,7 +74,7 @@ if(("false").equals(useExistingConn)){
 	}
 globalMap.put("<%=cid%>_NB_LINE", <%=cid%>_NB_LINE);
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - Retrieved records count: " + <%=cid%>_NB_LINE + " .");
+	log.debug("<%=cid%> - Retrieved records count: " + <%=cid%>_NB_LINE + " .");
 <%}%>
 
 <%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tLDAPOutput/tLDAPOutput_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLDAPOutput/tLDAPOutput_begin.javajet
@@ -70,14 +70,14 @@ if(("false").equals(useExistingConn)){
 			if(alwaysTrust) {
 %>
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Adnanced CA trusting all certs.");
+					log.debug("<%=cid%> - Adnanced CA trusting all certs.");
 				<%}%>
 				talend.ssl.AdvancedSocketFactory.alwaysTrust();
 <%
 			} else {
 %>
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Advanced CA using a store CA file and Keystore password.");
+					log.debug("<%=cid%> - Advanced CA using a store CA file and Keystore password.");
 					log.debug("Store CA : '" + <%=storepath %> + "'.");
 				<%}%>
 				talend.ssl.AdvancedSocketFactory.setCertStorePath(<%=storepath%>);
@@ -102,7 +102,7 @@ if(("false").equals(useExistingConn)){
     }
 %>
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection attempt to '"+ <%=host%> + "'.");
+		log.debug("<%=cid%> - Connection attempt to '"+ <%=host%> + "'.");
 	<%}%>
     javax.naming.ldap.InitialLdapContext ctx_<%=cid%> = new javax.naming.ldap.InitialLdapContext(env_<%=cid%>, null);
 <%
@@ -115,7 +115,7 @@ if(("false").equals(useExistingConn)){
 	}
 %>
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection to '"+<%=host%>+"' has succeeded.");
+		log.debug("<%=cid%> - Connection to '"+<%=host%>+"' has succeeded.");
 	<%}%>
 <%
 }else{
@@ -123,7 +123,7 @@ if(("false").equals(useExistingConn)){
 	javax.naming.ldap.InitialLdapContext ctx_<%=cid%> = (javax.naming.ldap.InitialLdapContext)globalMap.get("<%=exConn%>");
 	<%if(isLog4jEnabled){%>
 		if(ctx_<%=cid%>!=null) {
-			log.info("<%=cid%> - Uses an existing connection ,connection URL is: '" + ctx_<%=cid%>.getEnvironment().get(javax.naming.Context.PROVIDER_URL) + "'."); 
+			log.debug("<%=cid%> - Uses an existing connection ,connection URL is: '" + ctx_<%=cid%>.getEnvironment().get(javax.naming.Context.PROVIDER_URL) + "'."); 
 		}
 	<%}%>
     String baseDN_<%=cid%> = (String)globalMap.get("<%=exConnBaseDN%>");

--- a/main/plugins/org.talend.designer.components.localprovider/components/tLDAPOutput/tLDAPOutput_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLDAPOutput/tLDAPOutput_end.javajet
@@ -16,11 +16,11 @@
 if(("false").equals(useExistingConn)){
 %>
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Closing the connection to the server.");
+		log.debug("<%=cid%> - Closing the connection to the server.");
 	<%}%>
 	ctx_<%=cid%>.close();
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection to the server closed.");
+		log.debug("<%=cid%> - Connection to the server closed.");
 	<%}%>
 <%
 }
@@ -28,5 +28,5 @@ if(("false").equals(useExistingConn)){
 globalMap.put("<%=cid %>_NB_LINE", nb_line_<%=cid %>);
 globalMap.put("<%=cid %>_NB_LINE_REJECTED",nb_line_rejected_<%=cid%>);
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - Written records count: " + nb_line_<%=cid %> + ".");
+	log.debug("<%=cid%> - Written records count: " + nb_line_<%=cid %> + ".");
 <%}%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tLDAPRenameEntry/tLDAPRenameEntry_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLDAPRenameEntry/tLDAPRenameEntry_begin.javajet
@@ -75,14 +75,14 @@ if(("false").equals(useExistingConn)){
 			if(alwaysTrust) {
 %>
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Adnanced CA trusting all certs.");
+					log.debug("<%=cid%> - Adnanced CA trusting all certs.");
 				<%}%>
 				talend.ssl.AdvancedSocketFactory.alwaysTrust();
 <%
 			} else {
 %>
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Advanced CA using a store CA file and Keystore password.");
+					log.debug("<%=cid%> - Advanced CA using a store CA file and Keystore password.");
 					log.debug("Store CA : '" + <%=storepath %> + "'.");
 				<%}%>
 				talend.ssl.AdvancedSocketFactory.setCertStorePath(<%=storepath%>);
@@ -107,7 +107,7 @@ if(("false").equals(useExistingConn)){
     }
 %>
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection attempt to '"+ <%=host%>);
+		log.debug("<%=cid%> - Connection attempt to '"+ <%=host%>);
 	<%}%>
     javax.naming.ldap.InitialLdapContext ctx_<%=cid%> = new javax.naming.ldap.InitialLdapContext(env_<%=cid%>, null);
 <%
@@ -120,7 +120,7 @@ if(("false").equals(useExistingConn)){
 	}
 	if(isLog4jEnabled){
 %>
-		log.info("<%=cid%> - Connection to '"+<%=host%>+"' has succeeded.");
+		log.debug("<%=cid%> - Connection to '"+<%=host%>+"' has succeeded.");
 <%
 	}
 }else{
@@ -128,7 +128,7 @@ if(("false").equals(useExistingConn)){
 javax.naming.ldap.InitialLdapContext ctx_<%=cid%> = (javax.naming.ldap.InitialLdapContext)globalMap.get("<%=exConn%>");
 	<%if(isLog4jEnabled){%>
 		if(ctx_<%=cid%>!=null) {
-			log.info("<%=cid%> - Uses an existing connection ,connection URL is: '" + ctx_<%=cid%>.getEnvironment().get(javax.naming.Context.PROVIDER_URL) + "'."); 
+			log.debug("<%=cid%> - Uses an existing connection ,connection URL is: '" + ctx_<%=cid%>.getEnvironment().get(javax.naming.Context.PROVIDER_URL) + "'."); 
 		}
 	<%}%>
 <%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tLDAPRenameEntry/tLDAPRenameEntry_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLDAPRenameEntry/tLDAPRenameEntry_end.javajet
@@ -16,11 +16,11 @@
 if(("false").equals(useExistingConn)){
 %>
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Closing the connection to the server.");
+		log.debug("<%=cid%> - Closing the connection to the server.");
 	<%}%>
 	ctx_<%=cid%>.close();
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection to the server closed.");
+		log.debug("<%=cid%> - Connection to the server closed.");
 	<%}%>
 <%
 }

--- a/main/plugins/org.talend.designer.components.localprovider/components/tLogRow/tLogRow_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLogRow/tLogRow_begin.javajet
@@ -217,7 +217,7 @@ if (("true").equals(printHeader)) {
                     <%
                     if(isLogContent && isLog4jEnabled){
                     %>
-                    	log.info("<%=cid%> - Header names: " + sbHeader_<%=cid%>.toString());
+                    	log.debug("<%=cid%> - Header names: " + sbHeader_<%=cid%>.toString());
                     <%
                     }
                     %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tLogRow/tLogRow_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLogRow/tLogRow_end.javajet
@@ -45,7 +45,7 @@ if ((metadatas!=null)&&(metadatas.size()>0)) {//1
 %>
 //////
 globalMap.put("<%=cid %>_NB_LINE",nb_line_<%=cid %>);
-<%log.info(log.str("Printed row count: "), log.var("nb_line"), log.str("."));%>
+<%log.debug(log.str("Printed row count: "), log.var("nb_line"), log.str("."));%>
 
 ///////////////////////    			
 <%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tLogRow/tLogRow_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLogRow/tLogRow_main.javajet
@@ -207,7 +207,7 @@ if (basic) {
                     <%
                     if(isLogContent && isLog4jEnabled){
                     %>
-                    	log.info("<%=cid%> - Content of row "+(nb_line_<%=cid %>+1)+": " + strBuffer_<%=cid%>.toString());
+                    	log.debug("<%=cid%> - Content of row "+(nb_line_<%=cid %>+1)+": " + strBuffer_<%=cid%>.toString());
                     <%
                     }
                     %>
@@ -295,7 +295,7 @@ if (basic) {
 				}
                 if(isLogContent && isLog4jEnabled){
                 %>
-                	log.info("<%=cid%> - Content of row "+nb_line_<%=cid %>+": " + TalendString.unionString("|",row_<%=cid%>));
+                	log.debug("<%=cid%> - Content of row "+nb_line_<%=cid %>+": " + TalendString.unionString("|",row_<%=cid%>));
                 <%
                 }
 	}//***

--- a/main/plugins/org.talend.designer.components.localprovider/components/tLoop/tLoop_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLoop/tLoop_begin.javajet
@@ -30,7 +30,7 @@ if (("").equals(step)) step = "1";
 boolean increase = ("true").equals(ElementParameterParser.getValue(node, "__INCREASE__"));
 if(isLog4jEnabled){
 %>
-	log.info("<%=cid%> - Start to loop from " + (<%=from%>) + " to " + (<%=to%>) + " with a step of " + (<%=step%>) + " (" + <%=increase?"\"Increasing\"":"\"Decreasing\""%> + ").");
+	log.debug("<%=cid%> - Start to loop from " + (<%=from%>) + " to " + (<%=to%>) + " with a step of " + (<%=step%>) + " (" + <%=increase?"\"Increasing\"":"\"Decreasing\""%> + ").");
 <%
 }
 if(increase){%>
@@ -58,7 +58,7 @@ String declaration = ElementParameterParser.getValue(node, "__DECLARATION__");
 <%=declaration%>;
 	<%if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Start to loop using a while loop. Initial declaration: '" + <%=org.talend.core.model.utils.NodeUtil.getNormalizeParameterValue(node, "DECLARATION")%> + "'. Condition: '" + <%=org.talend.core.model.utils.NodeUtil.getNormalizeParameterValue(node, "CONDITION")%> + "'.");
+		log.debug("<%=cid%> - Start to loop using a while loop. Initial declaration: '" + <%=org.talend.core.model.utils.NodeUtil.getNormalizeParameterValue(node, "DECLARATION")%> + "'. Condition: '" + <%=org.talend.core.model.utils.NodeUtil.getNormalizeParameterValue(node, "CONDITION")%> + "'.");
 	<%}%>
 while(<%=condition%>){
 	<%if(isLog4jEnabled){%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMSSqlBulkExec/tMSSqlBulkExec_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMSSqlBulkExec/tMSSqlBulkExec_begin.javajet
@@ -202,14 +202,14 @@ if(("EXPORT").equals(action)) {
     		if(isLog4jEnabled_tableAction){
     		%>
     			log.debug("<%=cid%> - Bulk SQL:"+bulkSQL_<%=cid%>+".");
-    			log.info("<%=cid%> - Bulk inserting data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
+    			log.debug("<%=cid%> - Bulk inserting data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
     		<%
     		}
     		%>
     		stmtBulkInsert_<%=cid %>.execute(bulkSQL_<%=cid%>);
     		stmtBulkInsert_<%=cid %>.close();
     		<%if(isLog4jEnabled_tableAction){%>
-    			log.info("<%=cid%> - Bulk insert data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
+    			log.debug("<%=cid%> - Bulk insert data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
     		<%
     		}
     	} else if(("UPDATE").equals(action)) {
@@ -229,29 +229,29 @@ if(("EXPORT").equals(action)) {
     			tableName_<%=cid%> = "tmp_<%=cid%>" + "_" + pid + Thread.currentThread().getId();
     			java.sql.Statement stmtCreateTmp_<%=cid%> = conn_<%=cid%>.createStatement();
     			<%if(isLog4jEnabled_tableAction){%>
-    				log.info("<%=cid%> - Creating temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
+    				log.debug("<%=cid%> - Creating temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
     			<%}%>
     			stmtCreateTmp_<%=cid%>.execute("<%=manager.getCreateTableSQL(stmtStructure)%>)");
     			<%if(isLog4jEnabled_tableAction){%>
-    				log.info("<%=cid%> - Create temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
+    				log.debug("<%=cid%> - Create temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
     			<%}%>
     			stmtCreateTmp_<%=cid%>.close();
     			java.sql.Statement stmtTmpBulk_<%=cid%> = conn_<%=cid%>.createStatement();
     			String bulkSQL_<%=cid%> = "BULK INSERT <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> FROM '" + <%=file%> + "' WITH ( CODEPAGE='" + <%=codePage%> + "',DATAFILETYPE='<%=data_file_type%>',FIELDTERMINATOR='" + <%=field_separator%> + "',FIRSTROW =" + <%=first_row%> + ",ROWTERMINATOR='" + <%=row_separator%>+"')";
     			<%if(isLog4jEnabled_tableAction){%>
     				log.debug("<%=cid%> - Bulk SQL:"+bulkSQL_<%=cid%>+".");
-    				log.info("<%=cid%> - Bulk inserting data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
+    				log.debug("<%=cid%> - Bulk inserting data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
     			<%}%>
     			stmtTmpBulk_<%=cid%>.execute(bulkSQL_<%=cid%>);
     			stmtTmpBulk_<%=cid%>.close();
     			<%if(isLog4jEnabled_tableAction){%>
-    				log.info("<%=cid%> - Bulk insert data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
+    				log.debug("<%=cid%> - Bulk insert data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
     			<%}%>
     			tableName_<%=cid%> = tmpTableName_<%=cid%>;
     			tmpTableName_<%=cid%> = "tmp_<%=cid%>" + "_" + pid + Thread.currentThread().getId();
     			java.sql.Statement stmtUpdateBulk_<%=cid%> = conn_<%=cid%>.createStatement();
     			<%if(isLog4jEnabled_tableAction){%>
-    				log.info("<%=cid%> - Updating <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> from <%=manager.getLProtectedChar()%>"+tmpTableName_<%=cid%>+"<%=manager.getRProtectedChar()%>.");
+    				log.debug("<%=cid%> - Updating <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> from <%=manager.getLProtectedChar()%>"+tmpTableName_<%=cid%>+"<%=manager.getRProtectedChar()%>.");
     			<%}%>
     			stmtUpdateBulk_<%=cid%>.executeUpdate("<%=manager.getUpdateBulkSQL(columnList)%>");
     			<%log4jCodeGenerateUtil.logInfo(node,"info",cid+" - Update has finished.");%>
@@ -259,11 +259,11 @@ if(("EXPORT").equals(action)) {
     			tableName_<%=cid%> = "tmp_<%=cid%>" + "_" +pid + Thread.currentThread().getId();
     			java.sql.Statement stmtTmpDrop_<%=cid%> = conn_<%=cid%>.createStatement();
     			<%if(isLog4jEnabled_tableAction){%>
-    				log.info("<%=cid%> - Droping temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
+    				log.debug("<%=cid%> - Droping temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
     			<%}%>
     			stmtTmpDrop_<%=cid%>.execute("<%=manager.getDropTableSQL()%>");
     			<%if(isLog4jEnabled_tableAction){%>
-    				log.info("<%=cid%> - Drop temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%>+ "<%=manager.getRProtectedChar()%> has succeeded.");
+    				log.debug("<%=cid%> - Drop temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%>+ "<%=manager.getRProtectedChar()%> has succeeded.");
     			<%}%>
     			stmtTmpDrop_<%=cid%>.close();
     			<%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMSSqlColumnList/tMSSqlColumnList_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMSSqlColumnList/tMSSqlColumnList_begin.javajet
@@ -63,7 +63,7 @@ imports="
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Query:'"+query_<%=cid %>+"'.");
+		log.debug("<%=cid%> - Query:'"+query_<%=cid %>+"'.");
 	<%
 	}
 	%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMSSqlTableList/tMSSqlTableList_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMSSqlTableList/tMSSqlTableList_begin.javajet
@@ -50,7 +50,7 @@ if(whereClause_<%=cid %> != null && whereClause_<%=cid %>.length() > 0){
 <%
 if(isLog4jEnabled){
 %>
-    log.info("<%=cid%> - Query:'"+query_<%=cid %>+"'.");
+    log.debug("<%=cid%> - Query:'"+query_<%=cid %>+"'.");
 <%
 }
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMomCommit/tMomCommit_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMomCommit/tMomCommit_main.javajet
@@ -39,7 +39,7 @@ imports="
 			if(isTransacted){
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Committing the session...");
+					log.debug("<%=cid%> - Committing the session...");
 				<%
 				}
 				%>
@@ -47,7 +47,7 @@ imports="
 				<%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Commit successfully.");
+					log.debug("<%=cid%> - Commit successfully.");
 				<%
 				}
 			}
@@ -57,7 +57,7 @@ imports="
 			    	<%
 			    	if (isLog4jEnabled) {
 					%>
-						log.info("<%=cid%> - Closing producer...");
+						log.debug("<%=cid%> - Closing producer...");
 					<%
 					}
 					%>
@@ -65,7 +65,7 @@ imports="
 			    	<%
 					if (isLog4jEnabled) {
 					%>
-						log.info("<%=cid%> - Closed successfully.");
+						log.debug("<%=cid%> - Closed successfully.");
 					<%
 					}
 					%>
@@ -73,7 +73,7 @@ imports="
 			    <%
 			   	if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Closing connection...");
+					log.debug("<%=cid%> - Closing connection...");
 				<%
 				}
 			    %>
@@ -82,7 +82,7 @@ imports="
 				<% 
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Closed successfully.");
+					log.debug("<%=cid%> - Closed successfully.");
 				<%
 				}
 			}
@@ -96,7 +96,7 @@ imports="
 			<%
 			if (isLog4jEnabled) {
 			%>
-				log.info("<%=cid%> - Committing ...");
+				log.debug("<%=cid%> - Committing ...");
 			<%
 			}
 			%>
@@ -106,13 +106,13 @@ imports="
 			<%  
 			if (isLog4jEnabled) {
 			%>
-				log.info("<%=cid%> - Commit successfully.");
+				log.debug("<%=cid%> - Commit successfully.");
 			<%
 			}
 			if(close){
 			   	if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Closing connection...");
+					log.debug("<%=cid%> - Closing connection...");
 				<%
 				}
 			    %>
@@ -120,7 +120,7 @@ imports="
 				<% 
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Closed successfully.");
+					log.debug("<%=cid%> - Closed successfully.");
 				<%
 				}
 			}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMomConnection/tMomConnection_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMomConnection/tMomConnection_begin.javajet
@@ -114,8 +114,8 @@ class="MomConnection"
 			<%
 			if(isLog4jEnabled){
 			%>	
-				log.info("<%=cid%> - Created connection successfully.");
-				log.info("<%=cid%> - Activating the connection...");
+				log.debug("<%=cid%> - Created connection successfully.");
+				log.debug("<%=cid%> - Activating the connection...");
 			<%
 			}
 			%>
@@ -124,13 +124,13 @@ class="MomConnection"
 		    <%
 			if(isLog4jEnabled){
 			%>	
-				log.info("<%=cid%> - Activated successfully.");
+				log.debug("<%=cid%> - Activated successfully.");
 			<%
 			}
 		}
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Creating a session...");
+			log.debug("<%=cid%> - Creating a session...");
 		<%
 		}
 		%>
@@ -141,7 +141,7 @@ class="MomConnection"
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Created session successfully.");
+			log.debug("<%=cid%> - Created session successfully.");
 		<%
 		}
 	}else{	/***WebSphere MQ*****/

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMomInputLoop/tMomInputLoop_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMomInputLoop/tMomInputLoop_begin.javajet
@@ -131,7 +131,7 @@ imports="
 	            <%
 				if(isLog4jEnabled){
 				%>	
-					log.info("<%=cid%> - Get a connection from component: <%=connectionComponentName%> .");
+					log.debug("<%=cid%> - Get a connection from component: <%=connectionComponentName%> .");
 				<%
 				}
 				%>
@@ -139,7 +139,7 @@ imports="
 		        <%
 				if(isLog4jEnabled){
 				%>	
-					log.info("<%=cid%> - Activating the connection...");
+					log.debug("<%=cid%> - Activating the connection...");
 				<%
 				}
 				%>
@@ -147,8 +147,8 @@ imports="
 	            <%
 				if(isLog4jEnabled){
 				%>	
-					log.info("<%=cid%> - Activate successfully.");
-					log.info("<%=cid%> - Get a  session from component: <%=connectionComponentName%> .");
+					log.debug("<%=cid%> - Activate successfully.");
+					log.debug("<%=cid%> - Get a  session from component: <%=connectionComponentName%> .");
 				<%
 				}
 				%>
@@ -348,7 +348,7 @@ imports="
 				<%
 				if(isLog4jEnabled){
 				%>	
-					log.info("<%=cid%> - Attempt to create connection from URL: " + url_<%=cid %> + ".");
+					log.debug("<%=cid%> - Attempt to create connection from URL: " + url_<%=cid %> + ".");
 				<%
 				}
 				%>
@@ -376,8 +376,8 @@ imports="
 			}
 			if(isLog4jEnabled){
 			%>	
-				log.info("<%=cid%> - Created connection successfully.");
-				log.info("<%=cid%> - Activating the connection...");
+				log.debug("<%=cid%> - Created connection successfully.");
+				log.debug("<%=cid%> - Activating the connection...");
 			<%
 			}
 			%>
@@ -385,8 +385,8 @@ imports="
 			<%
 			if(isLog4jEnabled){
 			%>	
-				log.info("<%=cid%> - Activate successfully.");
-				log.info("<%=cid%> - Creating a session...");
+				log.debug("<%=cid%> - Activate successfully.");
+				log.debug("<%=cid%> - Creating a session...");
 			<%
 			}
 			%>
@@ -394,7 +394,7 @@ imports="
 			<%
 			if(isLog4jEnabled){
 			%>	
-				log.info("<%=cid%> - Created session successfully.");
+				log.debug("<%=cid%> - Created session successfully.");
 			<%
 			}
 			%>
@@ -432,8 +432,8 @@ imports="
 			if(("JBoss").equals(serverType) ){ 
 				if(isLog4jEnabled){
 				%>	
-					log.info("<%=cid%> - Ready to receive message.");
-					log.info("<%=cid%> - Waiting...");
+					log.debug("<%=cid%> - Ready to receive message.");
+					log.debug("<%=cid%> - Waiting...");
 				<%
 				}
 				%>					
@@ -451,7 +451,7 @@ imports="
 				if(("true").equals(kListen)){
 					if(isLog4jEnabled){
 					%>	
-						log.info("<%=cid%> - Listening to receive messages...");
+						log.debug("<%=cid%> - Listening to receive messages...");
 					<%
 					}
 					%>
@@ -469,8 +469,8 @@ imports="
 				}else if (useMax) {
 					if(isLog4jEnabled){
 					%>	
-						log.info("<%=cid%> - Listening to receive messages...");
-						log.info("<%=cid%> - Consume max message number:  " + <%=maxiumMessages %>);
+						log.debug("<%=cid%> - Listening to receive messages...");
+						log.debug("<%=cid%> - Consume max message number:  " + <%=maxiumMessages %>);
 					<%
 					}
 					%>
@@ -498,8 +498,8 @@ imports="
 				}else {
 					if(isLog4jEnabled){
 					%>	
-						log.info("<%=cid%> - Listening to receive messages...");
-						log.info("<%=cid%> - Listening time last for:  " + <%=receiveTimeOut%>*1000 + " ms, and then stop.");
+						log.debug("<%=cid%> - Listening to receive messages...");
+						log.debug("<%=cid%> - Listening time last for:  " + <%=receiveTimeOut%>*1000 + " ms, and then stop.");
 					<%
 					}
 					%>
@@ -654,7 +654,7 @@ imports="
 						<%
 						if(isLog4jEnabled){
 						%>	
-							log.info("<%=cid%> - Initing backout queue ...");
+							log.debug("<%=cid%> - Initing backout queue ...");
 						<%
 						}
 						%>
@@ -669,9 +669,9 @@ imports="
 						<%
 						if(isLog4jEnabled){
 						%>	
-							log.info("<%=cid%> - The backout queue of "+<%=queue%>+" is:"+backoutQName_<%=cid%>);
-							log.info("<%=cid%> - The threshold value of messages in "+<%=queue%>+" is:"+threshold_<%=cid%>);
-							log.info("<%=cid%> - Init backout queue successfully.");
+							log.debug("<%=cid%> - The backout queue of "+<%=queue%>+" is:"+backoutQName_<%=cid%>);
+							log.debug("<%=cid%> - The threshold value of messages in "+<%=queue%>+" is:"+threshold_<%=cid%>);
+							log.debug("<%=cid%> - Init backout queue successfully.");
 						<%
 						}
 						%>
@@ -703,8 +703,8 @@ imports="
 			}	
 			if(isLog4jEnabled){
 			%>	
-				log.info("<%=cid%> - Ready to receive message.");
-				log.info("<%=cid%> - Waiting...");
+				log.debug("<%=cid%> - Ready to receive message.");
+				log.debug("<%=cid%> - Waiting...");
 			<%
 			}
 			%>	

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMomInputLoop/tMomInputLoop_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMomInputLoop/tMomInputLoop_end.javajet
@@ -73,7 +73,7 @@
 			if("true".equals(kListen)){
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Sleepping time(<%=timeOut%>s)...");
+					log.debug("<%=cid%> - Sleepping time(<%=timeOut%>s)...");
 				<%
 				}
 				%>
@@ -97,7 +97,7 @@
 					<%
 					if (isLog4jEnabled) {
 					%>
-						log.info("<%=cid%> - Committing the session...");
+						log.debug("<%=cid%> - Committing the session...");
 					<%
 					}
 					%>
@@ -105,7 +105,7 @@
 					<%
 					if (isLog4jEnabled) {
 					%>
-						log.info("<%=cid%> - Commit successfully.");
+						log.debug("<%=cid%> - Commit successfully.");
 					<%
 					}
 					%>
@@ -124,7 +124,7 @@
 					<%
 					if (isLog4jEnabled) {
 					%>
-						log.info("<%=cid%> - Rollback operations...");
+						log.debug("<%=cid%> - Rollback operations...");
 					<%
 					}
 					%>
@@ -132,7 +132,7 @@
 					<%
 					if (isLog4jEnabled) {
 					%>
-						log.info("<%=cid%> - Rollback successfully.");
+						log.debug("<%=cid%> - Rollback successfully.");
 					<%
 					}
 					%>
@@ -158,7 +158,7 @@
 					<%
 					if(isLog4jEnabled){
 					%>	
-						log.info("<%=cid%> - Moving backout message to backout queue...");
+						log.debug("<%=cid%> - Moving backout message to backout queue...");
 					<%
 					}
 					%>
@@ -167,7 +167,7 @@
 					<%
 					if(isLog4jEnabled){
 					%>	
-						log.info("<%=cid%> - Moved successfully.");
+						log.debug("<%=cid%> - Moved successfully.");
 					<%
 					}
 					%>
@@ -202,7 +202,7 @@
 		%>
 		
 			<%if (isLog4jEnabled) {%>
-			log.info("<%=cid%> - Closing connection...");
+			log.debug("<%=cid%> - Closing connection...");
 			<%}%>
 		
 			<%
@@ -220,7 +220,7 @@
 	        }
 	        
 	        <%if (isLog4jEnabled) {%>
-			log.info("<%=cid%> - Closed successfully");
+			log.debug("<%=cid%> - Closed successfully");
 			<%}%>
 		
 		<%
@@ -228,7 +228,7 @@
 	} else if("JBoss".equals(serverType)){%>
 	
 		<%if (isLog4jEnabled) {%>
-		log.info("<%=cid%> - Closing connection...");
+		log.debug("<%=cid%> - Closing connection...");
 		<%}%>
 		
 		System.out.println("Closing connection");
@@ -246,7 +246,7 @@
         }
         
         <%if (isLog4jEnabled) {%>
-		log.info("<%=cid%> - Closed successfully.");
+		log.debug("<%=cid%> - Closed successfully.");
 		<%}%>
 		
 	<%} else {//websphere
@@ -259,7 +259,7 @@
 		
 		if (!isUseExistConnection && isLog4jEnabled && !isCommitRollback) {
 		%>
-		log.info("<%=cid%> - Disconnecting connection...");
+		log.debug("<%=cid%> - Disconnecting connection...");
 		<%
 		}
 		%>
@@ -275,11 +275,11 @@
 		%>
 		if(backoutQueue_<%=cid%>!=null){
 			<%if (isLog4jEnabled) {%>
-			log.info("<%=cid%> - Closing backout queue...");
+			log.debug("<%=cid%> - Closing backout queue...");
 			<%}%>
 			backoutQueue_<%=cid%>.close();
 			<%if (isLog4jEnabled) {%>
-			log.info("<%=cid%> - Closed successfully.");
+			log.debug("<%=cid%> - Closed successfully.");
 			<%}%>
 		}
 		<%
@@ -296,7 +296,7 @@
 		
 		if (!isUseExistConnection && isLog4jEnabled && !isCommitRollback) {
 		%>
-			log.info("<%=cid%> - Disconnected successfully.");
+			log.debug("<%=cid%> - Disconnected successfully.");
 		<%
 		}
 	}
@@ -304,7 +304,7 @@
 }
 
 <%if (isLog4jEnabled) {%>
-	log.info("<%=cid%> - Consumed messages count: "+ nb_line_<%=cid%> + " .");
+	log.debug("<%=cid%> - Consumed messages count: "+ nb_line_<%=cid%> + " .");
 <%}%>
 
 	globalMap.put("<%=cid %>_NB_LINE",nb_line_<%=cid %>);

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMomMessageIdList/tMomMessageIdList_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMomMessageIdList/tMomMessageIdList_begin.javajet
@@ -91,8 +91,8 @@ class="MomInput"
 			<%
 			if(isLog4jEnabled){
 			%>	
-				log.info("<%=cid%> - Ready to receive message.");
-				log.info("<%=cid%> - Waiting...");
+				log.debug("<%=cid%> - Ready to receive message.");
+				log.debug("<%=cid%> - Waiting...");
 			<%
 			}
 			%>
@@ -108,7 +108,7 @@ class="MomInput"
 				<%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Disconnecting connection...");
+					log.debug("<%=cid%> - Disconnecting connection...");
 				<%
 				}
 				%>
@@ -118,7 +118,7 @@ class="MomInput"
 	            <%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Disconnected successfully.");
+					log.debug("<%=cid%> - Disconnected successfully.");
 				<%
 				}
 	            %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMomMessageIdList/tMomMessageIdList_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMomMessageIdList/tMomMessageIdList_end.javajet
@@ -27,7 +27,7 @@ if(("WebSphere").equals(serverType)){
 	}
 	if (isLog4jEnabled) {
 	%>
-		log.info("<%=cid%> - Retrieved records count: "+ nb_line_<%=cid%> + " .");
+		log.debug("<%=cid%> - Retrieved records count: "+ nb_line_<%=cid%> + " .");
 	<%
 	}
 	%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMomOutput/tMomOutput_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMomOutput/tMomOutput_begin.javajet
@@ -101,7 +101,7 @@ class="MomInput"
         	<%
 			if(isLog4jEnabled){
 			%>	
-				log.info("<%=cid%> - Get a connection from component: <%=connectionComponentName%> .");
+				log.debug("<%=cid%> - Get a connection from component: <%=connectionComponentName%> .");
 			<%
 			}
 			%>
@@ -109,7 +109,7 @@ class="MomInput"
 	        <%
 			if(isLog4jEnabled){
 			%>	
-				log.info("<%=cid%> - Activating the connection...");
+				log.debug("<%=cid%> - Activating the connection...");
 			<%
 			}
 			%>
@@ -117,8 +117,8 @@ class="MomInput"
             <%
 			if(isLog4jEnabled){
 			%>	
-				log.info("<%=cid%> - Activate successfully.");
-				log.info("<%=cid%> - Get a  session from component: <%=connectionComponentName%> .");
+				log.debug("<%=cid%> - Activate successfully.");
+				log.debug("<%=cid%> - Get a  session from component: <%=connectionComponentName%> .");
 			<%
 			}
 			%>
@@ -239,7 +239,7 @@ class="MomInput"
 			<%
 			if(isLog4jEnabled){
 			%>	
-				log.info("<%=cid%> - Attempt to create connection from URL: " + url_<%=cid %> + ".");
+				log.debug("<%=cid%> - Attempt to create connection from URL: " + url_<%=cid %> + ".");
 			<%
 			}
 			%>
@@ -269,8 +269,8 @@ class="MomInput"
 		} 
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Created connection successfully.");
-			log.info("<%=cid%> - Activating the connection...");
+			log.debug("<%=cid%> - Created connection successfully.");
+			log.debug("<%=cid%> - Activating the connection...");
 		<%
 		}
 		%>
@@ -278,8 +278,8 @@ class="MomInput"
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Activate successfully.");
-			log.info("<%=cid%> - Creating a session...");
+			log.debug("<%=cid%> - Activate successfully.");
+			log.debug("<%=cid%> - Creating a session...");
 		<%
 		}
 		%>
@@ -287,7 +287,7 @@ class="MomInput"
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Created session successfully.");
+			log.debug("<%=cid%> - Created session successfully.");
 		<%
 		}
 		%>
@@ -325,7 +325,7 @@ class="MomInput"
 		}
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Start to produce " + (<%=!("Queue").equals(msgType)%> ? "topic" : "queue") + ": " + <%=to %>);
+			log.debug("<%=cid%> - Start to produce " + (<%=!("Queue").equals(msgType)%> ? "topic" : "queue") + ": " + <%=to %>);
 		<%
 		}
 	} else if(("WebSphere").equals(serverType)){ //server judgement   /***WebSphere MQ*****/
@@ -374,13 +374,13 @@ class="MomInput"
 			<%
 			if(isLog4jEnabled){
 			%>	
-			log.info("<%=cid%> - Created successfully.");
+			log.debug("<%=cid%> - Created successfully.");
 			<%
 			}
 		}
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Creating queue instance for queue: "+<%=queue%>+"...");
+			log.debug("<%=cid%> - Creating queue instance for queue: "+<%=queue%>+"...");
 		<%
 		}
 		%>
@@ -388,7 +388,7 @@ class="MomInput"
 	    <%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Created successfully.");
+			log.debug("<%=cid%> - Created successfully.");
 		<%
 		}
 		%>
@@ -401,7 +401,7 @@ class="MomInput"
 	    }
 	    if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Start to produce queue: " + <%=queue%>);
+			log.debug("<%=cid%> - Start to produce queue: " + <%=queue%>);
 		<%
 		}
 	}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMomOutput/tMomOutput_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMomOutput/tMomOutput_end.javajet
@@ -56,7 +56,7 @@ if(("JBoss").equals(serverType) || ("ActiveMQ").equals(serverType)){
 		if(!isCommitRollback && transacted){
 			if (isLog4jEnabled) {
 			%>
-				log.info("<%=cid%> - Committing the session...");
+				log.debug("<%=cid%> - Committing the session...");
 			<%
 			}
 			%>
@@ -64,14 +64,14 @@ if(("JBoss").equals(serverType) || ("ActiveMQ").equals(serverType)){
 			<%
 			if (isLog4jEnabled) {
 			%>
-				log.info("<%=cid%> - Commit successfully.");
+				log.debug("<%=cid%> - Commit successfully.");
 			<%
 			}
 		}
         if (!isCommitRollback && !isUseExistConnection) {
         	if (isLog4jEnabled) {
 			%>
-				log.info("<%=cid%> - Closing connection...");
+				log.debug("<%=cid%> - Closing connection...");
 			<%
 			}
 			%> // if no commmit or rollback component exists - close session
@@ -81,12 +81,12 @@ if(("JBoss").equals(serverType) || ("ActiveMQ").equals(serverType)){
 			<%	
 			if (isLog4jEnabled) {
 			%>
-				log.info("<%=cid%> - Closed successfully.");
+				log.debug("<%=cid%> - Closed successfully.");
 			<%
 			}
             if (isLog4jEnabled) {
             %>
-                log.info("<%=cid%> - Closing producer...");
+                log.debug("<%=cid%> - Closing producer...");
             <%
             }
             %>
@@ -94,7 +94,7 @@ if(("JBoss").equals(serverType) || ("ActiveMQ").equals(serverType)){
             <%
             if (isLog4jEnabled) {
             %>
-                log.info("<%=cid%> - Closed successfully.");
+                log.debug("<%=cid%> - Closed successfully.");
             <%
             }
 		}
@@ -112,7 +112,7 @@ if(("JBoss").equals(serverType) || ("ActiveMQ").equals(serverType)){
 	} else {
 		if (!isUseExistConnection && isLog4jEnabled && !isCommitRollback) {
 		%>
-			log.info("<%=cid%> - Disconnecting connection...");
+			log.debug("<%=cid%> - Disconnecting connection...");
 		<%
 		}
 		%>
@@ -127,14 +127,14 @@ if(("JBoss").equals(serverType) || ("ActiveMQ").equals(serverType)){
 		}
 		if (!isUseExistConnection && isLog4jEnabled && !isCommitRollback) {
 		%>
-			log.info("<%=cid%> - Disconnected successfully.");
+			log.debug("<%=cid%> - Disconnected successfully.");
 		<%
 		}
 	}
 }
 if (isLog4jEnabled) {
 %>
-	log.info("<%=cid%> - Written records count: "+ nb_line_<%=cid%> + " .");
+	log.debug("<%=cid%> - Written records count: "+ nb_line_<%=cid%> + " .");
 <%
 }
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMomRollback/tMomRollback_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMomRollback/tMomRollback_main.javajet
@@ -41,7 +41,7 @@ imports="
 			<%
 			if (isLog4jEnabled) {
 			%>
-				log.info("<%=cid%> - Rollback operations...");
+				log.debug("<%=cid%> - Rollback operations...");
 			<%
 			}
 			%>
@@ -49,7 +49,7 @@ imports="
 			<%  
 			if (isLog4jEnabled) {
 			%>
-				log.info("<%=cid%> - Rollback successfully.");
+				log.debug("<%=cid%> - Rollback successfully.");
 			<%
 			}
 			if(close){
@@ -58,7 +58,7 @@ imports="
 					<%
 			    	if (isLog4jEnabled) {
 					%>
-						log.info("<%=cid%> - Closing producer...");
+						log.debug("<%=cid%> - Closing producer...");
 					<%
 					}
 					%>
@@ -66,7 +66,7 @@ imports="
 					<%
 					if (isLog4jEnabled) {
 					%>
-						log.info("<%=cid%> - Closed successfully.");
+						log.debug("<%=cid%> - Closed successfully.");
 					<%
 					}
 					%> 
@@ -74,7 +74,7 @@ imports="
 				<%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Closing connection...");
+					log.debug("<%=cid%> - Closing connection...");
 				<%
 				}
 				%>
@@ -83,7 +83,7 @@ imports="
 				<% 
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Closed successfully.");
+					log.debug("<%=cid%> - Closed successfully.");
 				<%
 				}
 			}
@@ -134,7 +134,7 @@ imports="
 						<%
 						if(isLog4jEnabled){
 						%>	
-							log.info("<%=cid%> - Initing backout queue ...");
+							log.debug("<%=cid%> - Initing backout queue ...");
 						<%
 						}
 						%>
@@ -149,9 +149,9 @@ imports="
 						<%
 						if(isLog4jEnabled){
 						%>	
-							log.info("<%=cid%> - The backout queue of "+this.inQueuename+" is:"+backoutQName);
-							log.info("<%=cid%> - The threshold value of messages in "+this.inQueuename+" is:"+this.threshold);
-							log.info("<%=cid%> - Init backout queue successfully.");
+							log.debug("<%=cid%> - The backout queue of "+this.inQueuename+" is:"+backoutQName);
+							log.debug("<%=cid%> - The threshold value of messages in "+this.inQueuename+" is:"+this.threshold);
+							log.debug("<%=cid%> - Init backout queue successfully.");
 						<%
 						}
 						%>
@@ -239,7 +239,7 @@ imports="
 							<%
 							if(isLog4jEnabled){
 							%>	
-								log.info("<%=cid%> - Moving backout message to backout queue...");
+								log.debug("<%=cid%> - Moving backout message to backout queue...");
 							<%
 							}
 							%>
@@ -247,7 +247,7 @@ imports="
 							<%
 							if(isLog4jEnabled){
 							%>	
-								log.info("<%=cid%> - Moved successfully.");
+								log.debug("<%=cid%> - Moved successfully.");
 							<%
 							}
 							%>
@@ -255,7 +255,7 @@ imports="
 						<%
 						if(isLog4jEnabled){
 						%>	
-							log.info("<%=cid%> - Closing backout backout queue:"+(backoutQueue.name)+"...");
+							log.debug("<%=cid%> - Closing backout backout queue:"+(backoutQueue.name)+"...");
 						<%
 						}
 						%>
@@ -263,7 +263,7 @@ imports="
 						<%
 						if(isLog4jEnabled){
 						%>	
-							log.info("<%=cid%> - Closed successfully.");
+							log.debug("<%=cid%> - Closed successfully.");
 						<%
 						}
 						%>
@@ -271,7 +271,7 @@ imports="
 							<%
 							if(isLog4jEnabled){
 							%>	
-								log.info("<%=cid%> - Closing input queue:"+inQueueName+"...");
+								log.debug("<%=cid%> - Closing input queue:"+inQueueName+"...");
 							<%
 							}
 							%>
@@ -279,7 +279,7 @@ imports="
 							<%
 							if(isLog4jEnabled){
 							%>	
-								log.info("<%=cid%> - Closed successfully.");
+								log.debug("<%=cid%> - Closed successfully.");
 							<%
 							}
 							%>
@@ -336,7 +336,7 @@ imports="
 			if(close){
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Closing connection...");
+					log.debug("<%=cid%> - Closing connection...");
 				<%
 				}
 				%>
@@ -344,7 +344,7 @@ imports="
 				<% 
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Closed successfully.");
+					log.debug("<%=cid%> - Closed successfully.");
 				<%
 				}
 			}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMysqlBulkExec/tMysqlBulkExec_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMysqlBulkExec/tMysqlBulkExec_begin.javajet
@@ -153,15 +153,15 @@ if(("UPDATE").equals(dataAction)) {
 		tableName_<%=cid%> = "tmp_<%=cid%>" + "_" + pid + Thread.currentThread().getId();
 		java.sql.Statement stmtTmpCreate_<%=cid%> = conn_<%=cid%>.createStatement();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Creating temp table " + tableName_<%=cid%> + "." );
+			log.debug("<%=cid%> - Creating temp table " + tableName_<%=cid%> + "." );
 		<%}%>
 		stmtTmpCreate_<%=cid%>.execute("<%=manager.getCreateTableSQL(stmtStructure)%>)");
 		stmtTmpCreate_<%=cid%>.close();
 
 		java.sql.Statement stmtTmpBulk_<%=cid %> = conn_<%=cid %>.createStatement();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Create temp table " + tableName_<%=cid%> + " has succeeded.");
-			log.info("<%=cid%> - Bulk inserting data into " + tableName_<%=cid%> + "." );
+			log.debug("<%=cid%> - Create temp table " + tableName_<%=cid%> + " has succeeded.");
+			log.debug("<%=cid%> - Bulk inserting data into " + tableName_<%=cid%> + "." );
 		<%}%>
 		stmtTmpBulk_<%=cid %>.execute("SET character_set_database=" + charset_<%=cid %>);
 		stmtTmpBulk_<%=cid %>.execute(
@@ -191,13 +191,13 @@ if(("UPDATE").equals(dataAction)) {
 %>
 		);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Bulk insert data into " + tableName_<%=cid%> + " has finished.");
+			log.debug("<%=cid%> - Bulk insert data into " + tableName_<%=cid%> + " has finished.");
 		<%}%>
 		tableName_<%=cid%> = <%=table%>;
 		String tmpTableName_<%=cid%> = "tmp_<%=cid%>" + "_" + pid + Thread.currentThread().getId();
 		java.sql.Statement stmtUpdateBulk_<%=cid%> = conn_<%=cid%>.createStatement();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Updating " + tableName_<%=cid%> + " from "+tmpTableName_<%=cid%>+".");
+			log.debug("<%=cid%> - Updating " + tableName_<%=cid%> + " from "+tmpTableName_<%=cid%>+".");
 		<%}%>
 		stmtUpdateBulk_<%=cid%>.executeUpdate("<%=manager.getUpdateBulkSQL(columnList)%>");
 		<%log4jCodeGenerateUtil.logInfo(node,"info",cid+" - Update has finished.");%>
@@ -205,12 +205,12 @@ if(("UPDATE").equals(dataAction)) {
 		tableName_<%=cid%> = tmpTableName_<%=cid%>;
 		java.sql.Statement stmtTmpDrop_<%=cid%> = conn_<%=cid%>.createStatement();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Droping temp table " + tableName_<%=cid%> + ".");
+			log.debug("<%=cid%> - Droping temp table " + tableName_<%=cid%> + ".");
 		<%}%>
 		stmtTmpDrop_<%=cid%>.execute("<%=manager.getDropTableSQL()%>");
 		stmtTmpDrop_<%=cid%>.close();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Drop temp table " + tableName_<%=cid%>+ " has succeeded.");
+			log.debug("<%=cid%> - Drop temp table " + tableName_<%=cid%>+ " has succeeded.");
 		<%}%>
 		<%
 	}
@@ -219,21 +219,21 @@ if(("UPDATE").equals(dataAction)) {
 %>
 		replace_<%=cid%> = "REPLACE";
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Replacing records in table " + tableName_<%=cid%> + ".");
+			log.debug("<%=cid%> - Replacing records in table " + tableName_<%=cid%> + ".");
 		<%}%>
 <%
 	} else if (("IGNORE").equals(dataAction)) {
 %>
 		replace_<%=cid%> = "IGNORE";
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Loading data ignore records in table " + tableName_<%=cid%> + ".");
+			log.debug("<%=cid%> - Loading data ignore records in table " + tableName_<%=cid%> + ".");
 		<%}%>
 <%
 	} else {
 %>
 		replace_<%=cid%> = "";
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Inserting records in table " + tableName_<%=cid%> + ".");
+			log.debug("<%=cid%> - Inserting records in table " + tableName_<%=cid%> + ".");
 		<%}%>
 <%
 	}
@@ -271,15 +271,15 @@ if(("UPDATE").equals(dataAction)) {
 	<%if(isLog4jEnabled){
 		if(("REPLACE").equals(dataAction)) {
 		%>
-			log.info("<%=cid%> - Replace records in table " + tableName_<%=cid%> + " has finished.");
+			log.debug("<%=cid%> - Replace records in table " + tableName_<%=cid%> + " has finished.");
 		<%
 		} else if (("IGNORE").equals(dataAction)) {
 		%>
-			log.info("<%=cid%> - Load data ignore records in table " + tableName_<%=cid%> + " has finished.");
+			log.debug("<%=cid%> - Load data ignore records in table " + tableName_<%=cid%> + " has finished.");
 		<%
 		} else {
 		%>
-			log.info("<%=cid%> - Insert records in table " + tableName_<%=cid%> + " has finished.");
+			log.debug("<%=cid%> - Insert records in table " + tableName_<%=cid%> + " has finished.");
 		<%
 		}
 		%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMysqlColumnList/tMysqlColumnList_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMysqlColumnList/tMysqlColumnList_begin.javajet
@@ -32,7 +32,7 @@ String query_<%=cid %> = "SELECT column_name,data_type,column_default,is_nullabl
 <%
 if(isLog4jEnabled){
 %>
-    log.info("<%=cid%> - Query:'"+query_<%=cid %>+"'.");
+    log.debug("<%=cid%> - Query:'"+query_<%=cid %>+"'.");
 <%
 }
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMysqlSP/tMysqlSP_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMysqlSP/tMysqlSP_main.javajet
@@ -212,11 +212,11 @@ if (canGenerate) {
 			}
 		}
 		
-		dbLog.info(dbLog.str("Try to execute store procedure:"),spName,dbLog.str("."));
+		dblog.debug(dbLog.str("Try to execute store procedure:"),spName,dbLog.str("."));
 		%>
 		statement_<%=cid%>.execute();
 		<%
-		dbLog.info(dbLog.str("The store procedure:"),spName,dbLog.str(" executed successfully."));
+		dblog.debug(dbLog.str("The store procedure:"),spName,dbLog.str(" executed successfully."));
 		
 		List<? extends IConnection> outConnections = node.getOutgoingConnections();
 		IConnection firstOutConnection = null;

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMysqlTableList/tMysqlTableList_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMysqlTableList/tMysqlTableList_begin.javajet
@@ -41,7 +41,7 @@ if(whereClause_<%=cid %> != null && whereClause_<%=cid %>.length() > 0){
 <%
 if(isLog4jEnabled){
 %>
-    log.info("<%=cid%> - Query:'"+query_<%=cid %>+"'.");
+    log.debug("<%=cid%> - Query:'"+query_<%=cid %>+"'.");
 <%
 }
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tNetezzaBulkExec/tNetezzaBulkExec_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tNetezzaBulkExec/tNetezzaBulkExec_begin.javajet
@@ -98,13 +98,13 @@ String skiprows = ElementParameterParser.getValue(node, "__SKIPROWS__");
 %>
 	<%if(isLog4jEnabled){%>
 		log.debug("<%=cid%> - Bulk SQL:"+bulkSQL_<%=cid%>+".");
-		log.info("<%=cid%> - Bulk inserting data into " + <%= table %> + "." );
+		log.debug("<%=cid%> - Bulk inserting data into " + <%= table %> + "." );
 	<%}%>
     java.sql.Statement stmtBulk_<%=cid %> = conn_<%=cid %>.createStatement();
     stmtBulk_<%=cid %>.execute(bulkSQL_<%=cid%>);
     stmtBulk_<%=cid %>.close();
     <%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Bulk insert data into " + <%= table %> + " has finished.");
+		log.debug("<%=cid%> - Bulk insert data into " + <%= table %> + " has finished.");
 	<%}%>
 <%
 if(!useExistingConnection) {

--- a/main/plugins/org.talend.designer.components.localprovider/components/tNetezzaNzLoad/tNetezzaNzLoad_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tNetezzaNzLoad/tNetezzaNzLoad_begin.javajet
@@ -139,22 +139,22 @@ skeleton="../templates/db_output_bulk.skeleton"
             %>
 			java.sql.Statement stmtDrop_<%=cid%> = conn_<%=cid%>.createStatement();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Droping table '" + tableName_<%=cid%> + "'.");
+				log.debug("<%=cid%> - Droping table '" + tableName_<%=cid%> + "'.");
 			<%}%>
 			stmtDrop_<%=cid%>.execute("<%=manager.getDropTableSQL()%>");
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Drop table '" + tableName_<%=cid%> + "' has succeeded.");
+				log.debug("<%=cid%> - Drop table '" + tableName_<%=cid%> + "' has succeeded.");
 			<%}%>
 			stmtDrop_<%=cid%>.close();
 			java.sql.Statement stmtCreate_<%=cid%> =  null;
 			try{
 				stmtCreate_<%=cid%> = conn_<%=cid%>.createStatement();
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Creating table '" + tableName_<%=cid%> + "'.");
+					log.debug("<%=cid%> - Creating table '" + tableName_<%=cid%> + "'.");
 				<%}%>
 				stmtCreate_<%=cid%>.execute("<%=manager.getCreateTableSQL(stmtStructure)%>)");
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Create table '" + tableName_<%=cid%> + "' has succeeded.");
+					log.debug("<%=cid%> - Create table '" + tableName_<%=cid%> + "' has succeeded.");
 				<%}%>
 				stmtCreate_<%=cid%>.close();
 			}catch(java.sql.SQLException e){
@@ -169,11 +169,11 @@ skeleton="../templates/db_output_bulk.skeleton"
 			try{
 				stmtCreate_<%=cid%> = conn_<%=cid%>.createStatement();
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Creating table '" + tableName_<%=cid%> + "'.");
+					log.debug("<%=cid%> - Creating table '" + tableName_<%=cid%> + "'.");
 				<%}%>
 				stmtCreate_<%=cid%>.execute("<%=manager.getCreateTableSQL(stmtStructure)%>)");
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Create table '" + tableName_<%=cid%> + "' has succeeded.");
+					log.debug("<%=cid%> - Create table '" + tableName_<%=cid%> + "' has succeeded.");
 				<%}%>
 				stmtCreate_<%=cid%>.close();
 			}catch(java.sql.SQLException e){
@@ -207,11 +207,11 @@ skeleton="../templates/db_output_bulk.skeleton"
 					try{
 						stmtCreate_<%=cid%> = conn_<%=cid%>.createStatement();
 						<%if(isLog4jEnabled){%>
-							log.info("<%=cid%> - Creating table '" + tableName_<%=cid%>+"'.");
+							log.debug("<%=cid%> - Creating table '" + tableName_<%=cid%>+"'.");
 						<%}%>
 						stmtCreate_<%=cid%>.execute("<%=manager.getCreateTableSQL(stmtStructure)%>)");
 						<%if(isLog4jEnabled){%>
-							log.info("<%=cid%> - Create table " + tableName_<%=cid%> + "' has succeeded. ");
+							log.debug("<%=cid%> - Create table " + tableName_<%=cid%> + "' has succeeded. ");
 						<%}%> 
 						stmtCreate_<%=cid%>.close();
 					}catch(java.sql.SQLException e){
@@ -234,11 +234,11 @@ skeleton="../templates/db_output_bulk.skeleton"
                     try{
                     	stmtDrop_<%=cid%> = conn_<%=cid%>.createStatement();
 						<%if(isLog4jEnabled){%>
-							log.info("<%=cid%> - Droping table '" + tableName_<%=cid%> + "'.");
+							log.debug("<%=cid%> - Droping table '" + tableName_<%=cid%> + "'.");
 						<%}%>
                     	stmtDrop_<%=cid%>.execute("<%=manager.getDropTableSQL()%>");
 						<%if(isLog4jEnabled){%>
-							log.info("<%=cid%> - Drop table '" + tableName_<%=cid%> + "' has succeeded.");
+							log.debug("<%=cid%> - Drop table '" + tableName_<%=cid%> + "' has succeeded.");
 						<%}%>
 						stmtDrop_<%=cid%>.close();
                     }catch(java.sql.SQLException e){
@@ -257,11 +257,11 @@ skeleton="../templates/db_output_bulk.skeleton"
                 try{
                 stmtCreate_<%=cid%> = conn_<%=cid%>.createStatement();
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Creating table '" + tableName_<%=cid%>+"'.");
+					log.debug("<%=cid%> - Creating table '" + tableName_<%=cid%>+"'.");
 				<%}%>
                 stmtCreate_<%=cid%>.execute("<%=manager.getCreateTableSQL(stmtStructure)%>)");           
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Drop table '" + tableName_<%=cid%> + "' has succeeded.");
+					log.debug("<%=cid%> - Drop table '" + tableName_<%=cid%> + "' has succeeded.");
 				<%}%>
 				stmtCreate_<%=cid%>.close();
                 }catch(java.sql.SQLException e){
@@ -282,11 +282,11 @@ skeleton="../templates/db_output_bulk.skeleton"
             java.sql.ResultSet rsClearCount_<%=cid%> = stmtClearCount_<%=cid%>.executeQuery("<%=manager.getSelectionSQL()%>");
             java.sql.Statement stmtClear_<%=cid%> = conn_<%=cid%>.createStatement();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Truncating table '" + tableName_<%=cid%> + "'.");
+				log.debug("<%=cid%> - Truncating table '" + tableName_<%=cid%> + "'.");
 			<%}%>
             stmtClear_<%=cid%>.executeUpdate("<%=manager.getTruncateTableSQL()%>");
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Truncate table '" + tableName_<%=cid%> + "' has succeeded.");
+				log.debug("<%=cid%> - Truncate table '" + tableName_<%=cid%> + "' has succeeded.");
 			<%}%>
             while(rsClearCount_<%=cid%>.next()) {
                 deletedCount_<%=cid%> = rsClearCount_<%=cid%>.getInt(1);
@@ -300,11 +300,11 @@ skeleton="../templates/db_output_bulk.skeleton"
             try{
             	stmtClear_<%=cid%> = conn_<%=cid%>.createStatement();
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Clearing table '" + tableName_<%=cid%> + "'.");
+					log.debug("<%=cid%> - Clearing table '" + tableName_<%=cid%> + "'.");
 				<%}%>
             	deletedCount_<%=cid%> = stmtClear_<%=cid%>.executeUpdate("<%=manager.getDeleteTableSQL()%>");
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Clear table '" + tableName_<%=cid%> + "' has succeeded.");
+					log.debug("<%=cid%> - Clear table '" + tableName_<%=cid%> + "' has succeeded.");
 				<%}%>
             	stmtClear_<%=cid%>.close();
             }catch(java.sql.SQLException e){
@@ -463,13 +463,13 @@ skeleton="../templates/db_output_bulk.skeleton"
 	} else { // no input connections
 %>
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Executing '"+command_<%=cid %>.toString()+"'.");
+			log.debug("<%=cid%> - Executing '"+command_<%=cid %>.toString()+"'.");
 		<%}%>
 		nzloadThread_<%=cid%>.start();
 		nzloadThread_<%=cid%>.join(0);
 		globalMap.put("<%=cid%>_NZLOAD_OUTPUT", nzloadOutput_<%=cid%>.toString());
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Execute '"+command_<%=cid %>.toString()+"' has finished.");
+			log.debug("<%=cid%> - Execute '"+command_<%=cid %>.toString()+"' has finished.");
 		<%}%>
 <%
 	}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tNetezzaNzLoad/tNetezzaNzLoad_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tNetezzaNzLoad/tNetezzaNzLoad_end.javajet
@@ -74,7 +74,7 @@ skeleton="../templates/db_output_bulk.skeleton"
 		outputStream_<%=cid%>.flush();
 		outputStream_<%=cid%>.close();
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Executing '"+command_<%=cid %>.toString()+"'");
+					log.debug("<%=cid%> - Executing '"+command_<%=cid %>.toString()+"'");
 				<%}%>
 	<%
 		if (useNamedPiped) { // wait for nzload thread to finish
@@ -89,7 +89,7 @@ skeleton="../templates/db_output_bulk.skeleton"
 			<%
 		}
 				if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Execute '"+command_<%=cid %>.toString()+"' has finished.");
+					log.debug("<%=cid%> - Execute '"+command_<%=cid %>.toString()+"' has finished.");
 				<%}
 	}
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tOracleBulkExec/tOracleBulkExec_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tOracleBulkExec/tOracleBulkExec_begin.javajet
@@ -599,13 +599,13 @@ if(("UPDATE").equals(data_action)) {
     try{
     java.sql.Statement stmtCreateTmp_<%=cid%> = conn_<%=cid%>.createStatement();
     <%if(isLog4jEnabled){%>
-        log.info("<%=cid%> - Creating temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
+        log.debug("<%=cid%> - Creating temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
     <%}%>
     stmtCreateTmp_<%=cid%>.execute("<%=manager.getCreateTableSQL(stmtStructure)%>)");
     stmtCreateTmp_<%=cid%>.close();
         <%if(isLog4jEnabled){%>
-        log.info("<%=cid%> - Create temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
-        log.info("<%=cid%> - Executing command:'" + printableCommand + "'.");
+        log.debug("<%=cid%> - Create temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
+        log.debug("<%=cid%> - Executing command:'" + printableCommand + "'.");
     <%}%>
     <%
     }
@@ -655,7 +655,7 @@ if(("UPDATE").equals(data_action)) {
     }
     if(isLog4jEnabled){
     %>
-        log.info("<%=cid%> - Executing command:'" + printableCommand + "'.");
+        log.debug("<%=cid%> - Executing command:'" + printableCommand + "'.");
     <%
     }
 %>
@@ -744,8 +744,8 @@ if ("true".equals((String)globalMap.get("<%=cid%>_SQLLOAD_ERROR"))) {
 <%
 if(isLog4jEnabled){
 %>
-    log.info("<%=cid%> - Excute command: '" + printableCommand + "' has finished.");
-    log.info("<%=cid%> - Retrieving information from oracle log file: '" + logf_<%=cid %> + "'.");
+    log.debug("<%=cid%> - Excute command: '" + printableCommand + "' has finished.");
+    log.debug("<%=cid%> - Retrieving information from oracle log file: '" + logf_<%=cid %> + "'.");
 <%
 }
 %>
@@ -881,10 +881,10 @@ globalMap.put("<%=cid %>_RETURN_CODE", exitCode_<%=cid%>);
 <%
 if(isLog4jEnabled){
 %>
-    log.info("<%=cid%> - Retrieved number of line: " + nb_line_data_<%=cid %> + ".");
-    log.info("<%=cid%> - Retrieved number of bad line: " + nb_line_bad_<%=cid %> + ".");
-    log.info("<%=cid%> - Retrieved number of inserted line: " + nb_line_inserted_<%=cid %> + ".");
-    log.info("<%=cid%> - Retrieved information from oracle log file: '" + logf_<%=cid %> + "' finish.");
+    log.debug("<%=cid%> - Retrieved number of line: " + nb_line_data_<%=cid %> + ".");
+    log.debug("<%=cid%> - Retrieved number of bad line: " + nb_line_bad_<%=cid %> + ".");
+    log.debug("<%=cid%> - Retrieved number of inserted line: " + nb_line_inserted_<%=cid %> + ".");
+    log.debug("<%=cid%> - Retrieved information from oracle log file: '" + logf_<%=cid %> + "' finish.");
 <%
 }
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tOracleBulkExec/tOracleBulkExec_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tOracleBulkExec/tOracleBulkExec_end.javajet
@@ -31,7 +31,7 @@ if(("UPDATE").equals(dataAction)) {
         tmpTableName_<%=cid%> = uniqueTableName_<%=cid%>;
         java.sql.Statement stmtUpdateBulk_<%=cid%> = conn_<%=cid%>.createStatement();
         <%if(isLog4jEnabled){%>
-            log.info("<%=cid%> - Updating <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> from <%=manager.getLProtectedChar()%>"+tmpTableName_<%=cid%>+"<%=manager.getRProtectedChar()%>.");
+            log.debug("<%=cid%> - Updating <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> from <%=manager.getLProtectedChar()%>"+tmpTableName_<%=cid%>+"<%=manager.getRProtectedChar()%>.");
         <%}%>
         stmtUpdateBulk_<%=cid%>.executeUpdate("<%=manager.getUpdateBulkSQL(columnList)%>");
         <%log4jCodeGenerateUtil.logInfo(node,"info",cid+" - Update has finished.");%>
@@ -40,11 +40,11 @@ if(("UPDATE").equals(dataAction)) {
         tableName_<%=cid%> = uniqueTableName_<%=cid%>;
         java.sql.Statement stmtTmpDrop_<%=cid%> = conn_<%=cid%>.createStatement();
         <%if(isLog4jEnabled){%>
-            log.info("<%=cid%> - Droping table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
+            log.debug("<%=cid%> - Droping table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
         <%}%>
         stmtTmpDrop_<%=cid%>.execute("<%=manager.getDropTableSQL()%>");
         <%if(isLog4jEnabled){%>
-            log.info("<%=cid%> - Drop table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
+            log.debug("<%=cid%> - Drop table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
         <%}%>
         stmtTmpDrop_<%=cid%>.close();         
     }

--- a/main/plugins/org.talend.designer.components.localprovider/components/tOracleTableList/tOracleTableList_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tOracleTableList/tOracleTableList_begin.javajet
@@ -79,7 +79,7 @@ if("USER_TABLES".equals(fetch_from) || "ALL_TABLES".equals(fetch_from)) {
 <%
 if(isLog4jEnabled){
 %>
-    log.info("<%=cid%> - Query:'"+query_<%=cid %>+"'.");
+    log.debug("<%=cid%> - Query:'"+query_<%=cid %>+"'.");
 <%
 }
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPOP/tPOP_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPOP/tPOP_begin.javajet
@@ -79,11 +79,11 @@ boolean isNewerEmailFirst = ("true").equals(ElementParameterParser.getValue(node
   		session_<%=cid %> = javax.mail.Session.getInstance(props_<%=cid %>, null);
   		store_<%=cid %> = session_<%=cid %>.getStore("<%=protocol%>");
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection attempt to '" + server_<%=cid %> + "' as '" + user_<%=cid %> + "'.");
+			log.debug("<%=cid%> - Connection attempt to '" + server_<%=cid %> + "' as '" + user_<%=cid %> + "'.");
 		<%}%>
   		store_<%=cid %>.connect(server_<%=cid %>, port_<%=cid %>, user_<%=cid %>, password_<%=cid %>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection to '" + server_<%=cid %> + "' has succeeded.");
+			log.debug("<%=cid%> - Connection to '" + server_<%=cid %> + "' has succeeded.");
 		<%}%>
   		folder_<%=cid %> = store_<%=cid %>.getDefaultFolder();
 
@@ -108,11 +108,11 @@ boolean isNewerEmailFirst = ("true").equals(ElementParameterParser.getValue(node
 		session_<%=cid %> = javax.mail.Session.getInstance(props_<%=cid %>, null);
 		store_<%=cid %> = new com.sun.mail.imap.IMAPStore(session_<%=cid %>, url_<%=cid %>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection attempt to '" + server_<%=cid %> + "' as '" + user_<%=cid %> + "'.");
+			log.debug("<%=cid%> - Connection attempt to '" + server_<%=cid %> + "' as '" + user_<%=cid %> + "'.");
 		<%}%>
   		store_<%=cid %>.connect();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection to '" + server_<%=cid %> + "' has succeeded.");
+			log.debug("<%=cid%> - Connection to '" + server_<%=cid %> + "' has succeeded.");
 		<%}%>
 		folder_<%=cid %> = store_<%=cid %>.getFolder(mbox_<%=cid%>);
 <%
@@ -137,7 +137,7 @@ boolean isNewerEmailFirst = ("true").equals(ElementParameterParser.getValue(node
 	
 
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Retrieving mails from server.");
+		log.debug("<%=cid%> - Retrieving mails from server.");
 	<%}%>
 	for (int counter_<%=cid %> = 0; counter_<%=cid %> < msgs_<%=cid %>.length; counter_<%=cid %>++) {
 		<%if ("false".equals(allEmails)) {%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPOP/tPOP_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPOP/tPOP_end.javajet
@@ -61,15 +61,15 @@
 
 	if (store_<%=cid %> != null) {
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Closing the connection to the server.");
+			log.debug("<%=cid%> - Closing the connection to the server.");
 		<%}%>
 		store_<%=cid %>.close();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection to the server closed.");
+			log.debug("<%=cid%> - Connection to the server closed.");
 		<%}%>
 	}
 	globalMap.put("<%=cid %>_NB_EMAIL", nb_email_<%=cid %>);  
 
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Retrived "+nb_email_<%=cid %> + " mails.");
+		log.debug("<%=cid%> - Retrived "+nb_email_<%=cid %> + " mails.");
 	<%}%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPaloCheckElements/tPaloCheckElements_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPaloCheckElements/tPaloCheckElements_begin.javajet
@@ -49,7 +49,7 @@
 		pConn_<%=cid %> =  (org.talend.jpalo.paloconnection)globalMap.get("<%=pConn%>");
 		<%if(isLog4jEnabled){%>
 			if(pConn_<%=cid %>!=null) {
-				log.info("<%=cid%> - Uses an existing connection.");  
+				log.debug("<%=cid%> - Uses an existing connection.");  
 			}
 		<%}%>
 <%
@@ -59,7 +59,7 @@
 		p_<%=cid %> = new org.talend.jpalo.palo(<%=bDeploypalolibs%>);
 		// Open the connection
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection attempt to '" + <%=sServer%> + "' with the username '" + <%=sUsername%> + "'.");
+			log.debug("<%=cid%> - Connection attempt to '" + <%=sServer%> + "' with the username '" + <%=sUsername%> + "'.");
 		<%}%>
 	        
 		<%
@@ -70,7 +70,7 @@
 	   	
 		pConn_<%=cid %> = p_<%=cid %>.connect(<%=sUsername%>, decryptedPassword_<%=cid%>, <%=sServer%>, <%=sServerport%>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection to '" + <%=sServer%> + "' has succeeded.");
+			log.debug("<%=cid%> - Connection to '" + <%=sServer%> + "' has succeeded.");
 		<%}%>
 <%
 	}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPaloCheckElements/tPaloCheckElements_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPaloCheckElements/tPaloCheckElements_end.javajet
@@ -15,11 +15,11 @@
 %>
 		if(pConn_<%=cid %> != null) {
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Closing the connection to the database.");
+				log.debug("<%=cid%> - Closing the connection to the database.");
 			<%}%>
 			pConn_<%=cid %>.logout();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Connection to the database closed.");
+				log.debug("<%=cid%> - Connection to the database closed.");
 			<%}%>
 		}
 <%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPaloClose/tPaloClose_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPaloClose/tPaloClose_main.javajet
@@ -22,10 +22,10 @@ imports="
 	
 	if(pConn_<%=cid %> != null)	{
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Closing the connection to the server.");
+			log.debug("<%=cid%> - Closing the connection to the server.");
 		<%}%>
 		pConn_<%=cid %>.logout();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection to the server closed.");
+			log.debug("<%=cid%> - Connection to the server closed.");
 		<%}%>
 	}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPaloConnection/tPaloConnection_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPaloConnection/tPaloConnection_begin.javajet
@@ -28,7 +28,7 @@ org.talend.jpalo.palo p_<%=cid %> = new org.talend.jpalo.palo(<%=bDeploypalolibs
 
 // Open the connection
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - Connection attempt to '" + <%=sServer%> + "' with the username '" + <%=sUsername%> + "'.");
+	log.debug("<%=cid%> - Connection attempt to '" + <%=sServer%> + "' with the username '" + <%=sUsername%> + "'.");
 <%}%>
 	        
 <%
@@ -39,7 +39,7 @@ String passwordFieldName = "__PASS__";
 
 org.talend.jpalo.paloconnection pConn_<%=cid %> = p_<%=cid %>.connect(<%=sUsername%>, decryptedPassword_<%=cid%>, <%=sServer%>, <%=sServerport%>);
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - Connection to '" + <%=sServer%> + "' has succeeded.");
+	log.debug("<%=cid%> - Connection to '" + <%=sServer%> + "' has succeeded.");
 <%}%>
 
 globalMap.put("p_<%=cid %>", p_<%=cid %>);

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPaloCube/tPaloCube_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPaloCube/tPaloCube_begin.javajet
@@ -51,7 +51,7 @@ if(useExistingConnection){
 	pConn_<%=cid %> =  (org.talend.jpalo.paloconnection)globalMap.get("<%=pConn%>");
 	<%if(isLog4jEnabled){%>
 		if(pConn_<%=cid %>!=null) {
-			log.info("<%=cid%> - Uses an existing connection.");
+			log.debug("<%=cid%> - Uses an existing connection.");
 		}
 	<%}%>
 <%
@@ -61,7 +61,7 @@ if(useExistingConnection){
 	p_<%=cid %> = new org.talend.jpalo.palo(<%=bDeploypalolibs%>);
 	// Open the connection
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection attempt to '" + <%=sServer%> + "' with the username '" + <%=sUsername%> + "' .");
+		log.debug("<%=cid%> - Connection attempt to '" + <%=sServer%> + "' with the username '" + <%=sUsername%> + "' .");
 	<%}%>
 	        
 	<%
@@ -72,7 +72,7 @@ if(useExistingConnection){
    	
 	pConn_<%=cid %> = p_<%=cid %>.connect(<%=sUsername%>, decryptedPassword_<%=cid%>, <%=sServer%>, <%=sServerport%>);
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection to '" + <%=sServer%> + "' has succeeded.");
+		log.debug("<%=cid%> - Connection to '" + <%=sServer%> + "' has succeeded.");
 	<%}%>
 <%
 }
@@ -101,11 +101,11 @@ if(("CREATE").equals(sCubeAction)){
 %>
 	org.talend.jpalo.palocubes pCUBs_<%=cid %> = pDB_<%=cid %>.getCubes(org.talend.jpalo.palocubes.<%=sCubeType%>);
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Creating cube '" + <%=sCubeName%> + "' .");
+		log.debug("<%=cid%> - Creating cube '" + <%=sCubeName%> + "' .");
 	<%}%>
 	pCUBs_<%=cid %>.createCube(<%=sCubeName%>, new String[]{<%=sbX.toString()%>}, org.talend.jpalo.palocubes.<%=sCubeType%>);
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Create cube '" + <%=sCubeName%> + "' has succeeded.");
+		log.debug("<%=cid%> - Create cube '" + <%=sCubeName%> + "' has succeeded.");
 	<%}%>
 <%
 }else if(("CREATE_IF_NOT_EXISTS").equals(sCubeAction)){
@@ -113,11 +113,11 @@ if(("CREATE").equals(sCubeAction)){
 	org.talend.jpalo.palocubes pCUBs_<%=cid %> = pDB_<%=cid %>.getCubes(org.talend.jpalo.palocubes.<%=sCubeType%>);
 	if(null==pCUBs_<%=cid %>.getCube(<%=sCubeName%>)){
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Creating cube '" + <%=sCubeName%> + "' .");
+			log.debug("<%=cid%> - Creating cube '" + <%=sCubeName%> + "' .");
 		<%}%>
 		pCUBs_<%=cid %>.createCube(<%=sCubeName%>, new String[]{<%=sbX.toString()%>}, org.talend.jpalo.palocubes.<%=sCubeType%>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Create cube '" + <%=sCubeName%> + "' has succeeded.");
+			log.debug("<%=cid%> - Create cube '" + <%=sCubeName%> + "' has succeeded.");
 		<%}%>
 	}
 <%
@@ -125,38 +125,38 @@ if(("CREATE").equals(sCubeAction)){
 %>
 	org.talend.jpalo.palocubes pCUBs_<%=cid %> = pDB_<%=cid %>.getCubes(org.talend.jpalo.palocubes.<%=sCubeType%>);
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Deleting cube '" + <%=sCubeName%> + "' .");
+		log.debug("<%=cid%> - Deleting cube '" + <%=sCubeName%> + "' .");
 	<%}%>
 	if(null!=pCUBs_<%=cid %>.getCube(<%=sCubeName%>)) pCUBs_<%=cid %>.deleteCube(<%=sCubeName%>);
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Delete cube '" + <%=sCubeName%> + "' has succeeded.");
-		log.info("<%=cid%> - Creating cube '" + <%=sCubeName%> + "' .");
+		log.debug("<%=cid%> - Delete cube '" + <%=sCubeName%> + "' has succeeded.");
+		log.debug("<%=cid%> - Creating cube '" + <%=sCubeName%> + "' .");
 	<%}%>
 	pCUBs_<%=cid %>.createCube(<%=sCubeName%>, new String[]{<%=sbX.toString()%>}, org.talend.jpalo.palocubes.<%=sCubeType%>);
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Create cube '" + <%=sCubeName%> + "' has succeeded.");
+		log.debug("<%=cid%> - Create cube '" + <%=sCubeName%> + "' has succeeded.");
 	<%}%>
 <%
 }else if(("DELETE").equals(sCubeAction)){
 %>
 	org.talend.jpalo.palocubes pCUBs_<%=cid %> = pDB_<%=cid %>.getCubes(org.talend.jpalo.palocubes.<%=sCubeType%>);
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Deleting cube '" + <%=sCubeName%> + "' .");
+		log.debug("<%=cid%> - Deleting cube '" + <%=sCubeName%> + "' .");
 	<%}%>
 	pCUBs_<%=cid %>.deleteCube(<%=sCubeName%>);
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Delete cube '" + <%=sCubeName%> + "' has succeeded.");
+		log.debug("<%=cid%> - Delete cube '" + <%=sCubeName%> + "' has succeeded.");
 	<%}%>	
 <%	
 } else if(("CLEAR").equals(sCubeAction)){
 %>
 	org.talend.jpalo.palocubes pCUBs_<%=cid %> = pDB_<%=cid %>.getCubes(org.talend.jpalo.palocubes.<%=sCubeType%>);
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Clearing cube '" + <%=sCubeName%> + "' .");
+		log.debug("<%=cid%> - Clearing cube '" + <%=sCubeName%> + "' .");
 	<%}%>
 	pCUBs_<%=cid %>.getCube(<%=sCubeName%>).clear();
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Clear cube '" + <%=sCubeName%> + "' has succeeded.");
+		log.debug("<%=cid%> - Clear cube '" + <%=sCubeName%> + "' has succeeded.");
 	<%}%>		
 <%	
 }
@@ -164,11 +164,11 @@ if(("CREATE").equals(sCubeAction)){
 %>
 		if(pConn_<%=cid %> != null){
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Closing the connection to the database.");
+				log.debug("<%=cid%> - Closing the connection to the database.");
 			<%}%>
 			pConn_<%=cid %>.logout();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Connection to the database closed.");
+				log.debug("<%=cid%> - Connection to the database closed.");
 			<%}%>
 		}
 <%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPaloCubeList/tPaloCubeList_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPaloCubeList/tPaloCubeList_begin.javajet
@@ -47,7 +47,7 @@ if(useExistingConnection){
 	pConn_<%=cid %> =  (org.talend.jpalo.paloconnection)globalMap.get("<%=pConn%>");
 	<%if(isLog4jEnabled){%>
 		if(pConn_<%=cid %>!=null) {
-			log.info("<%=cid%> - Uses an existing connection.");
+			log.debug("<%=cid%> - Uses an existing connection.");
 		}
 	<%}%>
 <%
@@ -57,7 +57,7 @@ if(useExistingConnection){
 	p_<%=cid %> = new org.talend.jpalo.palo(<%=bDeploypalolibs%>);
 	// Open the connection
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection attempt to '" + <%=sServer%> + "' with the username '" + <%=sUsername%> + "'.");
+		log.debug("<%=cid%> - Connection attempt to '" + <%=sServer%> + "' with the username '" + <%=sUsername%> + "'.");
 	<%}%>
 	        
 	<%
@@ -68,7 +68,7 @@ if(useExistingConnection){
    	
 	pConn_<%=cid %> = p_<%=cid %>.connect(<%=sUsername%>, decryptedPassword_<%=cid%>, <%=sServer%>, <%=sServerport%>);
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection to '" + <%=sServer%> + "' has succeeded.");
+		log.debug("<%=cid%> - Connection to '" + <%=sServer%> + "' has succeeded.");
 	<%}%>
 <%
 }
@@ -114,7 +114,7 @@ if(pDB_<%=cid %> == null){
 if (outputConnName != null || bIterate){
 %>
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - Listing cubes from server.");
+	log.debug("<%=cid%> - Listing cubes from server.");
 <%}%>
 for(int i_<%=cid %>=0;i_<%=cid %><4;i_<%=cid %>++){
 	org.talend.jpalo.palocubes pCUBs_<%=cid %> = pDB_<%=cid %>.getCubes(i_<%=cid %>);

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPaloCubeList/tPaloCubeList_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPaloCubeList/tPaloCubeList_end.javajet
@@ -54,11 +54,11 @@ if (outputConnName != null || bIterate){
 %>
 		if(pConn_<%=cid %> != null) {
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Closing the connection to the database.");
+				log.debug("<%=cid%> - Closing the connection to the database.");
 			<%}%>
 			pConn_<%=cid %>.logout();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Connection to the database closed.");
+				log.debug("<%=cid%> - Connection to the database closed.");
 			<%}%>
 		}
 <%
@@ -67,5 +67,5 @@ if (outputConnName != null || bIterate){
 globalMap.put("<%=cid%>_NB_CUBES", NB_CUBES<%=cid%>);
 
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - List cubes count " + NB_CUBES<%=cid%> + " .");
+		log.debug("<%=cid%> - List cubes count " + NB_CUBES<%=cid%> + " .");
 	<%}%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPaloDatabase/tPaloDatabase_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPaloDatabase/tPaloDatabase_begin.javajet
@@ -45,7 +45,7 @@ if(useExistingConnection){
 	pConn_<%=cid %> =  (org.talend.jpalo.paloconnection)globalMap.get("<%=pConn%>");
 	<%if(isLog4jEnabled){%>
 		if(pConn_<%=cid %>!=null) {
-			log.info("<%=cid%> - Uses an existing connection.");
+			log.debug("<%=cid%> - Uses an existing connection.");
 		}
 	<%}%>
 <%
@@ -55,7 +55,7 @@ if(useExistingConnection){
 	p_<%=cid %> = new org.talend.jpalo.palo(<%=bDeploypalolibs%>);
 	// Open the connection
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection attempt to '" + <%=sServer%> + "' with the username '" + <%=sUsername%> + "'.");
+		log.debug("<%=cid%> - Connection attempt to '" + <%=sServer%> + "' with the username '" + <%=sUsername%> + "'.");
 	<%}%>
 	        
 	<%
@@ -66,7 +66,7 @@ if(useExistingConnection){
    	
 	pConn_<%=cid %> = p_<%=cid %>.connect(<%=sUsername%>, decryptedPassword_<%=cid%>, <%=sServer%>, <%=sServerport%>);
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection to '" + <%=sServer%> + "' has succeeded.");
+		log.debug("<%=cid%> - Connection to '" + <%=sServer%> + "' has succeeded.");
 	<%}%>
 <%
 }
@@ -77,11 +77,11 @@ if(("CREATE").equals(sDatabaseAction)){
 %>
 	org.talend.jpalo.palodatabases pDBs_<%=cid %> = pConn_<%=cid %>.getDatabases();
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Creating database '" + <%=sDatabaseName%> + "' .");
+		log.debug("<%=cid%> - Creating database '" + <%=sDatabaseName%> + "' .");
 	<%}%>
 	pDBs_<%=cid %>.createDatabase(<%=sDatabaseName%>);
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Create database '" + <%=sDatabaseName%> + "' has succeeded.");
+		log.debug("<%=cid%> - Create database '" + <%=sDatabaseName%> + "' has succeeded.");
 	<%}%>
 <%
 }else if(("CREATE_IF_NOT_EXISTS").equals(sDatabaseAction)){
@@ -89,11 +89,11 @@ if(("CREATE").equals(sDatabaseAction)){
 	org.talend.jpalo.palodatabases pDBs_<%=cid %> = pConn_<%=cid %>.getDatabases();
 	if(null==pDBs_<%=cid %>.getDatabase(<%=sDatabaseName%>)){
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Creating database '" + <%=sDatabaseName%> + "' .");
+			log.debug("<%=cid%> - Creating database '" + <%=sDatabaseName%> + "' .");
 		<%}%> 
 		pDBs_<%=cid %>.createDatabase(<%=sDatabaseName%>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Create database '" + <%=sDatabaseName%> + "' has succeeded.");
+			log.debug("<%=cid%> - Create database '" + <%=sDatabaseName%> + "' has succeeded.");
 		<%}%>
 	}
 <%
@@ -102,19 +102,19 @@ if(("CREATE").equals(sDatabaseAction)){
 	org.talend.jpalo.palodatabases pDBs_<%=cid %> = pConn_<%=cid %>.getDatabases();
 	if(null!=pDBs_<%=cid %>.getDatabase(<%=sDatabaseName%>)){ 
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Deleting database '" + <%=sDatabaseName%> + "' .");
+			log.debug("<%=cid%> - Deleting database '" + <%=sDatabaseName%> + "' .");
 		<%}%>
 		pDBs_<%=cid %>.deleteDatabase(<%=sDatabaseName%>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Delete database '" + <%=sDatabaseName%> + "' has succeeded.");
+			log.debug("<%=cid%> - Delete database '" + <%=sDatabaseName%> + "' has succeeded.");
 		<%}%>
 	}
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Creating database '" + <%=sDatabaseName%> + "' .");
+		log.debug("<%=cid%> - Creating database '" + <%=sDatabaseName%> + "' .");
 	<%}%> 
 	pDBs_<%=cid %>.createDatabase(<%=sDatabaseName%>);
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Create database '" + <%=sDatabaseName%> + "' has succeeded.");
+		log.debug("<%=cid%> - Create database '" + <%=sDatabaseName%> + "' has succeeded.");
 	<%}%>	
 <%
 }else if(("DELETE").equals(sDatabaseAction)){
@@ -123,11 +123,11 @@ if(("CREATE").equals(sDatabaseAction)){
 	org.talend.jpalo.palodatabase pDB_<%=cid %> = pDBs_<%=cid %>.getDatabase(<%=sDatabaseName%>);
 	if(null != pDB_<%=cid %>){
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Deleting database '" + <%=sDatabaseName%> + "' .");
+			log.debug("<%=cid%> - Deleting database '" + <%=sDatabaseName%> + "' .");
 		<%}%>
 	    pDBs_<%=cid %>.deleteDatabase(<%=sDatabaseName%>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Delete database '" + <%=sDatabaseName%> + "' has succeeded.");
+			log.debug("<%=cid%> - Delete database '" + <%=sDatabaseName%> + "' has succeeded.");
 		<%}%>
 	}else{
 		 throw new RuntimeException ("Database '" + <%=sDatabaseName%> + "' not found. exiting...");
@@ -138,11 +138,11 @@ if(("CREATE").equals(sDatabaseAction)){
 %>
 		if(pConn_<%=cid %> != null){
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Closing the connection to the database.");
+				log.debug("<%=cid%> - Closing the connection to the database.");
 			<%}%>
 			pConn_<%=cid %>.logout();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Connection to the database closed.");
+				log.debug("<%=cid%> - Connection to the database closed.");
 			<%}%>
 		}
 <%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPaloDatabaseList/tPaloDatabaseList_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPaloDatabaseList/tPaloDatabaseList_begin.javajet
@@ -44,7 +44,7 @@ if(useExistingConnection){
 	pConn_<%=cid %> =  (org.talend.jpalo.paloconnection)globalMap.get("<%=pConn%>");
 	<%if(isLog4jEnabled){%>
 		if(pConn_<%=cid %>!=null) {
-			log.info("<%=cid%> - Uses an existing connection.");
+			log.debug("<%=cid%> - Uses an existing connection.");
 		}
 	<%}%>
 <%
@@ -54,7 +54,7 @@ if(useExistingConnection){
 	p_<%=cid %> = new org.talend.jpalo.palo(<%=bDeploypalolibs%>);
 	// Open the connection
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection attempt to '" + <%=sServer%> + "' with the username '" + <%=sUsername%> + "'.");
+		log.debug("<%=cid%> - Connection attempt to '" + <%=sServer%> + "' with the username '" + <%=sUsername%> + "'.");
 	<%}%>
 	        
 	<%
@@ -65,7 +65,7 @@ if(useExistingConnection){
    	
 	pConn_<%=cid %> = p_<%=cid %>.connect(<%=sUsername%>, decryptedPassword_<%=cid%>, <%=sServer%>, <%=sServerport%>);
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection to '" + <%=sServer%> + "' has succeeded.");
+		log.debug("<%=cid%> - Connection to '" + <%=sServer%> + "' has succeeded.");
 	<%}%>
 <%
 }
@@ -102,7 +102,7 @@ if (conns!=null) {
 if (outputConnName != null || bIterate){
 %>
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - Listing databases from server.");
+	log.debug("<%=cid%> - Listing databases from server.");
 <%}%>
 	org.talend.jpalo.palodatabases pDBs_<%=cid %> = pConn_<%=cid %>.getDatabases();
 	for(int j_<%=cid %>=0;j_<%=cid %>< pDBs_<%=cid %>.getNumberOfDatabases();j_<%=cid %>++){

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPaloDatabaseList/tPaloDatabaseList_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPaloDatabaseList/tPaloDatabaseList_end.javajet
@@ -54,11 +54,11 @@ if (outputConnName != null || bIterate){
 %>
 		if(pConn_<%=cid %> != null){
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Closing the connection to the database.");
+				log.debug("<%=cid%> - Closing the connection to the database.");
 			<%}%>
 			pConn_<%=cid %>.logout();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Connection to the database closed.");
+				log.debug("<%=cid%> - Connection to the database closed.");
 			<%}%>
 		}
 <%
@@ -67,5 +67,5 @@ if (outputConnName != null || bIterate){
 globalMap.put("<%=cid%>_NB_DATABASES", NB_DATABASES<%=cid%>);
 
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - List databases count " + NB_DATABASES<%=cid%> + " .");
+		log.debug("<%=cid%> - List databases count " + NB_DATABASES<%=cid%> + " .");
 	<%}%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPaloDimension/tPaloDimension_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPaloDimension/tPaloDimension_begin.javajet
@@ -58,7 +58,7 @@ if(useExistingConnection){
 	pConn_<%=cid %> =  (org.talend.jpalo.paloconnection)globalMap.get("<%=pConn%>");
 	<%if(isLog4jEnabled){%>
 		if(pConn_<%=cid %>!=null) {
-			log.info("<%=cid%> - Uses an existing connection.");
+			log.debug("<%=cid%> - Uses an existing connection.");
 		}
 	<%}%>
 <%
@@ -68,7 +68,7 @@ if(useExistingConnection){
 	p_<%=cid %> = new org.talend.jpalo.palo(<%=bDeploypalolibs%>);
 	// Open the connection
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection attempt to '" + <%=sServer%> + "' with the username '" + <%=sUsername%> + "' .");
+		log.debug("<%=cid%> - Connection attempt to '" + <%=sServer%> + "' with the username '" + <%=sUsername%> + "' .");
 	<%}%>
 	        
 	<%
@@ -79,7 +79,7 @@ if(useExistingConnection){
    	
 	pConn_<%=cid %> = p_<%=cid %>.connect(<%=sUsername%>, decryptedPassword_<%=cid%>, <%=sServer%>, <%=sServerport%>);
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection to '" + <%=sServer%> + "' has succeeded.");
+		log.debug("<%=cid%> - Connection to '" + <%=sServer%> + "' has succeeded.");
 	<%}%>
 <%
 }
@@ -104,11 +104,11 @@ if(("NONE").equals(sDimensionAction)){
 }else if(("CREATE").equals(sDimensionAction)){
 %>
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Creating dimension '" + <%=sDimensionName%> + "' .");
+		log.debug("<%=cid%> - Creating dimension '" + <%=sDimensionName%> + "' .");
 	<%}%>
 	pDIM_<%=cid %> = pDIMs_<%=cid %>.createDimension(<%=sDimensionName%>);
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Create dimension '" + <%=sDimensionName%> + "' has succeeded.");
+		log.debug("<%=cid%> - Create dimension '" + <%=sDimensionName%> + "' has succeeded.");
 	<%}%>
 <%
 }else if(("CREATE_IF_NOT_EXISTS").equals(sDimensionAction)){
@@ -116,11 +116,11 @@ if(("NONE").equals(sDimensionAction)){
 	pDIM_<%=cid %> = pDIMs_<%=cid %>.getDimension(<%=sDimensionName%>);
 	if(null==pDIM_<%=cid %>){
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Creating dimension '" + <%=sDimensionName%> + "' .");
+			log.debug("<%=cid%> - Creating dimension '" + <%=sDimensionName%> + "' .");
 		<%}%>
 		pDIM_<%=cid %> = pDIMs_<%=cid %>.createDimension(<%=sDimensionName%>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Create dimension '" + <%=sDimensionName%> + "' has succeeded.");
+			log.debug("<%=cid%> - Create dimension '" + <%=sDimensionName%> + "' has succeeded.");
 		<%}%>
 	}
 <%
@@ -142,11 +142,11 @@ if(("NONE").equals(sDimensionAction)){
 		for(String strCubeName_<%=cid %> : strCubeNames_<%=cid %>) 
 		    CUBES_<%=cid %>.deleteCube(strCubeName_<%=cid %>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Deleting dimension '" + <%=sDimensionName%> + "' .");
+			log.debug("<%=cid%> - Deleting dimension '" + <%=sDimensionName%> + "' .");
 		<%}%>
 		pDIMs_<%=cid %>.deleteDimension(<%=sDimensionName%>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Delete dimension '" + <%=sDimensionName%> + "' has succeeded.");
+			log.debug("<%=cid%> - Delete dimension '" + <%=sDimensionName%> + "' has succeeded.");
 		<%}%>
 		pDIM_<%=cid %> = pDIMs_<%=cid %>.getDimension(<%=sDimensionName%>);
 	}
@@ -167,11 +167,11 @@ if(("NONE").equals(sDimensionAction)){
 		for(String strCubeName_<%=cid %> : strCubeNames_<%=cid %>) 
 		CUBES_<%=cid %> .deleteCube(strCubeName_<%=cid %>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Deleting dimension '" + <%=sDimensionName%> + "' .");
+			log.debug("<%=cid%> - Deleting dimension '" + <%=sDimensionName%> + "' .");
 		<%}%>
 		pDIMs_<%=cid %>.deleteDimension(<%=sDimensionName%>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Delete dimension '" + <%=sDimensionName%> + "' has succeeded.");
+			log.debug("<%=cid%> - Delete dimension '" + <%=sDimensionName%> + "' has succeeded.");
 		<%}%>
 		
 	
@@ -181,11 +181,11 @@ if(("NONE").equals(sDimensionAction)){
 	if(("DELETE_IF_EXISTS_AND_CREATE").equals(sDimensionAction)){
 %>
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Creating dimension '" + <%=sDimensionName%> + "' .");
+			log.debug("<%=cid%> - Creating dimension '" + <%=sDimensionName%> + "' .");
 		<%}%>
  		pDIM_<%=cid %> = pDIMs_<%=cid %>.createDimension(<%=sDimensionName%>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Create dimension '" + <%=sDimensionName%> + "' has succeeded.");
+			log.debug("<%=cid%> - Create dimension '" + <%=sDimensionName%> + "' has succeeded.");
 		<%}%>
 <%
 	}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPaloDimension/tPaloDimension_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPaloDimension/tPaloDimension_end.javajet
@@ -124,11 +124,11 @@
 %>
 		if(pConn_<%=cid %> != null){
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Closing the connection to the database.");
+				log.debug("<%=cid%> - Closing the connection to the database.");
 			<%}%>
 			pConn_<%=cid %>.logout();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Connection to the database closed.");
+				log.debug("<%=cid%> - Connection to the database closed.");
 			<%}%>
 		}
 <%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPaloDimensionList/tPaloDimensionList_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPaloDimensionList/tPaloDimensionList_begin.javajet
@@ -48,7 +48,7 @@ if(useExistingConnection){
 	pConn_<%=cid %> =  (org.talend.jpalo.paloconnection)globalMap.get("<%=pConn%>");
 	<%if(isLog4jEnabled){%>
 		if(pConn_<%=cid %>!=null) {
-			log.info("<%=cid%> - Uses an existing connection.");
+			log.debug("<%=cid%> - Uses an existing connection.");
 		}
 	<%}%>
 <%
@@ -58,7 +58,7 @@ if(useExistingConnection){
 	p_<%=cid %> = new org.talend.jpalo.palo(<%=bDeploypalolibs%>);
 	// Open the connection
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection attempt to '" + <%=sServer%> + "' with the username '" + <%=sUsername%> + "'.");
+		log.debug("<%=cid%> - Connection attempt to '" + <%=sServer%> + "' with the username '" + <%=sUsername%> + "'.");
 	<%}%>
 	        
 	<%
@@ -69,7 +69,7 @@ if(useExistingConnection){
    	
 	pConn_<%=cid %> = p_<%=cid %>.connect(<%=sUsername%>, decryptedPassword_<%=cid%>, <%=sServer%>, <%=sServerport%>);
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection to '" + <%=sServer%> + "' has succeeded.");
+		log.debug("<%=cid%> - Connection to '" + <%=sServer%> + "' has succeeded.");
 	<%}%>
 <%
 }
@@ -125,7 +125,7 @@ org.talend.jpalo.palodimension pDIM_<%=cid %> = null;
 if (outputConnName != null || bIterate){
 %>
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - Listing dimensions from server.");
+	log.debug("<%=cid%> - Listing dimensions from server.");
 <%}%>
 	for(int i_<%=cid %>=0;i_<%=cid %><4;i_<%=cid %>++){
 		org.talend.jpalo.palodimensions pDIMs_<%=cid %>=null;

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPaloDimensionList/tPaloDimensionList_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPaloDimensionList/tPaloDimensionList_end.javajet
@@ -68,11 +68,11 @@ if (outputConnName != null || bIterate){
 %>
 		if(pConn_<%=cid %> != null) {
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Closing the connection to the database.");
+				log.debug("<%=cid%> - Closing the connection to the database.");
 			<%}%>
 			pConn_<%=cid %>.logout();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Connection to the database closed.");
+				log.debug("<%=cid%> - Connection to the database closed.");
 			<%}%>
 		}
 <%
@@ -81,5 +81,5 @@ if (outputConnName != null || bIterate){
 //globalMap.put("<%=cid%>_NB_RULES", NB_RULES<%=cid%>);
 
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - List dimensions count " + NB_DIMENSIONS<%=cid%> + " .");
+		log.debug("<%=cid%> - List dimensions count " + NB_DIMENSIONS<%=cid%> + " .");
 	<%}%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPaloInputMulti/tPaloInputMulti_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPaloInputMulti/tPaloInputMulti_begin.javajet
@@ -44,7 +44,7 @@
 		pConn_<%=cid %> =  (org.talend.jpalo.paloconnection)globalMap.get("<%=pConn%>");
 		<%if(isLog4jEnabled){%>
 			if(pConn_<%=cid %>!=null) {
-				log.info("<%=cid%> - Uses an existing connection.");
+				log.debug("<%=cid%> - Uses an existing connection.");
 			}
 		<%}%>
 <%
@@ -54,7 +54,7 @@
 		p_<%=cid %> = new org.talend.jpalo.palo(<%=bDeploypalolibs%>);
 		// Open the connection
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection attempt to '" + <%=sServer%> + "' with the username '" + <%=sUsername%> + "'.");
+			log.debug("<%=cid%> - Connection attempt to '" + <%=sServer%> + "' with the username '" + <%=sUsername%> + "'.");
 		<%}%>
 	        
 		<%
@@ -65,7 +65,7 @@
 	   	
 		pConn_<%=cid %> = p_<%=cid %>.connect(<%=sUsername%>, decryptedPassword_<%=cid%>, <%=sServer%>, <%=sServerport%>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection to '" + <%=sServer%> + "' has succeeded.");
+			log.debug("<%=cid%> - Connection to '" + <%=sServer%> + "' has succeeded.");
 		<%}%>
 <%
 	}
@@ -109,7 +109,7 @@
 		org.talend.jpalo.palodata pDT_<%=cid %> = new org.talend.jpalo.palodata(pConn_<%=cid %>,pDB_<%=cid %>,pCB_<%=cid %>,alPaloElements_<%=cid %>, strDimensionElementArray_<%=cid %>, <%=iCommitSize%>);
 		int iRowCount_<%=cid %>=0;
 	    <%if(isLog4jEnabled){%>
-	    	log.info("<%=cid%> - Retrieving data from the cube.");
+	    	log.debug("<%=cid%> - Retrieving data from the cube.");
 	    <%}%>
 		while(pDT_<%=cid %>.getResults()){
 <%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPaloInputMulti/tPaloInputMulti_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPaloInputMulti/tPaloInputMulti_end.javajet
@@ -34,11 +34,11 @@
 %>
 		if(pConn_<%=cid %> != null){
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Closing the connection to the database.");
+				log.debug("<%=cid%> - Closing the connection to the database.");
 			<%}%>
 			pConn_<%=cid %>.logout();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Connection to the database closed.");
+				log.debug("<%=cid%> - Connection to the database closed.");
 			<%}%>
 		}
 <%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPaloOutput/tPaloOutput_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPaloOutput/tPaloOutput_begin.javajet
@@ -60,11 +60,11 @@ if ((metadatas!=null)&&(metadatas.size()>0)) {
 		
 		org.talend.palo.paloIX plIX_<%=cid %> = new org.talend.palo.paloIX();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection attempt to '" + server_<%=cid %> + "' with the username '" + username_<%=cid %> + "'.");
+			log.debug("<%=cid%> - Connection attempt to '" + server_<%=cid %> + "' with the username '" + username_<%=cid %> + "'.");
 		<%}%>
 		org.talend.palo.paloIXConnection plConn_<%=cid %> = plIX_<%=cid %>.initAndConnect(username_<%=cid %>,password_<%=cid %>,server_<%=cid %>,port_<%=cid %>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection to '" + server_<%=cid %> + "' has succeeded.");
+			log.debug("<%=cid%> - Connection to '" + server_<%=cid %> + "' has succeeded.");
 		<%}%>
 		
 		

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPaloOutput/tPaloOutput_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPaloOutput/tPaloOutput_end.javajet
@@ -15,24 +15,24 @@ imports="
 %> 
 
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Committing cube .");
+		log.debug("<%=cid%> - Committing cube .");
 	<%}%>
 	plDb_<%=cid %>.commitCube(cube_<%=cid %>);
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Commit has succeeded.");
+		log.debug("<%=cid%> - Commit has succeeded.");
 	<%}%>
 	nb_commit_count_<%=cid %> =0;
 	if(<%=isSaveCube %>) plDb_<%=cid %>.save();
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Closing the connection to the database.");
+		log.debug("<%=cid%> - Closing the connection to the database.");
 	<%}%>
 	plIX_<%=cid %>.kill();
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection to the database closed.");
+		log.debug("<%=cid%> - Connection to the database closed.");
 	<%}%>
 
 	globalMap.put("<%=cid %>_NB_LINE",nb_line_<%=cid %>);  
 
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Written records count: " + nb_line_<%=cid %> + " .");
+		log.debug("<%=cid%> - Written records count: " + nb_line_<%=cid %> + " .");
 	<%}%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPaloOutput/tPaloOutput_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPaloOutput/tPaloOutput_main.javajet
@@ -54,11 +54,11 @@
 			nb_commit_count_<%=cid %>=nb_commit_count_<%=cid %> + 1;
 			if(nb_commit_count_<%=cid %> >= <%=commitsize %>){
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Committing cube .");
+					log.debug("<%=cid%> - Committing cube .");
 				<%}%>
 				plDb_<%=cid %>.commitCube(cube_<%=cid %>);
 				<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Commit has succeeded.");
+					log.debug("<%=cid%> - Commit has succeeded.");
 				<%}%>
 				nb_commit_count_<%=cid %> =0;
 			}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPaloOutputMulti/tPaloOutputMulti_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPaloOutputMulti/tPaloOutputMulti_begin.javajet
@@ -46,7 +46,7 @@
 		pConn_<%=cid %> =  (org.talend.jpalo.paloconnection)globalMap.get("<%=pConn%>");
 		<%if(isLog4jEnabled){%>
 			if(pConn_<%=cid %>!=null) {
-				log.info("<%=cid%> - Uses an existing connection.");
+				log.debug("<%=cid%> - Uses an existing connection.");
 			}
 		<%}%>
 <%
@@ -56,7 +56,7 @@
 		p_<%=cid %> = new org.talend.jpalo.palo(<%=bDeploypalolibs%>);
 		// Open the connection
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection attempt to '" + <%=sServer%> + "' with the username '" + <%=sUsername%> + "'.");
+			log.debug("<%=cid%> - Connection attempt to '" + <%=sServer%> + "' with the username '" + <%=sUsername%> + "'.");
 		<%}%>
 	        
 		<%
@@ -67,7 +67,7 @@
 	   	
 		pConn_<%=cid %> = p_<%=cid %>.connect(<%=sUsername%>, decryptedPassword_<%=cid%>, <%=sServer%>, <%=sServerport%>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection to '" + <%=sServer%> + "' has succeeded.");
+			log.debug("<%=cid%> - Connection to '" + <%=sServer%> + "' has succeeded.");
 		<%}%>
 <%
 	}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPaloOutputMulti/tPaloOutputMulti_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPaloOutputMulti/tPaloOutputMulti_end.javajet
@@ -56,11 +56,11 @@
 %>
 		if(pConn_<%=cid %> != null){
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Closing the connection to the database.");
+				log.debug("<%=cid%> - Closing the connection to the database.");
 			<%}%>
 			pConn_<%=cid %>.logout();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Connection to the database closed.");
+				log.debug("<%=cid%> - Connection to the database closed.");
 			<%}%>
 		}
 <%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPaloRule/tPaloRule_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPaloRule/tPaloRule_begin.javajet
@@ -43,7 +43,7 @@
 		pConn_<%=cid %> =  (org.talend.jpalo.paloconnection)globalMap.get("<%=pConn%>");
 		<%if(isLog4jEnabled){%>
 			if(pConn_<%=cid %>!=null) {
-				log.info("<%=cid%> - Uses an existing connection.");
+				log.debug("<%=cid%> - Uses an existing connection.");
 			}
 		<%}%>
 <%
@@ -53,7 +53,7 @@
 		p_<%=cid %> = new org.talend.jpalo.palo(<%=bDeploypalolibs%>);
 		// Open the connection
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection attempt to '" + <%=sServer%> + "' with the username '" + <%=sUsername%> + "' .");
+			log.debug("<%=cid%> - Connection attempt to '" + <%=sServer%> + "' with the username '" + <%=sUsername%> + "' .");
 		<%}%>
 	        
 		<%
@@ -64,7 +64,7 @@
 	   	
 		pConn_<%=cid %> = p_<%=cid %>.connect(<%=sUsername%>, decryptedPassword_<%=cid%>, <%=sServer%>, <%=sServerport%>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection to '" + <%=sServer%> + "' has succeeded.");
+			log.debug("<%=cid%> - Connection to '" + <%=sServer%> + "' has succeeded.");
 		<%}%>
 <%
 	}
@@ -104,11 +104,11 @@ for(int i=0; i<iNbOfCubeRules; i++){
 %>
 		try{
     		<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Creating rule '" + <%=strRuleDefinition%> + "' .");
+				log.debug("<%=cid%> - Creating rule '" + <%=strRuleDefinition%> + "' .");
 			<%}%>
 			pRLs_<%=cid %>.addRule(<%=strRuleDefinition%>, true, "tPaloRule_"+ pRLs_<%=cid %>.getNumberOfRules(),  <%=strRuleComment%>, <%=bRuleActivate%>);
     		<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Create rule '" + <%=strRuleDefinition%> + "' has succeeded.");
+				log.debug("<%=cid%> - Create rule '" + <%=strRuleDefinition%> + "' has succeeded.");
 			<%}%>
 		}catch(Exception e){
 			<%if(isLog4jEnabled){%>
@@ -123,22 +123,22 @@ for(int i=0; i<iNbOfCubeRules; i++){
 			// Check if Rule exists
 			if(null==pRLs_<%=cid %>.getRule(<%=strRuleExtern_ID%>))
 	    		<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Creating rule '" + <%=strRuleDefinition%> + "' .");
+					log.debug("<%=cid%> - Creating rule '" + <%=strRuleDefinition%> + "' .");
 				<%}%>
 				pRLs_<%=cid %>.addRule(<%=strRuleDefinition%>, true, <%=strRuleExtern_ID%>,  <%=strRuleComment%>, <%=bRuleActivate%>);
 	    		<%if(isLog4jEnabled){%>
-					log.info("<%=cid%> - Create rule '" + <%=strRuleDefinition%> + "' has succeeded.");
+					log.debug("<%=cid%> - Create rule '" + <%=strRuleDefinition%> + "' has succeeded.");
 				<%}%>
 <%
 		}
 	}else if(("RULE_DELETE").equals(strRuleAction)){
 %>
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Deleting rule '" + <%=strRuleExtern_ID%> + "' .");
+			log.debug("<%=cid%> - Deleting rule '" + <%=strRuleExtern_ID%> + "' .");
 		<%}%>
 		pRLs_<%=cid %>.deleteRule(<%=strRuleExtern_ID%>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Delete rule '" + <%=strRuleExtern_ID%> + "' has succeeded.");
+			log.debug("<%=cid%> - Delete rule '" + <%=strRuleExtern_ID%> + "' has succeeded.");
 		<%}%>
 <%
 	}else if(("RULE_UPDATE").equals(strRuleAction)){
@@ -149,11 +149,11 @@ for(int i=0; i<iNbOfCubeRules; i++){
 			pRL_<%=cid%>.setComment(<%=strRuleComment%>);
 			pRL_<%=cid%>.setActivated(<%=bRuleActivate%>);
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Updating rule '" + <%=strRuleExtern_ID%> + "' .");
+				log.debug("<%=cid%> - Updating rule '" + <%=strRuleExtern_ID%> + "' .");
 			<%}%>
 			pRL_<%=cid%>.modifyRule();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Update rule '" + <%=strRuleExtern_ID%> + "' has succeeded.");
+				log.debug("<%=cid%> - Update rule '" + <%=strRuleExtern_ID%> + "' has succeeded.");
 			<%}%>
 		}
 <%
@@ -163,11 +163,11 @@ for(int i=0; i<iNbOfCubeRules; i++){
 %>
 		if(pConn_<%=cid %> != null){
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Closing the connection to the database.");
+				log.debug("<%=cid%> - Closing the connection to the database.");
 			<%}%>
 			pConn_<%=cid %>.logout();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Connection to the database closed.");
+				log.debug("<%=cid%> - Connection to the database closed.");
 			<%}%>
 		}
 <%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPaloRuleList/tPaloRuleList_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPaloRuleList/tPaloRuleList_begin.javajet
@@ -43,7 +43,7 @@
 		pConn_<%=cid %> =  (org.talend.jpalo.paloconnection)globalMap.get("<%=pConn%>");
 		<%if(isLog4jEnabled){%>
 			if(pConn_<%=cid %>!=null) {
-				log.info("<%=cid%> - Uses an existing connection.");
+				log.debug("<%=cid%> - Uses an existing connection.");
 			}
 		<%}%>
 <%
@@ -53,7 +53,7 @@
 		p_<%=cid %> = new org.talend.jpalo.palo(<%=bDeploypalolibs%>);
 		// Open the connection
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection attempt to '" + <%=sServer%> + "' with the username '" + <%=sUsername%> + "' .");
+			log.debug("<%=cid%> - Connection attempt to '" + <%=sServer%> + "' with the username '" + <%=sUsername%> + "' .");
 		<%}%>
 	        
 		<%
@@ -64,7 +64,7 @@
 	   	
 		pConn_<%=cid %> = p_<%=cid %>.connect(<%=sUsername%>, decryptedPassword_<%=cid%>, <%=sServer%>, <%=sServerport%>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection to '" + <%=sServer%> + "' has succeeded.");
+			log.debug("<%=cid%> - Connection to '" + <%=sServer%> + "' has succeeded.");
 		<%}%>
 <%
 	}
@@ -126,7 +126,7 @@
 	if (outputConnName != null || bIterate){
 %>
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Listing rules ...");
+			log.debug("<%=cid%> - Listing rules ...");
 		<%}%>
 		org.talend.jpalo.palorules pRULs_<%=cid %> = pCUB_<%=cid %>.getCubeRules();
 		for(int j=0;j< pRULs_<%=cid %>.getNumberOfRules();j++){		

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPaloRuleList/tPaloRuleList_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPaloRuleList/tPaloRuleList_end.javajet
@@ -53,11 +53,11 @@
 %>
 		if(pConn_<%=cid %> != null){
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Closing the connection to the database.");
+				log.debug("<%=cid%> - Closing the connection to the database.");
 			<%}%>
 			pConn_<%=cid %>.logout();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Connection to the database closed.");
+				log.debug("<%=cid%> - Connection to the database closed.");
 			<%}%>
 		}
 <%
@@ -66,5 +66,5 @@
 	//globalMap.put("<%=cid%>_NB_RULES", NB_RULES<%=cid%>);
 	
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - List rules count " + NB_RULES<%=cid%> + " .");
+		log.debug("<%=cid%> - List rules count " + NB_RULES<%=cid%> + " .");
 	<%}%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tParAccelBulkExec/tParAccelBulkExec_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tParAccelBulkExec/tParAccelBulkExec_begin.javajet
@@ -256,11 +256,11 @@ if((columnList != null && columnList.size() > 0) || "CLEAR".equals(tableAction))
 %>
 	<%if(isLog4jEnabled){%>
 		log.debug("<%=cid%> - Bulk SQL:"+bulkSQL_<%=cid%>+".");
-		log.info("<%=cid%> - Bulk inserting data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
+		log.debug("<%=cid%> - Bulk inserting data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
 	<%}%>
     stmtBulk_<%=cid %>.execute(bulkSQL_<%=cid%>);
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Bulk insert data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
+		log.debug("<%=cid%> - Bulk insert data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
 	<%}%>
     stmtBulk_<%=cid %>.close();    
 <%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPostgresPlusBulkExec/tPostgresPlusBulkExec_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPostgresPlusBulkExec/tPostgresPlusBulkExec_begin.javajet
@@ -181,13 +181,13 @@ if(("UPDATE").equals(dataAction)) {
         tableName_<%=cid%> = "tmp_<%=cid%>" + "_" + pid + Thread.currentThread().getId();        
         java.sql.Statement stmtCreateTmp_<%=cid%> = conn_<%=cid%>.createStatement();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Creating temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
+			log.debug("<%=cid%> - Creating temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
 		<%}%>
 
         stmtCreateTmp_<%=cid%>.execute("<%=manager.getCreateTableSQL(stmtStructure)%>)");
         stmtCreateTmp_<%=cid%>.close();
         <%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Create temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
+			log.debug("<%=cid%> - Create temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
 		<%}%>
         
         <%if(standardConformingString) {
@@ -199,19 +199,19 @@ if(("UPDATE").equals(dataAction)) {
         java.sql.Statement stmtTmpBulk_<%=cid%> = conn_<%=cid%>.createStatement();
 		<%if(isLog4jEnabled){%>
 			log.debug("<%=cid%> - Bulk SQL:"+bulkSQL_<%=cid%>+".");
-			log.info("<%=cid%> - Bulk inserting data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
+			log.debug("<%=cid%> - Bulk inserting data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
 		<%}%>
         stmtTmpBulk_<%=cid%>.execute(bulkSQL_<%=cid%>);
         stmtTmpBulk_<%=cid%>.close();
         
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Bulk insert data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
+			log.debug("<%=cid%> - Bulk insert data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
 		<%}%>
         tableName_<%=cid%> = tmpTableName_<%=cid%>;
         tmpTableName_<%=cid%> = "tmp_<%=cid%>" + "_" + pid + Thread.currentThread().getId();
         java.sql.Statement stmtUpdateBulk_<%=cid%> = conn_<%=cid%>.createStatement();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Updating <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> from <%=manager.getLProtectedChar()%>"+tmpTableName_<%=cid%>+"<%=manager.getRProtectedChar()%>.");
+			log.debug("<%=cid%> - Updating <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> from <%=manager.getLProtectedChar()%>"+tmpTableName_<%=cid%>+"<%=manager.getRProtectedChar()%>.");
 		<%}%>
         stmtUpdateBulk_<%=cid%>.executeUpdate("<%=manager.getUpdateBulkSQL(columnList)%>");
 		<%log4jCodeGenerateUtil.logInfo(node,"info",cid+" - Update has finished.");%>
@@ -219,12 +219,12 @@ if(("UPDATE").equals(dataAction)) {
         tableName_<%=cid%> = tmpTableName_<%=cid%>;
         java.sql.Statement stmtTmpDrop_<%=cid%> = conn_<%=cid%>.createStatement();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Droping temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
+			log.debug("<%=cid%> - Droping temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
 		<%}%>
         stmtTmpDrop_<%=cid%>.execute("<%=manager.getDropTableSQL()%>");
         stmtTmpDrop_<%=cid%>.close();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Drop temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%>+ "<%=manager.getRProtectedChar()%> has succeeded.");
+			log.debug("<%=cid%> - Drop temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%>+ "<%=manager.getRProtectedChar()%> has succeeded.");
 		<%}%>
         <%
     }
@@ -241,12 +241,12 @@ if(("UPDATE").equals(dataAction)) {
     //stmt.execute("SET client_encoding to 'UNICODE'");
 	<%if(isLog4jEnabled){%>
 		log.debug("<%=cid%> - Bulk SQL:"+bulkSQL_<%=cid%>+".");
-		log.info("<%=cid%> - Inserting records in table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
+		log.debug("<%=cid%> - Inserting records in table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
 	<%}%>
     stmtBulk_<%=cid %>.execute(bulkSQL_<%=cid%>);
     stmtBulk_<%=cid %>.close();    
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Insert records in table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
+		log.debug("<%=cid%> - Insert records in table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
 	<%
 	}
 }

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPostgresqlBulkExec/tPostgresqlBulkExec_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPostgresqlBulkExec/tPostgresqlBulkExec_begin.javajet
@@ -228,13 +228,13 @@ if(("UPDATE").equals(dataAction)) {
         tableName_<%=cid%> = "tmp_<%=cid%>" + "_" + pid + Thread.currentThread().getId() ;        
         java.sql.Statement stmtCreateTmp_<%=cid%> = conn_<%=cid%>.createStatement();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Creating temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
+			log.debug("<%=cid%> - Creating temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
 		<%}%>
 
         stmtCreateTmp_<%=cid%>.execute("<%=manager.getCreateTableSQL(stmtStructure)%>)");
         stmtCreateTmp_<%=cid%>.close();
         <%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Create temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
+			log.debug("<%=cid%> - Create temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
 		<%}%>
         
         <%if(standardConformingString) {
@@ -247,20 +247,20 @@ if(("UPDATE").equals(dataAction)) {
         java.sql.Statement stmtTmpBulk_<%=cid%> = conn_<%=cid%>.createStatement();
 		<%if(isLog4jEnabled){%>
 			log.debug("<%=cid%> - Bulk SQL:"+bulkSQL_<%=cid%>+".");
-			log.info("<%=cid%> - Bulk inserting data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
+			log.debug("<%=cid%> - Bulk inserting data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
 		<%}%>
         stmtTmpBulk_<%=cid%>.execute(bulkSQL_<%=cid%>);
         stmtTmpBulk_<%=cid%>.close();
         
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Bulk insert data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
+			log.debug("<%=cid%> - Bulk insert data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
 		<%}%>
         tableName_<%=cid%> = tmpTableName_<%=cid%>;
         tmpTableName_<%=cid%> = "tmp_<%=cid%>" + "_" + pid + Thread.currentThread().getId();
         
         java.sql.Statement stmtUpdateBulk_<%=cid%> = conn_<%=cid%>.createStatement();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Updating <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> from <%=manager.getLProtectedChar()%>"+tmpTableName_<%=cid%>+"<%=manager.getRProtectedChar()%>.");
+			log.debug("<%=cid%> - Updating <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> from <%=manager.getLProtectedChar()%>"+tmpTableName_<%=cid%>+"<%=manager.getRProtectedChar()%>.");
 		<%}%>
         stmtUpdateBulk_<%=cid%>.executeUpdate("<%=manager.getUpdateBulkSQL(columnList)%>");
 		<%log4jCodeGenerateUtil.logInfo(node,"info",cid+" - Update has finished.");%>
@@ -269,12 +269,12 @@ if(("UPDATE").equals(dataAction)) {
         
         java.sql.Statement stmtTmpDrop_<%=cid%> = conn_<%=cid%>.createStatement();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Droping temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
+			log.debug("<%=cid%> - Droping temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
 		<%}%>
         stmtTmpDrop_<%=cid%>.execute("<%=manager.getDropTableSQL()%>");
         stmtTmpDrop_<%=cid%>.close();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Drop temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%>+ "<%=manager.getRProtectedChar()%> has succeeded.");
+			log.debug("<%=cid%> - Drop temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%>+ "<%=manager.getRProtectedChar()%> has succeeded.");
 		<%}%>
         <%
     }
@@ -291,12 +291,12 @@ if(("UPDATE").equals(dataAction)) {
     //stmt.execute("SET client_encoding to 'UNICODE'");
 	<%if(isLog4jEnabled){%>
 		log.debug("<%=cid%> - Bulk SQL:"+bulkSQL_<%=cid%>+".");
-		log.info("<%=cid%> - Inserting records in table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
+		log.debug("<%=cid%> - Inserting records in table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
 	<%}%>
     stmtBulk_<%=cid %>.execute(bulkSQL_<%=cid%>);
     stmtBulk_<%=cid %>.close();    
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Insert records in table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
+		log.debug("<%=cid%> - Insert records in table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
 	<%
 	}
 }

--- a/main/plugins/org.talend.designer.components.localprovider/components/tREST/tREST_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tREST/tREST_begin.javajet
@@ -100,7 +100,7 @@ imports="
 	com.sun.jersey.api.client.ClientResponse errorResponse_<%=cid%> = null;
 	String restResponse_<%=cid%> = "";
 	try{
-		<%log.info(log.str("Prepare to send request to rest server."));%>
+		<%log.debug(log.str("Prepare to send request to rest server."));%>
 		com.sun.jersey.api.client.WebResource.Builder builder_<%=cid%> = null;
 		for(java.util.Map.Entry<String, Object> header_<%=cid%> : headers_<%=cid%>.entrySet()) {
 			if(builder_<%=cid%> == null) {
@@ -149,7 +149,7 @@ imports="
 	}catch (com.sun.jersey.api.client.UniformInterfaceException ue) {
         errorResponse_<%=cid%> = ue.getResponse();
     }
-	<%log.info(log.str("Has sent request to rest server."));%>
+	<%log.debug(log.str("Has sent request to rest server."));%>
 	// for output
 	<%
 	List< ? extends IConnection> conns = node.getOutgoingSortedConnections();

--- a/main/plugins/org.talend.designer.components.localprovider/components/tRedshiftBulkExec/tRedshiftBulkExec_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tRedshiftBulkExec/tRedshiftBulkExec_begin.javajet
@@ -427,7 +427,7 @@ skeleton="../templates/db_output_bulk.skeleton"
 	}
 %>
 	<%if(log4jEnabled){%>
-		log.info("<%=cid%> - Finish loading data to table : " + tableName2_<%=cid%> + ".");
+		log.debug("<%=cid%> - Finish loading data to table : " + tableName2_<%=cid%> + ".");
 	<%}%>
 <%
 	if(!useExistingConnection) {

--- a/main/plugins/org.talend.designer.components.localprovider/components/tRedshiftOutputBulk/tRedshiftOutputBulk_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tRedshiftOutputBulk/tRedshiftOutputBulk_end.javajet
@@ -29,7 +29,7 @@
 			<%
 			if(isLog4jEnabled){
 			%>	
-				log.info("<%=cid%> - Uploading an object with key:" + <%=key%>);
+				log.debug("<%=cid%> - Uploading an object with key:" + <%=key%>);
 			<%
 			}
 			%>
@@ -37,7 +37,7 @@
 			<%
 			if(isLog4jEnabled){
 			%>	
-				log.info("<%=cid%> - Upload the object successfully.");
+				log.debug("<%=cid%> - Upload the object successfully.");
 			<%
 			}
 			%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tRedshiftUnload/tRedshiftUnload_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tRedshiftUnload/tRedshiftUnload_begin.javajet
@@ -177,7 +177,7 @@ imports="
 	java.sql.Statement stmt_<%=cid %>=conn_<%=cid %>.createStatement();
 	stmt_<%=cid %>.execute(command_<%=cid%>.toString());
 	<%if(log4jEnabled){%>
-		log.info("<%=cid%> - Finish unloading data to s3.");
+		log.debug("<%=cid%> - Finish unloading data to s3.");
 	<%}%>
 <%
 	if(!useExistingConnection) {

--- a/main/plugins/org.talend.designer.components.localprovider/components/tRowGenerator/tRowGenerator_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tRowGenerator/tRowGenerator_begin.javajet
@@ -62,7 +62,7 @@ class <%=cid %>Randomizer {
 	<%=cid %>Randomizer rand<%=cid%> = new <%=cid %>Randomizer();
 	
     <%if(isLog4jEnabled){%>
-    	log.info("<%=cid%> - Generating records.");
+    	log.debug("<%=cid%> - Generating records.");
     <%}%>
 	for (int i<%=cid %>=0; i<%=cid %><nb_max_row_<%=cid%> ;i<%=cid %>++) {
 <%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tRowGenerator/tRowGenerator_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tRowGenerator/tRowGenerator_end.javajet
@@ -15,5 +15,5 @@
 }
 globalMap.put("<%=node.getUniqueName() %>_NB_LINE",nb_line_<%=node.getUniqueName() %>);
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - Generated records count:" + nb_line_<%=cid%> + " .");
+	log.debug("<%=cid%> - Generated records count:" + nb_line_<%=cid%> + " .");
 <%}%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tRunJob/tRunJob_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tRunJob/tRunJob_main.javajet
@@ -391,11 +391,11 @@ String inputConnName = null;
 			childJob_<%=cid %>.parentContextMap = parentContextMap_<%=cid %>;
 		<%}%>  
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - The child job '<%if(!useDynamicJob){%><%=childJob %><%}else{%>"+<%=dynamicJobName%>+"<%}%>' starts on the version '<%=version%>' with the context '<%=context%>'.");
+			log.debug("<%=cid%> - The child job '<%if(!useDynamicJob){%><%=childJob %><%}else{%>"+<%=dynamicJobName%>+"<%}%>' starts on the version '<%=version%>' with the context '<%=context%>'.");
 		<%}%>
 		String[][] childReturn_<%=cid %> = childJob_<%=cid %>.runJob((String[]) paraList_<%=cid %>.toArray(new String[paraList_<%=cid %>.size()]));
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - The child job '<%if(!useDynamicJob){%><%=childJob %><%}else{%>"+<%=dynamicJobName%>+"<%}%>' is done.");
+			log.debug("<%=cid%> - The child job '<%if(!useDynamicJob){%><%=childJob %><%}else{%>"+<%=dynamicJobName%>+"<%}%>' is done.");
 		<%}%>
 	  	<%
 		if (childJob != null) {
@@ -523,11 +523,11 @@ String inputConnName = null;
 	    	}
   		};
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - The child job '<%if(!useDynamicJob){%><%=childJob %><%}else{%>"+<%=dynamicJobName%>+"<%}%>' starts on the version '<%=version%>' with the context '<%=context%>'.");
+			log.debug("<%=cid%> - The child job '<%if(!useDynamicJob){%><%=childJob %><%}else{%>"+<%=dynamicJobName%>+"<%}%>' starts on the version '<%=version%>' with the context '<%=context%>'.");
 		<%}%>
 		normal_<%=cid %>.start();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - The child job '<%if(!useDynamicJob){%><%=childJob %><%}else{%>"+<%=dynamicJobName%>+"<%}%>' is done.");
+			log.debug("<%=cid%> - The child job '<%if(!useDynamicJob){%><%=childJob %><%}else{%>"+<%=dynamicJobName%>+"<%}%>' is done.");
 		<%}%>
 
 		final StringBuffer errorMsg_<%=cid %> = new StringBuffer();

--- a/main/plugins/org.talend.designer.components.localprovider/components/tS3BucketCreate/tS3BucketCreate_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tS3BucketCreate/tS3BucketCreate_main.javajet
@@ -19,7 +19,7 @@ imports="
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Creating a bucket with name:" + <%=bucket%>);
+			log.debug("<%=cid%> - Creating a bucket with name:" + <%=bucket%>);
 		<%
 		}
 		%>
@@ -27,7 +27,7 @@ imports="
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Create the bucket successfully.");
+			log.debug("<%=cid%> - Create the bucket successfully.");
 		<%
 		}
 		%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tS3BucketDelete/tS3BucketDelete_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tS3BucketDelete/tS3BucketDelete_begin.javajet
@@ -19,7 +19,7 @@ imports="
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Deleting a bucket with name:" + <%=bucket%>);
+			log.debug("<%=cid%> - Deleting a bucket with name:" + <%=bucket%>);
 		<%
 		}
 		%>
@@ -27,7 +27,7 @@ imports="
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Delete the bucket successfully.");
+			log.debug("<%=cid%> - Delete the bucket successfully.");
 		<%
 		}
 		%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tS3BucketExist/tS3BucketExist_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tS3BucketExist/tS3BucketExist_main.javajet
@@ -22,9 +22,9 @@ imports="
 		if(isLog4jEnabled){
 		%>	
 			if(bucketExist_<%=cid%>){
-				log.info("<%=cid%> - Bucket "+<%=bucket%>+" exists.");
+				log.debug("<%=cid%> - Bucket "+<%=bucket%>+" exists.");
 			}else{
-				log.info("<%=cid%> - Bucket "+<%=bucket%>+" does not exist.");
+				log.debug("<%=cid%> - Bucket "+<%=bucket%>+" does not exist.");
 			}
 		<%
 		}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tS3BucketList/tS3BucketList_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tS3BucketList/tS3BucketList_begin.javajet
@@ -17,7 +17,7 @@ imports="
 	<%
 	if (isLog4jEnabled) {
 	%>
-		log.info("<%=cid%> - Retrieving buckets from the server.");
+		log.debug("<%=cid%> - Retrieving buckets from the server.");
 	<%
 	}
 	%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tS3BucketList/tS3BucketList_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tS3BucketList/tS3BucketList_end.javajet
@@ -28,7 +28,7 @@ imports="
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Retrieved buckets count: " + nb_bucket_<%=cid%> + " .");
+		log.debug("<%=cid%> - Retrieved buckets count: " + nb_bucket_<%=cid%> + " .");
 	<%		
 	}
 	%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tS3Connection/S3Client.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tS3Connection/S3Client.javajet
@@ -32,7 +32,7 @@
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Get an free connection from " + "<%=connection%>" + ".");
+			log.debug("<%=cid%> - Get an free connection from " + "<%=connection%>" + ".");
 		<%
 		}
 	}else{
@@ -40,7 +40,7 @@
 	    <%
 	    if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Creating new connection.");
+			log.debug("<%=cid%> - Creating new connection.");
 		<%
 		}
 		
@@ -263,7 +263,7 @@
 		}
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Creating new connection successfully.");
+			log.debug("<%=cid%> - Creating new connection successfully.");
 		<%
 		}
 	}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tS3Copy/tS3Copy_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tS3Copy/tS3Copy_begin.javajet
@@ -25,7 +25,7 @@ imports="
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Copying an object with key:" + <%=from_key%>);
+			log.debug("<%=cid%> - Copying an object with key:" + <%=from_key%>);
 		<%
 		}
 		%>
@@ -45,7 +45,7 @@ imports="
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Copied the object successfully.");
+			log.debug("<%=cid%> - Copied the object successfully.");
 		<%
 		}
 		%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tS3Delete/tS3Delete_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tS3Delete/tS3Delete_begin.javajet
@@ -22,7 +22,7 @@ imports="
 			<%
 			if(isLog4jEnabled){
 			%>	
-				log.info("<%=cid%> - Deleting an object with key:" + <%=key%>);
+				log.debug("<%=cid%> - Deleting an object with key:" + <%=key%>);
 			<%
 			}
 			%>
@@ -30,7 +30,7 @@ imports="
 			<%
 			if(isLog4jEnabled){
 			%>	
-				log.info("<%=cid%> - Delete the object successfully.");
+				log.debug("<%=cid%> - Delete the object successfully.");
 			<%
 			}
 			%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tS3Get/tS3Get_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tS3Get/tS3Get_begin.javajet
@@ -21,7 +21,7 @@ imports="
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Getting an object with key:" + <%=key%>);
+			log.debug("<%=cid%> - Getting an object with key:" + <%=key%>);
 		<%
 		}
 		%>
@@ -29,7 +29,7 @@ imports="
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Get the object successfully.");
+			log.debug("<%=cid%> - Get the object successfully.");
 		<%
 		}
 		%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tS3List/tS3List_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tS3List/tS3List_end.javajet
@@ -60,8 +60,8 @@ imports="
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Retrieved the buckets count: " + nb_bucket_<%=cid%> + " .");
-		log.info("<%=cid%> - Retrieved the objects count: " + nb_bucket_object_<%=cid%> + " .");
+		log.debug("<%=cid%> - Retrieved the buckets count: " + nb_bucket_<%=cid%> + " .");
+		log.debug("<%=cid%> - Retrieved the objects count: " + nb_bucket_object_<%=cid%> + " .");
 	<%		
 	}
 	%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tS3Put/tS3Put_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tS3Put/tS3Put_begin.javajet
@@ -32,7 +32,7 @@ imports="
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Uploading an object with key:" + <%=key%>);
+			log.debug("<%=cid%> - Uploading an object with key:" + <%=key%>);
 		<%
 		}
 		%>
@@ -93,7 +93,7 @@ imports="
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Upload the object successfully.");
+			log.debug("<%=cid%> - Upload the object successfully.");
 		<%
 		}
 		%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSCPClose/tSCPClose_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSCPClose/tSCPClose_main.javajet
@@ -17,10 +17,10 @@ imports="
 	ch.ethz.ssh2.Connection conn_<%=cid%> = (ch.ethz.ssh2.Connection)globalMap.get("<%=conn%>");
 	if(conn_<%=cid%> != null){
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Closing the connection '<%= connection %>' to the server.");
+			log.debug("<%=cid%> - Closing the connection '<%= connection %>' to the server.");
 		<%}%>
 		conn_<%=cid%>.close();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection '<%= connection %>' to the server closed.");
+			log.debug("<%=cid%> - Connection '<%= connection %>' to the server closed.");
 		<%}%>
 	}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSCPConnection/tSCPConnection_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSCPConnection/tSCPConnection_begin.javajet
@@ -37,17 +37,17 @@ imports="
 %>
               /* Now connect */
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Attempt to connect to '" + hostname_<%=cid%> + "' with username '" + <%=user%> + "'.");
+			log.debug("<%=cid%> - Attempt to connect to '" + hostname_<%=cid%> + "' with username '" + <%=user%> + "'.");
 		<%}%>
         conn_<%=cid%>.connect();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connect to '" + hostname_<%=cid%> + "' has succeeded.");
+			log.debug("<%=cid%> - Connect to '" + hostname_<%=cid%> + "' has succeeded.");
 		<%}%>
 <%        
         if (("PUBLICKEY").equals(authMethod)) {
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication using a public key");
+				log.debug("<%=cid%> - Authentication using a public key");
 				log.debug("<%=cid%> - Private key: '" + <%=privatekey%> + "'." );
 			<%}%>
         	java.io.File keyfile_<%=cid%> = new java.io.File(<%=privatekey%>); 
@@ -63,14 +63,14 @@ imports="
                 throw new RuntimeException("Authentication failed.");
 			}
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication succeeded.");
+				log.debug("<%=cid%> - Authentication succeeded.");
 			<%}%>
 <%
         }
         if (("PASSWORD").equals(authMethod)) {
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication using a password");
+				log.debug("<%=cid%> - Authentication using a password");
 			<%}%>
 			
             <%
@@ -84,14 +84,14 @@ imports="
             	throw new RuntimeException("Authentication failed.");
             }
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication succeeded.");
+				log.debug("<%=cid%> - Authentication succeeded.");
 		    <%}%>
 <%
         }
         if (("KEYBOARDINTERACTIVE").equals(authMethod)) {
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication using an interactive action");
+				log.debug("<%=cid%> - Authentication using an interactive action");
 			<%}%>
 	        boolean isAuthenticated_<%=cid%> = conn_<%=cid%>.authenticateWithKeyboardInteractive(username_<%=cid%>, 
 	            new ch.ethz.ssh2.InteractiveCallback() {
@@ -119,7 +119,7 @@ imports="
             	throw new RuntimeException("Authentication failed.");
             }
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication succeeded.");
+				log.debug("<%=cid%> - Authentication succeeded.");
 			<%}%>
 <%
         }%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSCPDelete/tSCPDelete_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSCPDelete/tSCPDelete_begin.javajet
@@ -57,7 +57,7 @@ imports="
 	    String username_<%=cid%> = <%=user%>;
 	    <%if(isLog4jEnabled){%>
 			if(conn_<%=cid %>!=null) {
-				log.info("<%=cid%> - Uses an existing connection. Connection hostname: " + conn_<%=cid %>.getHostname() + ". Connection port: " + conn_<%=cid %>.getPort() + "."); 
+				log.debug("<%=cid%> - Uses an existing connection. Connection hostname: " + conn_<%=cid %>.getHostname() + ". Connection port: " + conn_<%=cid %>.getPort() + "."); 
 			}
 		<%}%>
 	
@@ -77,17 +77,17 @@ imports="
 %>
               /* Now connect */
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Attempt to connect to '" + hostname_<%=cid%> + "' with the username '" + username_<%=cid%> + "'.");
+			log.debug("<%=cid%> - Attempt to connect to '" + hostname_<%=cid%> + "' with the username '" + username_<%=cid%> + "'.");
 		<%}%>
         conn_<%=cid%>.connect();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connect to '" + hostname_<%=cid%> + "' has succeeded.");
+			log.debug("<%=cid%> - Connect to '" + hostname_<%=cid%> + "' has succeeded.");
 		<%}%>
 <%        
         if (("PUBLICKEY").equals(authMethod)) {
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication using a public key");
+				log.debug("<%=cid%> - Authentication using a public key");
 				log.debug("<%=cid%> - Private key: '" + <%=privatekey%> + "'." );
 			<%}%>
 			java.io.File keyfile_<%=cid%> = new java.io.File(<%=privatekey%>); 
@@ -103,14 +103,14 @@ imports="
                 throw new RuntimeException("Authentication failed.");
 			}
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication succeeded.");
+				log.debug("<%=cid%> - Authentication succeeded.");
 			<%}%>
 <%
         }
         if (("PASSWORD").equals(authMethod)) {
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication using a password");
+				log.debug("<%=cid%> - Authentication using a password");
 			<%}%>
 			
             <%
@@ -124,14 +124,14 @@ imports="
 	            throw new RuntimeException("Authentication failed.");
 	        }
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication succeeded.");
+				log.debug("<%=cid%> - Authentication succeeded.");
 		    <%}%>
 <%
         }
         if (("KEYBOARDINTERACTIVE").equals(authMethod)) {
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication using an interactive action");
+				log.debug("<%=cid%> - Authentication using an interactive action");
 			<%}%>
 	        boolean isAuthenticated_<%=cid%> = conn_<%=cid%>.authenticateWithKeyboardInteractive(username_<%=cid%>, 
 	            new ch.ethz.ssh2.InteractiveCallback() {
@@ -160,7 +160,7 @@ imports="
 	            throw new RuntimeException("Authentication failed.");
 	        }
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication succeeded.");
+				log.debug("<%=cid%> - Authentication succeeded.");
 			<%}%>
 <%
         }

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSCPDelete/tSCPDelete_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSCPDelete/tSCPDelete_end.javajet
@@ -14,15 +14,15 @@ imports="
 	if(!("true").equals(useExistingConn)){%>
 	/* Close the connection */
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Closing the connection to the server.");
+			log.debug("<%=cid%> - Closing the connection to the server.");
 		<%}%>
 	    conn_<%=cid%>.close();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection to the server closed.");
+			log.debug("<%=cid%> - Connection to the server closed.");
 		<%}%>
 <%			
 	}%>
 		globalMap.put("<%=cid %>_NB_FILE",nb_file_<%=cid%>);
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Deleted files count: "+nb_file_<%=cid%> + " .");
+			log.debug("<%=cid%> - Deleted files count: "+nb_file_<%=cid%> + " .");
 		<%}%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSCPFileExists/tSCPFileExists_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSCPFileExists/tSCPFileExists_begin.javajet
@@ -52,7 +52,7 @@ imports="
 		ch.ethz.ssh2.Connection conn_<%=cid %> = (ch.ethz.ssh2.Connection)globalMap.get("<%=conn %>");
 		<%if(isLog4jEnabled){%>
 			if(conn_<%=cid %>!=null) {
-				log.info("<%=cid%> - Uses an existing connection. Connection hostname: " + conn_<%=cid %>.getHostname() + ". Connection port: " + conn_<%=cid %>.getPort() + "."); 
+				log.debug("<%=cid%> - Uses an existing connection. Connection hostname: " + conn_<%=cid %>.getHostname() + ". Connection port: " + conn_<%=cid %>.getPort() + "."); 
 			}
 		<%}%>
 	
@@ -72,17 +72,17 @@ imports="
 %>
               /* Now connect */
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Attempt to connect to '" + hostname_<%=cid%> + "' with the username '" + <%=user%> + "'.");
+			log.debug("<%=cid%> - Attempt to connect to '" + hostname_<%=cid%> + "' with the username '" + <%=user%> + "'.");
 		<%}%>
         conn_<%=cid%>.connect();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connect to '" + hostname_<%=cid%> + "' has succeeded.");
+			log.debug("<%=cid%> - Connect to '" + hostname_<%=cid%> + "' has succeeded.");
 		<%}%>
 <%        
         if (("PUBLICKEY").equals(authMethod)) {
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication using a public key");
+				log.debug("<%=cid%> - Authentication using a public key");
 				log.debug("<%=cid%> - Private key: '" + <%=privatekey%> + "'." );
 			<%}%>
 	        java.io.File keyfile_<%=cid%> = new java.io.File(<%=privatekey%>); 
@@ -98,7 +98,7 @@ imports="
 				throw new RuntimeException("Authentication failed.");
 			}	
 			  <%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication succeeded.");
+				log.debug("<%=cid%> - Authentication succeeded.");
 			  <%}%>
 <%
         }
@@ -106,7 +106,7 @@ imports="
 %>
 
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication using a password");
+				log.debug("<%=cid%> - Authentication using a password");
 			<%}%>
 			
             <%
@@ -120,14 +120,14 @@ imports="
 	            throw new RuntimeException("Authentication failed.");
 			}
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication succeeded.");
+				log.debug("<%=cid%> - Authentication succeeded.");
 			<%}%>
 <%
         }
         if (("KEYBOARDINTERACTIVE").equals(authMethod)) {
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication using an interactive action");
+				log.debug("<%=cid%> - Authentication using an interactive action");
 			<%}%>
     	    boolean isAuthenticated_<%=cid%> = conn_<%=cid%>.authenticateWithKeyboardInteractive(username_<%=cid%>, 
         	    new ch.ethz.ssh2.InteractiveCallback() {
@@ -156,7 +156,7 @@ imports="
             	throw new RuntimeException("Authentication failed.");
             }
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication succeeded.");
+				log.debug("<%=cid%> - Authentication succeeded.");
 			<%}%>		
 <%
         }

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSCPFileExists/tSCPFileExists_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSCPFileExists/tSCPFileExists_end.javajet
@@ -15,10 +15,10 @@ imports="
 %>  	
         /* Close the connection */
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Closing the connection to the server.");
+			log.debug("<%=cid%> - Closing the connection to the server.");
 		<%}%>
         conn_<%=cid%>.close();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection to the server closed.");
+			log.debug("<%=cid%> - Connection to the server closed.");
 		<%}%>
 <%	}%> 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSCPFileList/tSCPFileList_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSCPFileList/tSCPFileList_begin.javajet
@@ -56,7 +56,7 @@ imports="
 		ch.ethz.ssh2.Connection conn_<%=cid %> = (ch.ethz.ssh2.Connection)globalMap.get("<%=conn %>");
 		<%if(isLog4jEnabled){%>
 			if(conn_<%=cid %>!=null) {
-				log.info("<%=cid%> - Uses an existing connection. Connection hostname: " + conn_<%=cid %>.getHostname() + ". Connection port: " + conn_<%=cid %>.getPort() + "."); 
+				log.debug("<%=cid%> - Uses an existing connection. Connection hostname: " + conn_<%=cid %>.getHostname() + ". Connection port: " + conn_<%=cid %>.getPort() + "."); 
 			}
 		<%}%>
 	<%}else{%>
@@ -75,17 +75,17 @@ imports="
 %>
               /* Now connect */
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Attempt to connect to '" + hostname_<%=cid%> + "' with the username '" + username_<%=cid%> + "'.");
+			log.debug("<%=cid%> - Attempt to connect to '" + hostname_<%=cid%> + "' with the username '" + username_<%=cid%> + "'.");
 		<%}%>
         conn_<%=cid%>.connect();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connect to '" + hostname_<%=cid%> + "' has succeeded.");
+			log.debug("<%=cid%> - Connect to '" + hostname_<%=cid%> + "' has succeeded.");
 		<%}%>
 <%        
         if (("PUBLICKEY").equals(authMethod)) {
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication using a public key");
+				log.debug("<%=cid%> - Authentication using a public key");
 				log.debug("<%=cid%> - Private key: '" + <%=privatekey%> + "'." );
 			<%}%>
 			java.io.File keyfile_<%=cid%> = new java.io.File(<%=privatekey%>); 
@@ -101,14 +101,14 @@ imports="
 				throw new RuntimeException("Authentication failed.");
 			}
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication succeeded.");
+				log.debug("<%=cid%> - Authentication succeeded.");
 			<%}%>
 <%
         }
         if (("PASSWORD").equals(authMethod)) {
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication using a password");
+				log.debug("<%=cid%> - Authentication using a password");
 			<%}%>
 			
             <%
@@ -122,14 +122,14 @@ imports="
 	            throw new RuntimeException("Authentication failed.");
 	        }
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication succeeded.");
+				log.debug("<%=cid%> - Authentication succeeded.");
 		    <%}%>
 <%
         }
         if (("KEYBOARDINTERACTIVE").equals(authMethod)) {
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication using an interactive action");
+				log.debug("<%=cid%> - Authentication using an interactive action");
 			<%}%>
 	        boolean isAuthenticated_<%=cid%> = conn_<%=cid%>.authenticateWithKeyboardInteractive(username_<%=cid%>, 
 	            new ch.ethz.ssh2.InteractiveCallback() {
@@ -158,7 +158,7 @@ imports="
 	            throw new RuntimeException("Authentication failed.");
 	        }
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication succeeded.");
+				log.debug("<%=cid%> - Authentication succeeded.");
 			<%}%>
 <%
         } 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSCPFileList/tSCPFileList_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSCPFileList/tSCPFileList_end.javajet
@@ -32,11 +32,11 @@ imports="
 %>  
             /* Close the connection */
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Closing the connection to the server.");
+				log.debug("<%=cid%> - Closing the connection to the server.");
 			<%}%>
             conn_<%=cid%>.close();
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Connection to the server closed.");
+				log.debug("<%=cid%> - Connection to the server closed.");
 			<%}%>
 <%  	
 		}%>
@@ -47,5 +47,5 @@ imports="
             }
 			globalMap.put("<%=cid %>_NB_LINE", nb_line_<%=cid %>);
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Listed files count: "+nb_line_<%=cid%> + " .");
+				log.debug("<%=cid%> - Listed files count: "+nb_line_<%=cid%> + " .");
 			<%}%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSCPGet/tSCPGet_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSCPGet/tSCPGet_begin.javajet
@@ -53,7 +53,7 @@ imports="
 		ch.ethz.ssh2.Connection conn_<%=cid %> = (ch.ethz.ssh2.Connection)globalMap.get("<%=conn %>");
 		<%if(isLog4jEnabled){%>
 			if(conn_<%=cid %>!=null) {
-				log.info("<%=cid%> - Uses an existing connection. Connection hostname: " + conn_<%=cid %>.getHostname() + ". Connection port: " + conn_<%=cid %>.getPort() + "."); 
+				log.debug("<%=cid%> - Uses an existing connection. Connection hostname: " + conn_<%=cid %>.getHostname() + ". Connection port: " + conn_<%=cid %>.getPort() + "."); 
 			}
 		<%}%>
 	<%}else{%>
@@ -72,17 +72,17 @@ imports="
 %>
               /* Now connect */
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Attempt to connect to '" + hostname_<%=cid%> + "' with the username '" + <%=user%> + "'.");
+			log.debug("<%=cid%> - Attempt to connect to '" + hostname_<%=cid%> + "' with the username '" + <%=user%> + "'.");
 		<%}%>
         conn_<%=cid%>.connect();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connect to '" + hostname_<%=cid%> + "' has succeeded.");
+			log.debug("<%=cid%> - Connect to '" + hostname_<%=cid%> + "' has succeeded.");
 		<%}%>
 <%        
         if (("PUBLICKEY").equals(authMethod)) {
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication using a public key");
+				log.debug("<%=cid%> - Authentication using a public key");
 				log.debug("<%=cid%> - Private key: '" + <%=privatekey%> + "'." );
 			<%}%>
 	        java.io.File keyfile_<%=cid%> = new java.io.File(<%=privatekey%>); 
@@ -98,14 +98,14 @@ imports="
 	                throw new RuntimeException("Authentication failed.");
 			}
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication succeeded.");
+				log.debug("<%=cid%> - Authentication succeeded.");
 			<%}%>
 	<%
 	        }
         if (("PASSWORD").equals(authMethod)) {
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication using a password");
+				log.debug("<%=cid%> - Authentication using a password");
 			<%}%>
 			
             <%
@@ -119,14 +119,14 @@ imports="
             	throw new RuntimeException("Authentication failed.");
 			}
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication succeeded.");
+				log.debug("<%=cid%> - Authentication succeeded.");
 			<%}%>
 <%
         }
         if (("KEYBOARDINTERACTIVE").equals(authMethod)) {
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication using an interactive action");
+				log.debug("<%=cid%> - Authentication using an interactive action");
 			<%}%>
 	        boolean isAuthenticated_<%=cid%> = conn_<%=cid%>.authenticateWithKeyboardInteractive(username_<%=cid%>, 
 	            new ch.ethz.ssh2.InteractiveCallback() {
@@ -153,7 +153,7 @@ imports="
             	throw new RuntimeException("Authentication failed.");
 			}
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication succeeded.");
+				log.debug("<%=cid%> - Authentication succeeded.");
 			<%}%>
 <%
         }

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSCPGet/tSCPGet_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSCPGet/tSCPGet_end.javajet
@@ -15,15 +15,15 @@ imports="
 %>  
 		/* Close the connection */
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Closing the connection to the server.");
+			log.debug("<%=cid%> - Closing the connection to the server.");
 		<%}%>
         conn_<%=cid%>.close();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection to the server closed.");
+			log.debug("<%=cid%> - Connection to the server closed.");
 		<%}%>
 	<%}%>
 		globalMap.put("<%=cid %>_NB_FILE",nb_file_<%=cid%>);
 			
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Downloaded files count: " + nb_file_<%=cid%>  + ".");
+			log.debug("<%=cid%> - Downloaded files count: " + nb_file_<%=cid%>  + ".");
 		<%}%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSCPGet/tSCPGet_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSCPGet/tSCPGet_main.javajet
@@ -74,7 +74,7 @@ imports="
 						nb_file_<%=cid%> ++ ;
 						<%if(isLog4jEnabled){%>
 							log.debug("<%=cid%> - Downloaded file " + nb_file_<%=cid%> +  ": " + sourceFile_<%=cid %> + " successfully.");
-							log.info("<%= cid %> - Appended to "+sourceFile_<%=cid %>+" at local directory "+<%= localdir %>+" successfully.");
+							log.debug("<%= cid %> - Appended to "+sourceFile_<%=cid %>+" at local directory "+<%= localdir %>+" successfully.");
 						<%}%>
 					}
 				}
@@ -145,11 +145,11 @@ imports="
 							<%if(isLog4jEnabled){%>
 								log.debug("<%=cid%> - Downloaded file " + nb_file_<%=cid%> +  ": " + sourceFile_<%=cid %> + " successfully.");
 								<% if(isDefaultAction){ %>
-									 log.info("<%= cid %> - Overwrote or appended to "+sourceFile_<%=cid %>+" at local directory "+<%= localdir %>+" successfully.");
+									 log.debug("<%= cid %> - Overwrote or appended to "+sourceFile_<%=cid %>+" at local directory "+<%= localdir %>+" successfully.");
 								<%
 								}else{
 								%>
-									 log.info("<%= cid %> - Overwrote to "+sourceFile_<%=cid %>+" at local directory "+<%= localdir %>+" successfully.");
+									 log.debug("<%= cid %> - Overwrote to "+sourceFile_<%=cid %>+" at local directory "+<%= localdir %>+" successfully.");
 								<%
 								}
 							}%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSCPPut/tSCPPut_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSCPPut/tSCPPut_begin.javajet
@@ -29,7 +29,7 @@ imports="
 		ch.ethz.ssh2.Connection conn_<%=cid %> = (ch.ethz.ssh2.Connection)globalMap.get("<%=conn %>");
 		<%if(isLog4jEnabled){%>
 			if(conn_<%=cid %>!=null) {
-				log.info("<%=cid%> - Uses an existing connection. Connection hostname: " + conn_<%=cid %>.getHostname() + ". Connection port: " + conn_<%=cid %>.getPort() + "."); 
+				log.debug("<%=cid%> - Uses an existing connection. Connection hostname: " + conn_<%=cid %>.getHostname() + ". Connection port: " + conn_<%=cid %>.getPort() + "."); 
 			}
 		<%}%>
 	
@@ -58,17 +58,17 @@ imports="
 %>
               /* Now connect */
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Attempt to connect to '" + hostname_<%=cid%> + "' with the username '" + <%=user%> + "'.");
+			log.debug("<%=cid%> - Attempt to connect to '" + hostname_<%=cid%> + "' with the username '" + <%=user%> + "'.");
 		<%}%>
         conn_<%=cid%>.connect();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connect to '" + hostname_<%=cid%> + "' has succeeded.");
+			log.debug("<%=cid%> - Connect to '" + hostname_<%=cid%> + "' has succeeded.");
 		<%}%>
 <%        
         if (("PUBLICKEY").equals(authMethod)) {
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication using a public key");
+				log.debug("<%=cid%> - Authentication using a public key");
 				log.debug("<%=cid%> - Private key: '" + <%=privatekey%> + "'." );
 			<%}%>
     	    java.io.File keyfile_<%=cid%> = new java.io.File(<%=privatekey%>); 
@@ -84,14 +84,14 @@ imports="
 				throw new RuntimeException("Authentication failed.");
 			}	
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication succeeded.");
+				log.debug("<%=cid%> - Authentication succeeded.");
 			<%}%>
 <%
         }
         if (("PASSWORD").equals(authMethod)) {
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication using a password");
+				log.debug("<%=cid%> - Authentication using a password");
 			<%}%>
 			
             <%
@@ -105,14 +105,14 @@ imports="
             	throw new RuntimeException("Authentication failed.");
         	}
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication succeeded.");
+				log.debug("<%=cid%> - Authentication succeeded.");
 			<%}%>
 <%
         }
         if (("KEYBOARDINTERACTIVE").equals(authMethod)) {
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication using an interactive action");
+				log.debug("<%=cid%> - Authentication using an interactive action");
 			<%}%>
 	        boolean isAuthenticated_<%=cid%> = conn_<%=cid%>.authenticateWithKeyboardInteractive(username_<%=cid%>, 
     	        new ch.ethz.ssh2.InteractiveCallback() {
@@ -141,7 +141,7 @@ imports="
             	throw new RuntimeException("Authentication failed.");
         	}
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication succeeded.");
+				log.debug("<%=cid%> - Authentication succeeded.");
 			<%}%>
 <%
         }

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSCPPut/tSCPPut_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSCPPut/tSCPPut_end.javajet
@@ -15,15 +15,15 @@ imports="
 %>  	
 		/* Close the connection */
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Closing the connection to the server.");
+			log.debug("<%=cid%> - Closing the connection to the server.");
 		<%}%>
         conn_<%=cid%>.close();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection to the server closed.");
+			log.debug("<%=cid%> - Connection to the server closed.");
 		<%}%>
 	<%}%>
 		globalMap.put("<%=cid %>_NB_FILE",nb_file_<%=cid%>);
 			
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Uploaded files count: " + nb_file_<%=cid%> +  ".");
+			log.debug("<%=cid%> - Uploaded files count: " + nb_file_<%=cid%> +  ".");
 		<%}%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSCPRename/tSCPRename_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSCPRename/tSCPRename_begin.javajet
@@ -52,7 +52,7 @@ imports="
 		ch.ethz.ssh2.Connection conn_<%=cid %> = (ch.ethz.ssh2.Connection)globalMap.get("<%=conn %>");
 		<%if(isLog4jEnabled){%>
 			if(conn_<%=cid %>!=null) {
-				log.info("<%=cid%> - Uses an existing connection. Connection hostname: " + conn_<%=cid %>.getHostname() + ". Connection port: " + conn_<%=cid %>.getPort() + "."); 
+				log.debug("<%=cid%> - Uses an existing connection. Connection hostname: " + conn_<%=cid %>.getHostname() + ". Connection port: " + conn_<%=cid %>.getPort() + "."); 
 			}
 		<%}%>
 	<%}else{%>
@@ -72,17 +72,17 @@ imports="
 %>
               /* Now connect */
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Attempt to connect to '" + hostname_<%=cid%> + "' with the username '" + username_<%=cid%> + "'.");
+			log.debug("<%=cid%> - Attempt to connect to '" + hostname_<%=cid%> + "' with the username '" + username_<%=cid%> + "'.");
 		<%}%>
         conn_<%=cid%>.connect();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connect to '" + hostname_<%=cid%> + "' has succeeded.");
+			log.debug("<%=cid%> - Connect to '" + hostname_<%=cid%> + "' has succeeded.");
 		<%}%>
 <%        
         if (("PUBLICKEY").equals(authMethod)) {
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication using a public key");
+				log.debug("<%=cid%> - Authentication using a public key");
 				log.debug("<%=cid%> - Private key: '" + <%=privatekey%> + "'." );
 			<%}%>
         	java.io.File keyfile_<%=cid%> = new java.io.File(<%=privatekey%>); 
@@ -98,14 +98,14 @@ imports="
                 	throw new RuntimeException("Authentication failed.");
 			}
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication succeeded.");
+				log.debug("<%=cid%> - Authentication succeeded.");
 			<%}%>
 <%
         }
         if (("PASSWORD").equals(authMethod)) {
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication using a password");
+				log.debug("<%=cid%> - Authentication using a password");
 			<%}%>
 			
             <%
@@ -119,14 +119,14 @@ imports="
             	throw new RuntimeException("Authentication failed.");
         	}
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication succeeded.");
+				log.debug("<%=cid%> - Authentication succeeded.");
 		    <%}%>
 <%
         }
         if (("KEYBOARDINTERACTIVE").equals(authMethod)) {
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication using an interactive action");
+				log.debug("<%=cid%> - Authentication using an interactive action");
 			<%}%>
 	        boolean isAuthenticated_<%=cid%> = conn_<%=cid%>.authenticateWithKeyboardInteractive(username_<%=cid%>, 
 	            new ch.ethz.ssh2.InteractiveCallback() {
@@ -155,7 +155,7 @@ imports="
 	            throw new RuntimeException("Authentication failed.");
 	        }
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication succeeded.");
+				log.debug("<%=cid%> - Authentication succeeded.");
 			<%}%>
 <%
         }

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSCPRename/tSCPRename_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSCPRename/tSCPRename_end.javajet
@@ -16,11 +16,11 @@ imports="
 %>  	
 		/* Close the connection */
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Closing the connection to the server.");
+			log.debug("<%=cid%> - Closing the connection to the server.");
 		<%}%>
         conn_<%=cid%>.close();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection to the server closed.");
+			log.debug("<%=cid%> - Connection to the server closed.");
 		<%}%>
 	<%
 	}%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSCPRename/tSCPRename_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSCPRename/tSCPRename_main.javajet
@@ -41,7 +41,7 @@ imports="
 	
 	if(("").equals(stringStderr_<%=cid %>.toString()) || (stringStderr_<%=cid %>.toString() == null)){
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Rename '" + <%=fromName%> + "'  to '" + <%=toName%> + "' successfully.");
+			log.debug("<%=cid%> - Rename '" + <%=fromName%> + "'  to '" + <%=toName%> + "' successfully.");
 		<%}%>
 		globalMap.put("<%=cid %>_STATUS","File rename OK");
 	}else{

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSCPTruncate/tSCPTruncate_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSCPTruncate/tSCPTruncate_begin.javajet
@@ -61,7 +61,7 @@ imports="
 		ch.ethz.ssh2.Connection conn_<%=cid %> = (ch.ethz.ssh2.Connection)globalMap.get("<%=conn %>");
 		<%if(isLog4jEnabled){%>
 			if(conn_<%=cid %>!=null) {
-				log.info("<%=cid%> - Uses an existing connection. Connection hostname: " + conn_<%=cid %>.getHostname() + ". Connection port: " + conn_<%=cid %>.getPort() + "."); 
+				log.debug("<%=cid%> - Uses an existing connection. Connection hostname: " + conn_<%=cid %>.getHostname() + ". Connection port: " + conn_<%=cid %>.getPort() + "."); 
 			}
 		<%}%>
 	<%}else{%>
@@ -80,17 +80,17 @@ imports="
 %>
               /* Now connect */
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Attempt to connect to '" + hostname_<%=cid%> + "' with the username '" + username_<%=cid%> + "'.");
+			log.debug("<%=cid%> - Attempt to connect to '" + hostname_<%=cid%> + "' with the username '" + username_<%=cid%> + "'.");
 		<%}%>
         conn_<%=cid%>.connect();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connect to '" + hostname_<%=cid%> + "' has succeeded.");
+			log.debug("<%=cid%> - Connect to '" + hostname_<%=cid%> + "' has succeeded.");
 		<%}%>
 <%        
         if (("PUBLICKEY").equals(authMethod)) {
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication using a public key");
+				log.debug("<%=cid%> - Authentication using a public key");
 				log.debug("<%=cid%> - Private key: '" + <%=privatekey%> + "'." );
 			<%}%>
         	java.io.File keyfile_<%=cid%> = new java.io.File(<%=privatekey%>); 
@@ -106,14 +106,14 @@ imports="
                 throw new RuntimeException("Authentication failed.");
 			}
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication succeeded.");
+				log.debug("<%=cid%> - Authentication succeeded.");
 			<%}%>
 <%
         }
         if (("PASSWORD").equals(authMethod)) {
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication using a password");
+				log.debug("<%=cid%> - Authentication using a password");
 			<%}%>
 			
             <%
@@ -127,14 +127,14 @@ imports="
 	            throw new RuntimeException("Authentication failed.");
 	        }
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication succeeded.");
+				log.debug("<%=cid%> - Authentication succeeded.");
 		    <%}%>
 <%
         }
         if (("KEYBOARDINTERACTIVE").equals(authMethod)) {
 %>
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication using an interactive action");
+				log.debug("<%=cid%> - Authentication using an interactive action");
 			<%}%>
 	        boolean isAuthenticated_<%=cid%> = conn_<%=cid%>.authenticateWithKeyboardInteractive(username_<%=cid%>, 
 	            new ch.ethz.ssh2.InteractiveCallback() {
@@ -163,7 +163,7 @@ imports="
 	            throw new RuntimeException("Authentication failed.");
 	        }
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Authentication succeeded.");
+				log.debug("<%=cid%> - Authentication succeeded.");
 			<%}%>
 <%
         }
@@ -182,6 +182,6 @@ imports="
          %>
        };
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Truncating file from the server.");
+			log.debug("<%=cid%> - Truncating file from the server.");
 		<%}%>
        for(String destFile_<%=cid %> : destFileNames_<%=cid%>){

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSCPTruncate/tSCPTruncate_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSCPTruncate/tSCPTruncate_end.javajet
@@ -18,16 +18,16 @@ imports="
 %>
         /* Close the connection */
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Closing the connection to the server.");
+			log.debug("<%=cid%> - Closing the connection to the server.");
 		<%}%>
         conn_<%=cid%>.close();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection to the server closed.");
+			log.debug("<%=cid%> - Connection to the server closed.");
 		<%}%>
 <%      
     }%>
 	globalMap.put("<%=cid %>_NB_FILE",nb_file_<%=cid%>);
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Truncated files count: "+nb_file_<%=cid%> + " .");
+		log.debug("<%=cid%> - Truncated files count: "+nb_file_<%=cid%> + " .");
 	<%}%>
 			

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSOAP/tSOAP_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSOAP/tSOAP_main.javajet
@@ -100,10 +100,10 @@ if(useMessageFromSchema && (connName==null || schemaEmpty)){
 			System.err.println("Subject for Kerberos is null!");
 			<%log.logPrintedException(log.str("Subject for Kerberos is null!"));%>
 		}
-		<%log.info(log.str("Prepare to send soap request to endpoint."));%>
+		<%log.debug(log.str("Prepare to send soap request to endpoint."));%>
 		TalendPrivilegedAction talendPrivilegedAction_<%=cid%> = new TalendPrivilegedAction(<%=useMessageFromSchema?connName+", ":""%>soapVersion_<%=cid%>);
 		javax.security.auth.Subject.doAs(subject_<%=cid%>,talendPrivilegedAction_<%=cid%>);
-		<%log.info(log.str("Have sent soap request to endpoint."));%>
+		<%log.debug(log.str("Have sent soap request to endpoint."));%>
 		<%
 		if(outputDocument){
 		%>
@@ -114,7 +114,7 @@ if(useMessageFromSchema && (connName==null || schemaEmpty)){
 	<%
 	}else{	
 	%>
-		<%log.info(log.str("Prepare to send soap request to endpoint."));%>
+		<%log.debug(log.str("Prepare to send soap request to endpoint."));%>
 		<%
 		if(outputDocument){
 		%>
@@ -126,7 +126,7 @@ if(useMessageFromSchema && (connName==null || schemaEmpty)){
 		<%
 		}
 		%>
-		<%log.info(log.str("Have sent soap request to endpoint."));%>
+		<%log.debug(log.str("Have sent soap request to endpoint."));%>
 	<%
 	}
 	%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSPSSInput/tSPSSInput_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSPSSInput/tSPSSInput_begin.javajet
@@ -45,7 +45,7 @@ if (outputConnName != null){
 %>
 	org.talend.jspss.spssrecord <%=cid%>_sr;
     <%if(isLog4jEnabled){%>
-    	log.info("<%=cid%> - Retrieving records from data");
+    	log.debug("<%=cid%> - Retrieving records from data");
     <%}%>
 	while(!<%=cid%>_sf.isEOF()){
 			nb_line_<%=cid%> ++;

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSPSSInput/tSPSSInput_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSPSSInput/tSPSSInput_end.javajet
@@ -34,7 +34,7 @@ if (outputConnName != null){
 	<%=cid%>_sf.close();
 	globalMap.put("<%=cid %>_NB_LINE",nb_line_<%=cid%>);
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Retrieved records count: "+ nb_line_<%=cid%> + " .");
+		log.debug("<%=cid%> - Retrieved records count: "+ nb_line_<%=cid%> + " .");
 	<%}%>
 <%
 }

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSPSSStructure/tSPSSStructure_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSPSSStructure/tSPSSStructure_begin.javajet
@@ -37,7 +37,7 @@ if (outputConnName != null){
 	org.talend.jspss.spssvariables <%=cid%>_spVars = <%=cid%>_sf.getVariables();
 	int nb_line_<%=cid%> = 0;
     <%if(isLog4jEnabled){%>
-    	log.info("<%=cid%> - Retrieving records from data ");
+    	log.debug("<%=cid%> - Retrieving records from data ");
     <%}%>
 	for(int i=0;i<<%=cid%>_spVars.getNumberOfVariables();i++){
 		nb_line_<%=cid%> ++;

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSQSConnection/SQSClient.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSQSConnection/SQSClient.javajet
@@ -30,7 +30,7 @@
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Get an free connection from " + "<%=connection%>" + ".");
+			log.debug("<%=cid%> - Get an free connection from " + "<%=connection%>" + ".");
 		<%
 		}
 	}else{
@@ -38,7 +38,7 @@
 	    <%
 	    if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Creating new connection.");
+			log.debug("<%=cid%> - Creating new connection.");
 		<%
 		}
 		boolean inherit_credentials = "true".equals(ElementParameterParser.getValue(node, "__INHERIT_CREDENTIALS__"));
@@ -134,7 +134,7 @@
 		}
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Creating new connection successfully.");
+			log.debug("<%=cid%> - Creating new connection successfully.");
 		<%
 		}
 	}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSQSInput/tSQSInput_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSQSInput/tSQSInput_begin.javajet
@@ -32,7 +32,7 @@ imports="
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Receiving messages from :" + <%=queueUrl%>);
+			log.debug("<%=cid%> - Receiving messages from :" + <%=queueUrl%>);
 		<%
 		}
 		%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSQSInput/tSQSInput_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSQSInput/tSQSInput_end.javajet
@@ -60,7 +60,7 @@ imports="
 		<%
 			if(isLog4jEnabled){
 		%>
-				log.info("Number of Messages Read: " + nbline_<%=cid%>);
+				log.debug("Number of Messages Read: " + nbline_<%=cid%>);
 		<%
 			}
 		}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSQSMessageChangeVisibility/tSQSMessageChangeVisibility_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSQSMessageChangeVisibility/tSQSMessageChangeVisibility_begin.javajet
@@ -21,7 +21,7 @@ imports="
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Change message visibility recipet handle:" + <%=recipethandle%>);
+			log.debug("<%=cid%> - Change message visibility recipet handle:" + <%=recipethandle%>);
 		<%
 		}
 		%>
@@ -29,7 +29,7 @@ imports="
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Change message visibility successfully.");
+			log.debug("<%=cid%> - Change message visibility successfully.");
 		<%
 		}
 		%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSQSMessageDelete/tSQSMessageDelete_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSQSMessageDelete/tSQSMessageDelete_begin.javajet
@@ -20,7 +20,7 @@ imports="
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Deleting a message with recipet handle:" + <%=recipethandle%>);
+			log.debug("<%=cid%> - Deleting a message with recipet handle:" + <%=recipethandle%>);
 		<%
 		}
 		%>
@@ -29,7 +29,7 @@ imports="
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Delete the message successfully.");
+			log.debug("<%=cid%> - Delete the message successfully.");
 		<%
 		}
 		%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSQSOutput/tSQSOutput_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSQSOutput/tSQSOutput_begin.javajet
@@ -35,7 +35,7 @@ imports="
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Sending messages to :" + <%=queueUrl%>);
+			log.debug("<%=cid%> - Sending messages to :" + <%=queueUrl%>);
 		<%
 		}
 		%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSQSQueueCreate/tSQSQueueCreate_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSQSQueueCreate/tSQSQueueCreate_main.javajet
@@ -35,7 +35,7 @@ imports="
 		}
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Creating a queue with name:" + <%=queue%>);
+			log.debug("<%=cid%> - Creating a queue with name:" + <%=queue%>);
 		<%
 		}
 		%>
@@ -44,7 +44,7 @@ imports="
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Create the queue successfully [" + queueUrl_<%=cid%> + "]");
+			log.debug("<%=cid%> - Create the queue successfully [" + queueUrl_<%=cid%> + "]");
 		<%
 		}
 		%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSQSQueueDelete/tSQSQueueDelete_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSQSQueueDelete/tSQSQueueDelete_begin.javajet
@@ -19,7 +19,7 @@ imports="
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Deleting a queue with name:" + <%=queue%>);
+			log.debug("<%=cid%> - Deleting a queue with name:" + <%=queue%>);
 		<%
 		}
 		%>
@@ -28,7 +28,7 @@ imports="
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Delete the queue successfully.");
+			log.debug("<%=cid%> - Delete the queue successfully.");
 		<%
 		}
 		%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSQSQueueList/tSQSQueueList_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSQSQueueList/tSQSQueueList_begin.javajet
@@ -17,7 +17,7 @@ imports="
 	<%
 	if (isLog4jEnabled) {
 	%>
-		log.info("<%=cid%> - Retrieving queues from the server.");
+		log.debug("<%=cid%> - Retrieving queues from the server.");
 	<%
 	}
 	%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSQSQueueList/tSQSQueueList_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSQSQueueList/tSQSQueueList_end.javajet
@@ -28,7 +28,7 @@ imports="
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Retrieved queues count: " + nb_queue_<%=cid%> + " .");
+		log.debug("<%=cid%> - Retrieved queues count: " + nb_queue_<%=cid%> + " .");
 	<%		
 	}
 	%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSQSQueuePurge/tSQSQueuePurge_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSQSQueuePurge/tSQSQueuePurge_begin.javajet
@@ -19,7 +19,7 @@ imports="
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Purging a queue with name:" + <%=queue%>);
+			log.debug("<%=cid%> - Purging a queue with name:" + <%=queue%>);
 		<%
 		}
 		%>
@@ -28,7 +28,7 @@ imports="
 		<%
 		if(isLog4jEnabled){
 		%>	
-			log.info("<%=cid%> - Purge queue successfully.");
+			log.debug("<%=cid%> - Purge queue successfully.");
 		<%
 		}
 		%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSSH/tSSH_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSSH/tSSH_begin.javajet
@@ -81,7 +81,7 @@ if ((metadatas!=null)&&(metadatas.size()>0)) {
 
 	/* Create a connection instance */
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection attempt to '" +hostname_<%=cid%> + "' on the port '<%=port%>' as '" + username_<%=cid%> + "'.");
+			log.debug("<%=cid%> - Connection attempt to '" +hostname_<%=cid%> + "' on the port '<%=port%>' as '" + username_<%=cid%> + "'.");
 		<%}%>
 <%
         if(("").equals(port)){
@@ -111,7 +111,7 @@ if ((metadatas!=null)&&(metadatas.size()>0)) {
         if (("PUBLICKEY").equals(authMethod)) {
 %>
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Authentication using a public key.");
+			log.debug("<%=cid%> - Authentication using a public key.");
 		<%}%>
         java.io.File keyfile_<%=cid%> = new java.io.File(<%=privatekey%>); 
         
@@ -130,7 +130,7 @@ if ((metadatas!=null)&&(metadatas.size()>0)) {
         if (("PASSWORD").equals(authMethod)) {
 %>
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Authentication using a password.");
+			log.debug("<%=cid%> - Authentication using a password.");
 		<%}%>
 		
         <%
@@ -149,7 +149,7 @@ if ((metadatas!=null)&&(metadatas.size()>0)) {
         if (("KEYBOARDINTERACTIVE").equals(authMethod)) {
 %>
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Authentication using an interactive action.");
+			log.debug("<%=cid%> - Authentication using an interactive action.");
 		<%}%>
         boolean isAuthenticated_<%=cid%> = conn_<%=cid%>.authenticateWithKeyboardInteractive(username_<%=cid%>, 
             new ch.ethz.ssh2.InteractiveCallback() {
@@ -182,7 +182,7 @@ if ((metadatas!=null)&&(metadatas.size()>0)) {
         }
 %>
         <%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection to '" +hostname_<%=cid%> + "' has succeeded.");
+			log.debug("<%=cid%> - Connection to '" +hostname_<%=cid%> + "' has succeeded.");
 		<%}%>
 <%
     }

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSSH/tSSH_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSSH/tSSH_end.javajet
@@ -40,11 +40,11 @@ imports="
 %>
 	/* Close the connection */
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Closing the connection to the server.");
+		log.debug("<%=cid%> - Closing the connection to the server.");
 	<%}%>
 	conn_<%=cid%>.close();
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Connection to the server closed.");
+		log.debug("<%=cid%> - Connection to the server closed.");
 	<%}%>
 	globalMap.put("<%=cid %>_EXIT_CODE",sess_<%=cid%>.getExitStatus());
 	

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSendMail/tSendMail_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSendMail/tSendMail_main.javajet
@@ -122,7 +122,7 @@ boolean isLog4jEnabled = ("true").equals(ElementParameterParser.getValue(node.ge
 %>     
 	try {
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection attempt to '" + smtpHost_<%=cid %> +"'.");
+			log.debug("<%=cid%> - Connection attempt to '" + smtpHost_<%=cid %> +"'.");
 		<%}%>
 		<%if ("false".equals(needAuth)) { %>  
 			props_<%=cid %>.put("mail.smtp.auth", "false");
@@ -143,7 +143,7 @@ boolean isLog4jEnabled = ("true").equals(ElementParameterParser.getValue(node.ge
 			});   
 		<%}%>
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection to '" + smtpHost_<%=cid %> + "' has succeeded.");
+			log.debug("<%=cid%> - Connection to '" + smtpHost_<%=cid %> + "' has succeeded.");
 		<%}%>
 		javax.mail.Message msg_<%=cid %> = new javax.mail.internet.MimeMessage(session_<%=cid %>);
 		msg_<%=cid %>.setFrom(new javax.mail.internet.InternetAddress(from_<%=cid %>, <%=personalName%>));

--- a/main/plugins/org.talend.designer.components.localprovider/components/tServiceNowConnection/tServiceNowConnection_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tServiceNowConnection/tServiceNowConnection_begin.javajet
@@ -47,8 +47,8 @@ try {//B
 		<%=cid%>_responsePhrase = <%=cid%>_response.getStatusLine().getReasonPhrase();
 		if(<%=cid%>_executionCode == 200) {
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Executing request '" + <%=cid%>_httpget.getRequestLine() + "'");
-  				log.info("<%=cid%> - Execution code '" + <%=cid%>_executionCode + "'");
+				log.debug("<%=cid%> - Executing request '" + <%=cid%>_httpget.getRequestLine() + "'");
+  				log.debug("<%=cid%> - Execution code '" + <%=cid%>_executionCode + "'");
   			<%}%>
 		}
 		globalMap.put("httpHost_conn_<%=cid%>", serviceNowURL_<%=cid%>);

--- a/main/plugins/org.talend.designer.components.localprovider/components/tServiceNowInput/tServiceNowInput_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tServiceNowInput/tServiceNowInput_begin.javajet
@@ -222,7 +222,7 @@ if(!hasDynamic) {
 <%
 if(isLog4jEnabled){
   %>
-  log.info("<%=cid%> - Executing method '" + <%=cid%>_httpget.getRequestLine().getMethod() + "'");
+  log.debug("<%=cid%> - Executing method '" + <%=cid%>_httpget.getRequestLine().getMethod() + "'");
   <%
 }
 %>
@@ -231,7 +231,7 @@ org.apache.http.client.methods.CloseableHttpResponse <%=cid%>_response = <%=cid%
 <%
 if(isLog4jEnabled){
   %>
-  log.info("<%=cid%> - Execution code '" + <%=cid%>_response.getStatusLine().getStatusCode() + "'");
+  log.debug("<%=cid%> - Execution code '" + <%=cid%>_response.getStatusLine().getStatusCode() + "'");
   <%
 }
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tServiceNowOutput/tServiceNowOutput_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tServiceNowOutput/tServiceNowOutput_end.javajet
@@ -29,9 +29,9 @@ if(isLog4jEnabled) {
 	} else {
 		<%
 		if("insert".equals(dataAction)) {
-			%>log.info("<%=cid%> - Inserted records count: " + nb_line_inserted_<%=cid%> + ".'");<%
+			%>log.debug("<%=cid%> - Inserted records count: " + nb_line_inserted_<%=cid%> + ".'");<%
 		} else {
-			%>log.info("<%=cid%> - Updated records count: " + nb_line_update_<%=cid%> + ".'");<%
+			%>log.debug("<%=cid%> - Updated records count: " + nb_line_update_<%=cid%> + ".'");<%
 		}
 		%>
 	}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tServiceNowOutput/tServiceNowOutput_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tServiceNowOutput/tServiceNowOutput_main.javajet
@@ -103,7 +103,7 @@ if ((metadatas!=null)&&(metadatas.size()>0)) {//1
 				<%
 				if (isEnablePayloadDebug) {//9
 					if(isLog4jEnabled){
-						%>log.info("<%=cid%> - Payload: '" + <%=cid%>_Payload + "'.");<%
+						%>log.debug("<%=cid%> - Payload: '" + <%=cid%>_Payload + "'.");<%
 					}
 					%>globalMap.put("<%=cid %>_PAYLOAD", <%=cid%>_Payload);<%
 				}//9
@@ -125,7 +125,7 @@ if ((metadatas!=null)&&(metadatas.size()>0)) {//1
 						<%=cid%>_entity = new org.apache.http.entity.StringEntity(<%=cid%>_PayloadArray.get(0).toString());
 						<%=cid%>_httpPost.setEntity(<%=cid%>_entity);
 						<%if(isLog4jEnabled){%>
-							log.info("<%=cid%> - Executing '" + "<%=dataAction%>".toUpperCase() + "' request.");
+							log.debug("<%=cid%> - Executing '" + "<%=dataAction%>".toUpperCase() + "' request.");
 							<%
 						}
 						%>
@@ -152,7 +152,7 @@ if ((metadatas!=null)&&(metadatas.size()>0)) {//1
 						<%
 						if(isLog4jEnabled){
 							%>
-							log.info("<%=cid%> - Executing '" + "<%=dataAction%>".toUpperCase() + "' request.");
+							log.debug("<%=cid%> - Executing '" + "<%=dataAction%>".toUpperCase() + "' request.");
 							<%
 						}
 						%>
@@ -186,7 +186,7 @@ if ((metadatas!=null)&&(metadatas.size()>0)) {//1
 					}
 					if(isLog4jEnabled) {
 						%>
-						log.info("<%=cid%> - Execution code '" + <%=cid%>_responseCode + "'.");
+						log.debug("<%=cid%> - Execution code '" + <%=cid%>_responseCode + "'.");
 						<%
 					}
 					if (isEnableResponseDebug) {
@@ -194,7 +194,7 @@ if ((metadatas!=null)&&(metadatas.size()>0)) {//1
 						<%
 						if(isLog4jEnabled) {
 							%>
-							log.info("<%=cid%> - Response: '" + <%=cid%>_responseBody + "'.");
+							log.debug("<%=cid%> - Response: '" + <%=cid%>_responseBody + "'.");
 							<%
 						}
 						%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSetEnv/tSetEnv_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSetEnv/tSetEnv_main.javajet
@@ -21,7 +21,7 @@ imports="
             boolean isLog4jEnabled = ("true").equals(ElementParameterParser.getValue(node.getProcess(), "__LOG4J_ACTIVATE__")); 
             List<Map<String, String>> params = (List<Map<String,String>>)ElementParameterParser.getObjectValue(node,"__PARAMS__");
 				if(isLog4jEnabled){%>
-		        	log.info("<%=cid%> - Setting environment variables.");
+		        	log.debug("<%=cid%> - Setting environment variables.");
 				<%}
         	    for (int i = 0; i < params.size(); i++) {
     	            Map<String, String> line = params.get(i);

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSybaseBulkExec/tSybaseBulkExec_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSybaseBulkExec/tSybaseBulkExec_begin.javajet
@@ -182,7 +182,7 @@ if(encoding_<%=cid%> != null && encoding_<%=cid%>.trim().length() > 0) {
 <%
 if(isLog4jEnabled){
 %>
-	log.info("<%=cid%> - Executing command:'" + command_<%=cid %> + "'.");
+	log.debug("<%=cid%> - Executing command:'" + command_<%=cid %> + "'.");
 <%
 }
 if(("INSERT").equals(dataAction)) {
@@ -195,12 +195,12 @@ if(("INSERT").equals(dataAction)) {
         %>
         java.sql.Statement stmtCreateTmp_<%=cid%> = conn_<%=cid%>.createStatement();
         <%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Creating temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
+			log.debug("<%=cid%> - Creating temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
 		<%}%>
         stmtCreateTmp_<%=cid%>.execute("<%=manager.getCreateTableSQL(stmtStructure)%>)");
         stmtCreateTmp_<%=cid%>.close();            
         <%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Create temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
+			log.debug("<%=cid%> - Create temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
 		<%}%>
         Runtime runtime_<%=cid%> = Runtime.getRuntime();
         final Process ps_<%=cid %> = runtime_<%=cid%>.exec(command_<%=cid %>.toString());       
@@ -273,7 +273,7 @@ ps_<%=cid %>.waitFor();
 normal_<%=cid%>.interrupt();
 error_<%=cid%>.interrupt();
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - Excute command: '" + command_<%=cid %> + "' has finished.");
+	log.debug("<%=cid%> - Excute command: '" + command_<%=cid %> + "' has finished.");
 <%
 }
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSybaseBulkExec/tSybaseBulkExec_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSybaseBulkExec/tSybaseBulkExec_end.javajet
@@ -35,7 +35,7 @@ if(("UPDATE").equals(dataAction)) {
     	}
         java.sql.Statement stmtUpdateBulk_<%=cid%> = conn_<%=cid%>.createStatement();
         <%if(isLog4jEnabled){%>
-            log.info("<%=cid%> - Updating <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> from <%=manager.getLProtectedChar()%>"+tmpTableName_<%=cid%>+"<%=manager.getRProtectedChar()%>.");
+            log.debug("<%=cid%> - Updating <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> from <%=manager.getLProtectedChar()%>"+tmpTableName_<%=cid%>+"<%=manager.getRProtectedChar()%>.");
         <%}%>
         stmtUpdateBulk_<%=cid%>.executeUpdate("<%=manager.getUpdateBulkSQL(columnList)%>");
         <%log4jCodeGenerateUtil.logInfo(node,"info",cid+" - Update has finished.");%>
@@ -43,11 +43,11 @@ if(("UPDATE").equals(dataAction)) {
         tableName_<%=cid%> = tmpTableName_<%=cid%>;
         java.sql.Statement stmtTmpDrop_<%=cid%> = conn_<%=cid%>.createStatement();
         <%if(isLog4jEnabled){%>
-            log.info("<%=cid%> - Droping table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
+            log.debug("<%=cid%> - Droping table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
         <%}%>
         stmtTmpDrop_<%=cid%>.execute("<%=manager.getDropTableSQL()%>");
         <%if(isLog4jEnabled){%>
-            log.info("<%=cid%> - Drop table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
+            log.debug("<%=cid%> - Drop table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
         <%}%>
         stmtTmpDrop_<%=cid%>.close();         
         <%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSybaseIQBulkExec/tSybaseIQBulkExec_begin_Load.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSybaseIQBulkExec/tSybaseIQBulkExec_begin_Load.javajet
@@ -186,8 +186,8 @@ if(columnList != null && columnList.size() > 0) {
 	}
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Bulk load SQL:"+strSQL_<%=cid%>+".");
-		log.info("<%=cid%> - Bulk loading data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
+		log.debug("<%=cid%> - Bulk load SQL:"+strSQL_<%=cid%>+".");
+		log.debug("<%=cid%> - Bulk loading data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
 	<%
 	}
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSybaseSP/tSybaseSP_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSybaseSP/tSybaseSP_main.javajet
@@ -231,7 +231,7 @@ if (canGenerate) {
 		
 		%>
 	<%
-		dbLog.info(dbLog.str("Try to execute store procedure:"),spName,dbLog.str("."));
+		dblog.debug(dbLog.str("Try to execute store procedure:"),spName,dbLog.str("."));
 	if (isFunction) {
 	%>
 		java.sql.ResultSet rs_<%=cid%> = statement_<%=cid%>.executeQuery();
@@ -249,7 +249,7 @@ if (canGenerate) {
 		statement_<%=cid%>.execute();
 	<%
 	}
-		dbLog.info(dbLog.str("The store procedure:"),spName,dbLog.str(" executed successfully."));
+		dblog.debug(dbLog.str("The store procedure:"),spName,dbLog.str(" executed successfully."));
 	%>
 		<%
 		

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSystem/tSystem_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSystem/tSystem_begin.javajet
@@ -77,7 +77,7 @@ java.util.Map<String,String> envMapClone_<%=cid %>= new java.util.HashMap();
 envMapClone_<%=cid %>.putAll(envMap_<%=cid %>);
 
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - Setting the parameters.");
+	log.debug("<%=cid%> - Setting the parameters.");
 <%}%>
 <%
     for (int i = 0; i < params.size(); i++) {
@@ -102,7 +102,7 @@ for (String envKey : (java.util.Set<String>) envMapClone_<%=cid %>.keySet()) {
 
 if(ifDir){%>
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Root directory: '" + <%=rootDir%> + "'.");
+		log.debug("<%=cid%> - Root directory: '" + <%=rootDir%> + "'.");
 	<%}%>
 final Process ps_<%=cid %> = runtime_<%=cid %>.exec(<% if(single_command) { %> <%= command%> <% } else { %>command_<%=cid %> <% } %>,env_<%=cid %>,new java.io.File(<%=rootDir%>));
 <%  }else{%>
@@ -175,12 +175,12 @@ Thread normal_<%=cid %> = new Thread() {
 	}
 };
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - Executing the command.");
-	log.info("<%=cid%> - Command to execute: '" + <% if(single_command) { %> <%= command%> <% } else { %>commandArrayForLog_<%=cid%> <% } %> + "'.");
+	log.debug("<%=cid%> - Executing the command.");
+	log.debug("<%=cid%> - Command to execute: '" + <% if(single_command) { %> <%= command%> <% } else { %>commandArrayForLog_<%=cid%> <% } %> + "'.");
 <%}%>
 normal_<%=cid %>.start();
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - The command has been executed successfully.");
+	log.debug("<%=cid%> - The command has been executed successfully.");
 <%}%>
 
 Thread error_<%=cid %> = new Thread() {

--- a/main/plugins/org.talend.designer.components.localprovider/components/tTeradataFastExport/tTeradataFastExport_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tTeradataFastExport/tTeradataFastExport_main.javajet
@@ -170,7 +170,7 @@ try{
         strArr_<%= cid %>[2] = expCmd_<%= cid %>;
 
     <%if(isLog4jEnabled){%>
-        log.info("<%=cid%> - Executing command '" + expCmd_<%= cid %> + "'.");
+        log.debug("<%=cid%> - Executing command '" + expCmd_<%= cid %> + "'.");
     <%}%>
     final Process process_<%=cid %> = Runtime.getRuntime().exec(strArr_<%= cid %>);
 
@@ -229,7 +229,7 @@ try{
      %>
 
     <%if(isLog4jEnabled){%>
-        log.info("<%=cid%> - Excute '" + expCmd_<%= cid %> + "' has finished.");
+        log.debug("<%=cid%> - Excute '" + expCmd_<%= cid %> + "' has finished.");
     <%}%>
 }finally{
     file_<%=cid %>.delete();

--- a/main/plugins/org.talend.designer.components.localprovider/components/tTeradataFastLoad/tTeradataFastLoad_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tTeradataFastLoad/tTeradataFastLoad_end.javajet
@@ -28,20 +28,20 @@ imports="
 pstmt_<%=cid %>.close();
 
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - Starting to commit.");
+	log.debug("<%=cid%> - Starting to commit.");
 <%}%>
 
 conn_<%=cid%>.commit();
 
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - Commit has succeeded.");
-	log.info("<%=cid%> - Closing the connection to the database.");
+	log.debug("<%=cid%> - Commit has succeeded.");
+	log.debug("<%=cid%> - Closing the connection to the database.");
 <%}%>
 
 conn_<%=cid%> .close();
 
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - Connection to the database closed.");
+	log.debug("<%=cid%> - Connection to the database closed.");
 <%}%>
 
 	nb_line_inserted_<%=cid%> += insertedCount_<%=cid%>;
@@ -49,5 +49,5 @@ conn_<%=cid%> .close();
 	globalMap.put("<%=cid %>_NB_LINE_INSERTED",nb_line_inserted_<%=cid%>);
 
 <%if(isLog4jEnabled){%>
-	log.info("<%=cid%> - Loaded records count:" + nb_line_inserted_<%=cid%> + "." );
+	log.debug("<%=cid%> - Loaded records count:" + nb_line_inserted_<%=cid%> + "." );
 <%}%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tTeradataFastLoadUtility/tTeradataFastLoadUtility_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tTeradataFastLoadUtility/tTeradataFastLoadUtility_main.javajet
@@ -149,7 +149,7 @@ String sb_<%=cid%>= new String("fastload -c "+<%=charset%>+" < \""+<%=scriptPath
 String sb_<%=cid%>= new String("fastload < \""+<%=scriptPath%>+<%=table%>+".script\" > \""+<%=errorFile%>+"\" 2>&1");
 <%}%>
 <%if(isLog4jEnabled){%>
-    log.info("<%=cid%> - Executing '" + sb_<%=cid%> + "'.");
+    log.debug("<%=cid%> - Executing '" + sb_<%=cid%> + "'.");
 <%}%>
 <%if(("Windows").equals(execution)){%>
 final Process process_<%=cid %> = Runtime.getRuntime().exec(new String[]{"cmd","/c",sb_<%=cid%>});
@@ -215,7 +215,7 @@ if(returnCodeDie) {
 %>
 
 <%if(isLog4jEnabled){%>
-    log.info("<%=cid%> - Excute '" + sb_<%=cid%> + "' has finished.");
+    log.debug("<%=cid%> - Excute '" + sb_<%=cid%> + "' has finished.");
 <%}%>
 }finally{
     try{

--- a/main/plugins/org.talend.designer.components.localprovider/components/tTeradataMultiLoad/tTeradataMultiLoad_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tTeradataMultiLoad/tTeradataMultiLoad_main.javajet
@@ -171,7 +171,7 @@ String sb_<%=cid%>= new String("mload -c "+<%=charset%>+" < \""+<%=scriptPath%>+
 String sb_<%=cid%>= new String("mload < \""+<%=scriptPath%>+<%=table%>+".script\" > \""+<%=errorFile%>+"\" 2>&1");
 <%}%>
 <%if(isLog4jEnabled){%>
-    log.info("<%=cid%> - Executing command '" + sb_<%=cid%> + "'.");
+    log.debug("<%=cid%> - Executing command '" + sb_<%=cid%> + "'.");
 <%}%>
 <%if(("Windows").equals(execution)){%>
 final Process process_<%=cid %> = Runtime.getRuntime().exec(new String[]{"cmd","/c",sb_<%=cid%>}); 
@@ -236,7 +236,7 @@ if(returnCodeDie) {
 }
 %>
 <%if(isLog4jEnabled){%>
-    log.info("<%=cid%> - Excute '" + sb_<%=cid%> + "' has finished.");
+    log.debug("<%=cid%> - Excute '" + sb_<%=cid%> + "' has finished.");
 <%}%>
 }finally{
 	try{

--- a/main/plugins/org.talend.designer.components.localprovider/components/tTeradataTPTExec/tTeradataTPTExec_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tTeradataTPTExec/tTeradataTPTExec_main.javajet
@@ -547,7 +547,7 @@ try{
                 }%>
                 <%if(isLog4jEnabled){%>
                 	String cmdStr_<%= cid %> = java.util.Arrays.toString(sb_<%=cid%>);
-                    log.info("<%=cid%> - Executing command: '" + cmdStr_<%= cid %> + "'.");
+                    log.debug("<%=cid%> - Executing command: '" + cmdStr_<%= cid %> + "'.");
                 <%}%>
                 final Process process_<%=cid %> = Runtime.getRuntime().exec(sb_<%=cid%>);
                 Thread normal_<%=cid %> = new Thread() {
@@ -608,7 +608,7 @@ try{
                 }
                 %>
                 <%if(isLog4jEnabled){%>
-                    log.info("<%=cid%> - Excute command:'" + cmdStr_<%= cid %> + "' has finished.");
+                    log.debug("<%=cid%> - Excute command:'" + cmdStr_<%= cid %> + "' has finished.");
                 <%}%>
 }finally{
 	try{

--- a/main/plugins/org.talend.designer.components.localprovider/components/tTeradataTPump/tTeradataTPump_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tTeradataTPump/tTeradataTPump_main.javajet
@@ -186,7 +186,7 @@ fw_<%=cid %>.close();
 }%>
 <%if(isLog4jEnabled){%>
 	String cmdStr_<%= cid %> = java.util.Arrays.toString(sb_<%=cid%>);
-    log.info("<%=cid%> - Executing command: '" + cmdStr_<%= cid %> + "'.");
+    log.debug("<%=cid%> - Executing command: '" + cmdStr_<%= cid %> + "'.");
 <%}%>
 final Process process_<%=cid %> = Runtime.getRuntime().exec(sb_<%=cid%>); 
 Thread normal_<%=cid %> = new Thread() {
@@ -247,7 +247,7 @@ if(returnCodeDie) {
 }
 %>
 <%if(isLog4jEnabled){%>
-    log.info("<%=cid%> - Excute command:'" + cmdStr_<%= cid %> + "' has finished.");
+    log.debug("<%=cid%> - Excute command:'" + cmdStr_<%= cid %> + "' has finished.");
 <%}%>
 }finally{
 	try{

--- a/main/plugins/org.talend.designer.components.localprovider/components/tUniqRow/tUniqRow_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tUniqRow/tUniqRow_begin.javajet
@@ -167,7 +167,7 @@ int nb_duplicates_<%=cid %> = 0;
 <%
 if (isLog4jEnabled) {
 %>
-	log.info("<%=cid%> - Start to process the data from datasource.");
+	log.debug("<%=cid%> - Start to process the data from datasource.");
 <%
 }
 if(hasKey){%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tUniqRow/tUniqRow_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tUniqRow/tUniqRow_end.javajet
@@ -18,8 +18,8 @@ globalMap.put("<%=cid %>_NB_DUPLICATES",nb_duplicates_<%=cid %>);
 <%
 if(isLog4jEnabled){
 %>
-	log.info("<%=cid%> - Unique records count: " + (nb_uniques_<%=cid %>)+" .");
-	log.info("<%=cid%> - Duplicate records count: " + (nb_duplicates_<%=cid %>)+" .");
+	log.debug("<%=cid%> - Unique records count: " + (nb_uniques_<%=cid %>)+" .");
+	log.debug("<%=cid%> - Duplicate records count: " + (nb_duplicates_<%=cid %>)+" .");
 <%
 }
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tUniqRow/tUniqRow_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tUniqRow/tUniqRow_main.javajet
@@ -131,7 +131,7 @@ new_<%=cid %>.<%=column.getLabel() %> = <%=connName %>.<%=column.getLabel() %>;
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Writing the unique record " + (nb_uniques_<%=cid %>+1) + " into <%=conn.getName() %>.");
+		log.debug("<%=cid%> - Writing the unique record " + (nb_uniques_<%=cid %>+1) + " into <%=conn.getName() %>.");
 	<%
 	}
 	%>
@@ -196,7 +196,7 @@ if(<%=conn.getName() %> == null){
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Writing the duplicate record " + (nb_duplicates_<%=cid %>+1) + " into <%=conn.getName() %>.");
+		log.debug("<%=cid%> - Writing the duplicate record " + (nb_duplicates_<%=cid %>+1) + " into <%=conn.getName() %>.");
 	<%
 	}
 	%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tUniqRowIn/tUniqRowIn_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tUniqRowIn/tUniqRowIn_begin.javajet
@@ -109,7 +109,7 @@ if(mode == UNIQUE){//HSS_____0
                     <%
 					if (isLog4jEnabled) {
 					%>
-						log.info("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
+						log.debug("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
 					<%
 					}
 					%>
@@ -119,7 +119,7 @@ if(mode == UNIQUE){//HSS_____0
                 	<%
 					if (isLog4jEnabled) {
 					%>
-						log.info("<%=cid%> - Writing the data into: "+file.getPath());
+						log.debug("<%=cid%> - Writing the data into: "+file.getPath());
 					<%
 					}
 					%>
@@ -130,7 +130,7 @@ if(mode == UNIQUE){//HSS_____0
 					<%
 					if (isLog4jEnabled) {
 					%>
-						log.info("<%=cid%> - Wrote successfully.");
+						log.debug("<%=cid%> - Wrote successfully.");
 					<%
 					}
 					%>
@@ -187,7 +187,7 @@ if(mode == UNIQUE){//HSS_____0
                 <%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
+					log.debug("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
 				<%
 				}
 				%>
@@ -200,7 +200,7 @@ if(mode == UNIQUE){//HSS_____0
             	<%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Writing the data into: "+file.getPath());
+					log.debug("<%=cid%> - Writing the data into: "+file.getPath());
 				<%
 				}
 				%>
@@ -214,7 +214,7 @@ if(mode == UNIQUE){//HSS_____0
              	<%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Wrote successfully.");
+					log.debug("<%=cid%> - Wrote successfully.");
 				<%
 				}
 				%>
@@ -260,7 +260,7 @@ if(mode == UNIQUE){//HSS_____0
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Writing the unique record " + (nb_uniq_<%=cid %>+1) + " into <%=connUniqName %>.");
+		log.debug("<%=cid%> - Writing the unique record " + (nb_uniq_<%=cid %>+1) + " into <%=connUniqName %>.");
 	<%
 	}
     for(IMetadataColumn column : columnList){//HSS_____0_____1
@@ -334,7 +334,7 @@ if(mode == UNIQUE){//HSS_____0
                    	<%
 					if (isLog4jEnabled) {
 					%>
-						log.info("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
+						log.debug("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
 					<%
 					}
 					%>
@@ -344,7 +344,7 @@ if(mode == UNIQUE){//HSS_____0
                 	<%
 					if (isLog4jEnabled) {
 					%>
-						log.info("<%=cid%> - Writing the data into: "+file.getPath());
+						log.debug("<%=cid%> - Writing the data into: "+file.getPath());
 					<%
 					}
 					%>
@@ -355,7 +355,7 @@ if(mode == UNIQUE){//HSS_____0
 	             	<%
 					if (isLog4jEnabled) {
 					%>
-						log.info("<%=cid%> - Wrote successfully.");
+						log.debug("<%=cid%> - Wrote successfully.");
 					<%
 					}
 					%>
@@ -389,7 +389,7 @@ if(mode == UNIQUE){//HSS_____0
                             <%
 							if (isLog4jEnabled) {
 							%>
-								log.info("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
+								log.debug("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
 							<%
 							}
 							%>
@@ -399,7 +399,7 @@ if(mode == UNIQUE){//HSS_____0
                         	<%
 							if (isLog4jEnabled) {
 							%>
-								log.info("<%=cid%> - Writing the data into: "+file.getPath());
+								log.debug("<%=cid%> - Writing the data into: "+file.getPath());
 							<%
 							}
 							%>
@@ -410,7 +410,7 @@ if(mode == UNIQUE){//HSS_____0
 			             	<%
 							if (isLog4jEnabled) {
 							%>
-								log.info("<%=cid%> - Wrote successfully.");
+								log.debug("<%=cid%> - Wrote successfully.");
 							<%
 							}
 							%>
@@ -439,7 +439,7 @@ if(mode == UNIQUE){//HSS_____0
                                     <%
 									if (isLog4jEnabled) {
 									%>
-										log.info("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
+										log.debug("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
 									<%
 									}
 									%>
@@ -449,7 +449,7 @@ if(mode == UNIQUE){//HSS_____0
 		                        	<%
 									if (isLog4jEnabled) {
 									%>
-										log.info("<%=cid%> - Writing the data into: "+file.getPath());
+										log.debug("<%=cid%> - Writing the data into: "+file.getPath());
 									<%
 									}
 									%>
@@ -460,7 +460,7 @@ if(mode == UNIQUE){//HSS_____0
 					             	<%
 									if (isLog4jEnabled) {
 									%>
-										log.info("<%=cid%> - Wrote successfully.");
+										log.debug("<%=cid%> - Wrote successfully.");
 									<%
 									}
 									%>
@@ -499,7 +499,7 @@ if(mode == UNIQUE){//HSS_____0
 				<%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
+					log.debug("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
 				<%
 				}
 				%>
@@ -511,7 +511,7 @@ if(mode == UNIQUE){//HSS_____0
             	<%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Writing the data into: "+file.getPath());
+					log.debug("<%=cid%> - Writing the data into: "+file.getPath());
 				<%
 				}
 				%>
@@ -524,7 +524,7 @@ if(mode == UNIQUE){//HSS_____0
 				<%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Wrote successfully.");
+					log.debug("<%=cid%> - Wrote successfully.");
 				<%
 				}
 				%>
@@ -545,7 +545,7 @@ if(mode == UNIQUE){//HSS_____0
                 <%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
+					log.debug("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
 				<%
 				}
 				%>
@@ -555,7 +555,7 @@ if(mode == UNIQUE){//HSS_____0
             	<%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Writing the data into: "+file.getPath());
+					log.debug("<%=cid%> - Writing the data into: "+file.getPath());
 				<%
 				}
 				%>
@@ -566,7 +566,7 @@ if(mode == UNIQUE){//HSS_____0
 				<%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Wrote successfully.");
+					log.debug("<%=cid%> - Wrote successfully.");
 				<%
 				}
 				%>
@@ -654,7 +654,7 @@ if(mode == UNIQUE){//HSS_____0
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Writing the duplicate record " + (nb_duplicate_<%=cid %>+1) + " into <%=connDuplicateName %>.");
+		log.debug("<%=cid%> - Writing the duplicate record " + (nb_duplicate_<%=cid %>+1) + " into <%=connDuplicateName %>.");
 	<%
 	}
     for(IMetadataColumn column : columnList){//HSS_____0_____1
@@ -693,7 +693,7 @@ if(mode == UNIQUE){//HSS_____0
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Writing the unique record " + (nb_uniq_<%=cid %>+1) + " into <%=connUniqName %>.");
+		log.debug("<%=cid%> - Writing the unique record " + (nb_uniq_<%=cid %>+1) + " into <%=connUniqName %>.");
 	<%
 	}
     for(IMetadataColumn column : columnList){//HSS_____0_____1
@@ -734,7 +734,7 @@ if(mode == UNIQUE){//HSS_____0
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Writing the unique record " + (nb_uniq_<%=cid %>+1) + " into <%=connUniqName %>.");
+		log.debug("<%=cid%> - Writing the unique record " + (nb_uniq_<%=cid %>+1) + " into <%=connUniqName %>.");
 	<%
 	}
     for(IMetadataColumn column : columnList){//HSS_____0_____1
@@ -773,7 +773,7 @@ if(mode == UNIQUE){//HSS_____0
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Writing the duplicate record " + (nb_duplicate_<%=cid %>+1) + " into <%=connDuplicateName %>.");
+		log.debug("<%=cid%> - Writing the duplicate record " + (nb_duplicate_<%=cid %>+1) + " into <%=connDuplicateName %>.");
 	<%
 	}
     for(IMetadataColumn column : columnList){//HSS_____0_____1
@@ -875,7 +875,7 @@ if(mode == UNIQUE){//HSS_____0
 	                        <%
 							if (isLog4jEnabled) {
 							%>
-								log.info("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
+								log.debug("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
 							<%
 							}
 							%>
@@ -885,7 +885,7 @@ if(mode == UNIQUE){//HSS_____0
                         	<%
 							if (isLog4jEnabled) {
 							%>
-								log.info("<%=cid%> - Writing the data into: "+file.getPath());
+								log.debug("<%=cid%> - Writing the data into: "+file.getPath());
 							<%
 							}
 							%>
@@ -896,7 +896,7 @@ if(mode == UNIQUE){//HSS_____0
 							<%
 							if (isLog4jEnabled) {
 							%>
-								log.info("<%=cid%> - Wrote successfully.");
+								log.debug("<%=cid%> - Wrote successfully.");
 							<%
 							}
 							%>
@@ -925,7 +925,7 @@ if(mode == UNIQUE){//HSS_____0
 	                        <%
 							if (isLog4jEnabled) {
 							%>
-								log.info("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
+								log.debug("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
 							<%
 							}
 							%>
@@ -936,7 +936,7 @@ if(mode == UNIQUE){//HSS_____0
                         	<%
 							if (isLog4jEnabled) {
 							%>
-								log.info("<%=cid%> - Writing the data into: "+file.getPath());
+								log.debug("<%=cid%> - Writing the data into: "+file.getPath());
 							<%
 							}
 							%>
@@ -947,7 +947,7 @@ if(mode == UNIQUE){//HSS_____0
 							<%
 							if (isLog4jEnabled) {
 							%>
-								log.info("<%=cid%> - Wrote successfully.");
+								log.debug("<%=cid%> - Wrote successfully.");
 							<%
 							}
 							%>
@@ -1005,7 +1005,7 @@ if(mode == UNIQUE){//HSS_____0
                         <%
 						if (isLog4jEnabled) {
 						%>
-							log.info("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
+							log.debug("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
 						<%
 						}
 						%>
@@ -1015,7 +1015,7 @@ if(mode == UNIQUE){//HSS_____0
                     	<%
 						if (isLog4jEnabled) {
 						%>
-							log.info("<%=cid%> - Writing the data into: "+file.getPath());
+							log.debug("<%=cid%> - Writing the data into: "+file.getPath());
 						<%
 						}
 						%>
@@ -1026,7 +1026,7 @@ if(mode == UNIQUE){//HSS_____0
 						<%
 						if (isLog4jEnabled) {
 						%>
-							log.info("<%=cid%> - Wrote successfully.");
+							log.debug("<%=cid%> - Wrote successfully.");
 						<%
 						}
 						%>
@@ -1061,7 +1061,7 @@ if(mode == UNIQUE){//HSS_____0
                 <%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
+					log.debug("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
 				<%
 				}
 				%>
@@ -1074,7 +1074,7 @@ if(mode == UNIQUE){//HSS_____0
             	<%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Writing the data into: "+file.getPath());
+					log.debug("<%=cid%> - Writing the data into: "+file.getPath());
 				<%
 				}
 				%>
@@ -1087,7 +1087,7 @@ if(mode == UNIQUE){//HSS_____0
 				<%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Wrote successfully.");
+					log.debug("<%=cid%> - Wrote successfully.");
 				<%
 				}
 				%>
@@ -1108,7 +1108,7 @@ if(mode == UNIQUE){//HSS_____0
                 <%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
+					log.debug("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
 				<%
 				}
 				%>
@@ -1118,7 +1118,7 @@ if(mode == UNIQUE){//HSS_____0
             	<%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Writing the data into: "+file.getPath());
+					log.debug("<%=cid%> - Writing the data into: "+file.getPath());
 				<%
 				}
 				%>
@@ -1129,7 +1129,7 @@ if(mode == UNIQUE){//HSS_____0
 				<%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Wrote successfully.");
+					log.debug("<%=cid%> - Wrote successfully.");
 				<%
 				}
 				%>
@@ -1218,7 +1218,7 @@ if(mode == UNIQUE){//HSS_____0
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Writing the duplicate record " + (nb_duplicate_<%=cid %>+1) + " into <%=connDuplicateName %>.");
+		log.debug("<%=cid%> - Writing the duplicate record " + (nb_duplicate_<%=cid %>+1) + " into <%=connDuplicateName %>.");
 	<%
 	}
     for(IMetadataColumn column : columnList){//HSS_____0_____1
@@ -1257,7 +1257,7 @@ if(mode == UNIQUE){//HSS_____0
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Writing the unique record " + (nb_uniq_<%=cid %>+1) + " into <%=connUniqName %>.");
+		log.debug("<%=cid%> - Writing the unique record " + (nb_uniq_<%=cid %>+1) + " into <%=connUniqName %>.");
 	<%
 	}
     for(IMetadataColumn column : columnList){//HSS_____0_____1
@@ -1298,7 +1298,7 @@ if(mode == UNIQUE){//HSS_____0
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Writing the unique record " + (nb_uniq_<%=cid %>+1) + " into <%=connUniqName %>.");
+		log.debug("<%=cid%> - Writing the unique record " + (nb_uniq_<%=cid %>+1) + " into <%=connUniqName %>.");
 	<%
 	}
     for(IMetadataColumn column : columnList){//HSS_____0_____1
@@ -1337,7 +1337,7 @@ if(mode == UNIQUE){//HSS_____0
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Writing the duplicate record " + (nb_duplicate_<%=cid %>+1) + " into <%=connDuplicateName %>.");
+		log.debug("<%=cid%> - Writing the duplicate record " + (nb_duplicate_<%=cid %>+1) + " into <%=connDuplicateName %>.");
 	<%
 	}
     for(IMetadataColumn column : columnList){//HSS_____0_____1
@@ -1442,7 +1442,7 @@ if(mode == UNIQUE){//HSS_____0
                             <%
 							if (isLog4jEnabled) {
 							%>
-								log.info("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
+								log.debug("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
 							<%
 							}
 							%>
@@ -1452,7 +1452,7 @@ if(mode == UNIQUE){//HSS_____0
                         	<%
 							if (isLog4jEnabled) {
 							%>
-								log.info("<%=cid%> - Writing the data into: "+file.getPath());
+								log.debug("<%=cid%> - Writing the data into: "+file.getPath());
 							<%
 							}
 							%>
@@ -1463,7 +1463,7 @@ if(mode == UNIQUE){//HSS_____0
 							<%
 							if (isLog4jEnabled) {
 							%>
-								log.info("<%=cid%> - Wrote successfully.");
+								log.debug("<%=cid%> - Wrote successfully.");
 							<%
 							}
 							%>
@@ -1492,7 +1492,7 @@ if(mode == UNIQUE){//HSS_____0
                                     <%
 									if (isLog4jEnabled) {
 									%>
-										log.info("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
+										log.debug("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
 									<%
 									}
 									%>
@@ -1502,7 +1502,7 @@ if(mode == UNIQUE){//HSS_____0
                                     <%
 									if (isLog4jEnabled) {
 									%>
-										log.info("<%=cid%> - Writing the data into: "+file.getPath());
+										log.debug("<%=cid%> - Writing the data into: "+file.getPath());
 									<%
 									}
 									%>
@@ -1513,7 +1513,7 @@ if(mode == UNIQUE){//HSS_____0
 									<%
 									if (isLog4jEnabled) {
 									%>
-										log.info("<%=cid%> - Wrote successfully.");
+										log.debug("<%=cid%> - Wrote successfully.");
 									<%
 									}
 									%>
@@ -1551,7 +1551,7 @@ if(mode == UNIQUE){//HSS_____0
                 <%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
+					log.debug("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
 				<%
 				}
 				%>
@@ -1561,7 +1561,7 @@ if(mode == UNIQUE){//HSS_____0
               	<%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Writing the data into: "+file.getPath());
+					log.debug("<%=cid%> - Writing the data into: "+file.getPath());
 				<%
 				}
 				%>
@@ -1572,7 +1572,7 @@ if(mode == UNIQUE){//HSS_____0
 				<%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Wrote successfully.");
+					log.debug("<%=cid%> - Wrote successfully.");
 				<%
 				}
 				%>
@@ -1623,7 +1623,7 @@ if(mode == UNIQUE){//HSS_____0
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Writing the duplicate record " + (nb_duplicate_<%=cid %>+1) + " into <%=connDuplicateName %>.");
+		log.debug("<%=cid%> - Writing the duplicate record " + (nb_duplicate_<%=cid %>+1) + " into <%=connDuplicateName %>.");
 	<%
 	}
     for(IMetadataColumn column : columnList){//HSS_____0_____1
@@ -1704,7 +1704,7 @@ if(mode == UNIQUE){//HSS_____0
 	                        <%
 							if (isLog4jEnabled) {
 							%>
-								log.info("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
+								log.debug("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
 							<%
 							}
 							%>
@@ -1714,7 +1714,7 @@ if(mode == UNIQUE){//HSS_____0
                         	<%
 							if (isLog4jEnabled) {
 							%>
-								log.info("<%=cid%> - Writing the data into: "+file.getPath());
+								log.debug("<%=cid%> - Writing the data into: "+file.getPath());
 							<%
 							}
 							%>
@@ -1725,7 +1725,7 @@ if(mode == UNIQUE){//HSS_____0
 							<%
 							if (isLog4jEnabled) {
 							%>
-								log.info("<%=cid%> - Wrote successfully.");
+								log.debug("<%=cid%> - Wrote successfully.");
 							<%
 							}
 							%>
@@ -1796,7 +1796,7 @@ if(mode == UNIQUE){//HSS_____0
                 <%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
+					log.debug("<%=cid%> - Invoke request to delete file: "+file.getPath()+" When VM exit.");
 				<%
 				}
 				%>
@@ -1806,7 +1806,7 @@ if(mode == UNIQUE){//HSS_____0
             	<%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Writing the data into: "+file.getPath());
+					log.debug("<%=cid%> - Writing the data into: "+file.getPath());
 				<%
 				}
 				%>
@@ -1817,7 +1817,7 @@ if(mode == UNIQUE){//HSS_____0
 				<%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Wrote successfully.");
+					log.debug("<%=cid%> - Wrote successfully.");
 				<%
 				}
 				%>
@@ -1867,7 +1867,7 @@ if(mode == UNIQUE){//HSS_____0
 	<%
 	if(isLog4jEnabled){
 	%>
-		log.info("<%=cid%> - Writing the duplicate record " + (nb_duplicate_<%=cid %>+1) + " into <%=connDuplicateName %>.");
+		log.debug("<%=cid%> - Writing the duplicate record " + (nb_duplicate_<%=cid %>+1) + " into <%=connDuplicateName %>.");
 	<%
 	}
     for(IMetadataColumn column : columnList){//HSS_____0_____1

--- a/main/plugins/org.talend.designer.components.localprovider/components/tUniqRowIn/tUniqRowIn_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tUniqRowIn/tUniqRowIn_end.javajet
@@ -63,8 +63,8 @@ if(mode == UNIQUE){//HSS_____0
             <%
 			if(isLog4jEnabled){
 			%>
-				log.info("<%=cid%> - Unique records count: " + (nb_uniq_<%=cid %>)+" .");
-				log.info("<%=cid%> - Duplicate records count: " + (nb_<%=cid %> - nb_uniq_<%=cid %>)+" .");
+				log.debug("<%=cid%> - Unique records count: " + (nb_uniq_<%=cid %>)+" .");
+				log.debug("<%=cid%> - Duplicate records count: " + (nb_<%=cid %> - nb_uniq_<%=cid %>)+" .");
 			<%
 			}
 			%>
@@ -77,8 +77,8 @@ if(mode == UNIQUE){//HSS_____0
             <%
 			if(isLog4jEnabled){
 			%>
-				log.info("<%=cid%> - Unique records count: " + (nb_uniq_<%=cid %>)+" .");
-				log.info("<%=cid%> - Duplicate records count: " + (nb_duplicate_<%=cid %>)+" .");
+				log.debug("<%=cid%> - Unique records count: " + (nb_uniq_<%=cid %>)+" .");
+				log.debug("<%=cid%> - Duplicate records count: " + (nb_duplicate_<%=cid %>)+" .");
 			<%
 			}
 			%>
@@ -91,8 +91,8 @@ if(mode == UNIQUE){//HSS_____0
             <%
 			if(isLog4jEnabled){
 			%>
-				log.info("<%=cid%> - Unique records count: " + (nb_<%=cid %> - nb_duplicate_<%=cid %>)+" .");
-				log.info("<%=cid%> - Duplicate records count: " + (nb_duplicate_<%=cid %>)+" .");
+				log.debug("<%=cid%> - Unique records count: " + (nb_<%=cid %> - nb_duplicate_<%=cid %>)+" .");
+				log.debug("<%=cid%> - Duplicate records count: " + (nb_duplicate_<%=cid %>)+" .");
 			<%
 			}
 			%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tUniqRowOut/tUniqRowOut_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tUniqRowOut/tUniqRowOut_begin.javajet
@@ -66,7 +66,7 @@ int bufferSize_<%=cid %> = <%=bufferSize %>;
 <%
 if (isLog4jEnabled) {
 %>
-	log.info("<%=cid%> - Start to process the data from datasource.");
+	log.debug("<%=cid%> - Start to process the data from datasource.");
 <%
 }
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tUniqRowOut/tUniqRowOut_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tUniqRowOut/tUniqRowOut_end.javajet
@@ -34,7 +34,7 @@ if ((metadatas!=null)&&(metadatas.size()>0) && !("").equals(connName)) {//HSS___
                 <%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Invoke request to delete file: "+file_<%=cid %>.getPath()+" When VM exit.");
+					log.debug("<%=cid%> - Invoke request to delete file: "+file_<%=cid %>.getPath()+" When VM exit.");
 				<%
 				}
 				%>
@@ -42,7 +42,7 @@ if ((metadatas!=null)&&(metadatas.size()>0) && !("").equals(connName)) {//HSS___
                 <%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Writing the data into: "+file_<%=cid %>.getPath());
+					log.debug("<%=cid%> - Writing the data into: "+file_<%=cid %>.getPath());
 				<%
 				}
 				%>
@@ -56,7 +56,7 @@ if ((metadatas!=null)&&(metadatas.size()>0) && !("").equals(connName)) {//HSS___
 				<%
 				if (isLog4jEnabled) {
 				%>
-					log.info("<%=cid%> - Wrote successfully.");
+					log.debug("<%=cid%> - Wrote successfully.");
 				<%
 				}
 				%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tUniqRowOut/tUniqRowOut_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tUniqRowOut/tUniqRowOut_main.javajet
@@ -35,7 +35,7 @@ if ((metadatas!=null)&&(metadatas.size()>0) && !("").equals(connName)) {//HSS___
 	    <%
 		if (isLog4jEnabled) {
 		%>
-			log.info("<%=cid%> - Invoke request to delete file: "+file_<%=cid %>.getPath()+" When VM exit.");
+			log.debug("<%=cid%> - Invoke request to delete file: "+file_<%=cid %>.getPath()+" When VM exit.");
 		<%
 		}
 		%>
@@ -44,7 +44,7 @@ if ((metadatas!=null)&&(metadatas.size()>0) && !("").equals(connName)) {//HSS___
 	    <%
 		if (isLog4jEnabled) {
 		%>
-			log.info("<%=cid%> - Writing the data into: "+file_<%=cid %>.getPath());
+			log.debug("<%=cid%> - Writing the data into: "+file_<%=cid %>.getPath());
 		<%
 		}
 		%>
@@ -56,7 +56,7 @@ if ((metadatas!=null)&&(metadatas.size()>0) && !("").equals(connName)) {//HSS___
 		<%
 		if (isLog4jEnabled) {
 		%>
-			log.info("<%=cid%> - Wrote successfully.");
+			log.debug("<%=cid%> - Wrote successfully.");
 		<%
 		}
 		%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tVerticaBulkExec/tVerticaBulkExec_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tVerticaBulkExec/tVerticaBulkExec_begin.javajet
@@ -146,11 +146,11 @@ if(("UPDATE").equals(dataAction)) {
 		}
         java.sql.Statement stmtCreateTmp_<%=cid%> = conn_<%=cid%>.createStatement();
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Creating temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
+			log.debug("<%=cid%> - Creating temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
 		<%}%>
         stmtCreateTmp_<%=cid%>.execute("<%=manager.getCreateTableSQL(stmtStructure)%>)");
         <%if(isLog4jEnabled){%>
-        	log.info("<%=cid%> - Create temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
+        	log.debug("<%=cid%> - Create temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
         <%}%>
         stmtCreateTmp_<%=cid%>.close();
 <%
@@ -194,7 +194,7 @@ if(("INSERT").equals(dataAction) || columnList != null && columnList.size() > 0)
 		
 		<%if(isLog4jEnabled){%>
 			log.debug("<%=cid%> - Bulk SQL:"+sql_<%=cid%>+".");
-			log.info("<%=cid%> - Bulk inserting data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
+			log.debug("<%=cid%> - Bulk inserting data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
         <%}%>
     	fis_<%=cid %> = new java.io.FileInputStream(new java.io.File(<%=file%>));
 <%
@@ -210,7 +210,7 @@ if(("INSERT").equals(dataAction) || columnList != null && columnList.size() > 0)
 	    ((com.vertica.PGStatement) stmt_<%=cid %>).addStreamToCopyIn(fis_<%=cid %>);
 	    ((com.vertica.PGStatement) stmt_<%=cid %>).finishCopyIn();
 	    <%if(isLog4jEnabled){%>
-            log.info("<%=cid%> - Bulk insert data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
+            log.debug("<%=cid%> - Bulk insert data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
         <%}%>
 		rs_<%=cid %> = stmt_<%=cid %>.executeQuery("select count(*) from " + tableName_<%=cid%>);
 	    int nbLineAfterLoad_<%=cid %> = 0;
@@ -222,7 +222,7 @@ if(("INSERT").equals(dataAction) || columnList != null && columnList.size() > 0)
 			throw new RuntimeException("No record was inserted in component <%=cid %>");
 		}else{
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Number of records inserted to table <%=manager.getLProtectedChar()%>" + tableName_<%=cid %> + "<%=manager.getRProtectedChar()%> by <%=cid %>: " + (nbLineAfterLoad_<%=cid %> - nbLineBeforeLoad_<%=cid %>)+".");
+				log.debug("<%=cid%> - Number of records inserted to table <%=manager.getLProtectedChar()%>" + tableName_<%=cid %> + "<%=manager.getRProtectedChar()%> by <%=cid %>: " + (nbLineAfterLoad_<%=cid %> - nbLineBeforeLoad_<%=cid %>)+".");
 			<%}%>
 			System.out.println("Number of records inserted to table <%=manager.getLProtectedChar()%>" + tableName_<%=cid %> + "<%=manager.getRProtectedChar()%> by <%=cid %>: " + (nbLineAfterLoad_<%=cid %> - nbLineBeforeLoad_<%=cid %>));
 		}
@@ -238,7 +238,7 @@ if(("INSERT").equals(dataAction) || columnList != null && columnList.size() > 0)
 		vcs_<%=cid%>.execute();
 		vcs_<%=cid%>.finish();
 		<%if(isLog4jEnabled){%>
-            log.info("<%=cid%> - Bulk insert data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
+            log.debug("<%=cid%> - Bulk insert data into <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has finished.");
         <%}%>
 		long copyNumber_<%=cid%> = vcs_<%=cid%>.getRowCount();
 		
@@ -263,7 +263,7 @@ if(("INSERT").equals(dataAction) || columnList != null && columnList.size() > 0)
 			throw new RuntimeException("No record was inserted into component <%=cid %>");
 		}else{
 			<%if(isLog4jEnabled){%>
-				log.info("<%=cid%> - Number of records inserted into table <%=manager.getLProtectedChar()%>" + tableName_<%=cid %> + "<%=manager.getRProtectedChar()%> by <%=cid %>: " + (copyNumber_<%=cid%>)+".");
+				log.debug("<%=cid%> - Number of records inserted into table <%=manager.getLProtectedChar()%>" + tableName_<%=cid %> + "<%=manager.getRProtectedChar()%> by <%=cid %>: " + (copyNumber_<%=cid%>)+".");
 			<%}%>
 			System.out.println("Number of records inserted into table <%=manager.getLProtectedChar()%>" + tableName_<%=cid %> + "<%=manager.getRProtectedChar()%> by <%=cid %>: " + (copyNumber_<%=cid%>));
 		}
@@ -285,7 +285,7 @@ if(("UPDATE").equals(dataAction) && columnList != null && columnList.size() > 0)
 		}
         java.sql.Statement stmtUpdateBulk_<%=cid%> = conn_<%=cid%>.createStatement();
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Updating <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> from <%=manager.getLProtectedChar()%>"+tmpTableName_<%=cid%>+"<%=manager.getRProtectedChar()%>.");
+		log.debug("<%=cid%> - Updating <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> from <%=manager.getLProtectedChar()%>"+tmpTableName_<%=cid%>+"<%=manager.getRProtectedChar()%>.");
 	<%}%>
         stmtUpdateBulk_<%=cid%>.executeUpdate("<%=manager.getUpdateBulkSQL(columnList)%>");
 	<%log4jCodeGenerateUtil.logInfo(node,"info",cid+" - Update has finished.");%>
@@ -293,12 +293,12 @@ if(("UPDATE").equals(dataAction) && columnList != null && columnList.size() > 0)
         tableName_<%=cid%> = tmpTableName_<%=cid%>;
         java.sql.Statement stmtTmpDrop_<%=cid%> = conn_<%=cid%>.createStatement();
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Droping temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
+		log.debug("<%=cid%> - Droping temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
 	<%}%>
         stmtTmpDrop_<%=cid%>.execute("<%=manager.getDropTableSQL()%>");
         stmtTmpDrop_<%=cid%>.close();        
 	<%if(isLog4jEnabled){%>
-		log.info("<%=cid%> - Drop temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%>+ "<%=manager.getRProtectedChar()%> has succeeded.");
+		log.debug("<%=cid%> - Drop temp table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%>+ "<%=manager.getRProtectedChar()%> has succeeded.");
 	<%}%>
 <%
 }

--- a/main/plugins/org.talend.designer.components.localprovider/components/tWebServiceInput/tWebServiceInput_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tWebServiceInput/tWebServiceInput_begin.javajet
@@ -95,7 +95,7 @@ if(("false").equals(ElementParameterParser.getValue(node,"__ADVANCED_USE__"))) {
                     <%}%>					
 					
 					System.setProperty("javax.net.ssl.trustStorePassword", decryptedPwd_<%=cid%>);
-					<%log.info(log.str("Set ssl."));%>
+					<%log.debug(log.str("Set ssl."));%>
 				<% 
 				}
 				%>
@@ -110,14 +110,14 @@ if(("false").equals(ElementParameterParser.getValue(node,"__ADVANCED_USE__"))) {
 				if (needAuth&&!winAuth) {
 				%>        	   
 	        		org.talend.DynamicInvoker.setAuth(true, <%=username %>, decryptedPassword_<%=cid%>);
-					<%log.info(log.str("Set username and password."));%>
+					<%log.debug(log.str("Set username and password."));%>
 				<%
 	  			}
 	  			if (needAuth&&winAuth){
 	  				String domain_username = "\""+TalendTextUtils.removeQuotes(domain)+"\\\\"+TalendTextUtils.removeQuotes(username)+"\"";
 					%>
 					org.talend.DynamicInvoker.setWINAuth(true, <%=domain_username %>, decryptedPassword_<%=cid%>);
-					<%log.info(log.str("Set username, password and domain."));%>	
+					<%log.debug(log.str("Set username, password and domain."));%>	
 				<%
 	  			}
 				if (useProxy) {
@@ -147,13 +147,13 @@ if(("false").equals(ElementParameterParser.getValue(node,"__ADVANCED_USE__"))) {
 						}
 					}
 					);
-					<%log.info(log.str("Set proxy."));%>
+					<%log.debug(log.str("Set proxy."));%>
 				<%
 	  			}
 				%> 
 				org.talend.DynamicInvoker.setTimeOut(<%=timeout %>);
 			
-				<%log.info(log.str("Sending soap request to endpoint."));%>
+				<%log.debug(log.str("Sending soap request to endpoint."));%>
 		 		org.talend.DynamicInvoker.main(params_<%=cid %>);
 		 		java.util.Map result_<%=cid %> = org.talend.DynamicInvoker.getResult();
 		        
@@ -210,7 +210,7 @@ if(("false").equals(ElementParameterParser.getValue(node,"__ADVANCED_USE__"))) {
 			    
 			    org.talend.TalendJobHTTPClientConfiguration clientConfig_<%=cid%> = new org.talend.TalendJobHTTPClientConfiguration();
 				clientConfig_<%=cid%>.setTimeout(<%=timeout %>);
-				<%log.info(log.str("Invoking talend webservice job."));%>
+				<%log.debug(log.str("Invoking talend webservice job."));%>
 		        org.talend.TalendJob talendJob_<%=cid%> = new org.talend.TalendJobProxy(<%=endpoint %>);
 				talendJob_<%=cid%>.setClientConfig(clientConfig_<%=cid%>);	        
 		        String[][] runJob_<%=cid%> = talendJob_<%=cid%>.runJob(new String[]{

--- a/main/plugins/org.talend.designer.components.localprovider/components/tWebServiceInput/tWebServiceInput_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tWebServiceInput/tWebServiceInput_end.javajet
@@ -29,5 +29,5 @@ if(("false").equals(ElementParameterParser.getValue(node,"__ADVANCED_USE__"))) {
 <%
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 }
-log.info(log.str("Retrieved records count: "), log.var("nb_line"), log.str("."));
+log.debug(log.str("Retrieved records count: "), log.var("nb_line"), log.str("."));
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tXMLRPCInput/tXMLRPCInput_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tXMLRPCInput/tXMLRPCInput_end.javajet
@@ -13,4 +13,4 @@
 %>
 	}
 	globalMap.put("<%=cid %>_NB_LINE", nb_line_<%=cid %>);
-	<%log.info(log.str("Retrieved records count: "), log.var("nb_line"), log.str("."));%>
+	<%log.debug(log.str("Retrieved records count: "), log.var("nb_line"), log.str("."));%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/templates/Hive/GetConnection.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/templates/Hive/GetConnection.javajet
@@ -374,7 +374,7 @@ java.sql.Connection conn_<%=cid%> = null;
 	   		log4jCodeGenerateUtil.debugConnectionParams(node);
 		%>
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection attempt to '" + url_<%=cid %> + "' with the username '" + dbUser_<%=cid%> + "'.");
+			log.debug("<%=cid%> - Connection attempt to '" + url_<%=cid %> + "' with the username '" + dbUser_<%=cid%> + "'.");
 		<%}%>
 <%
 		if(securedStandaloneHive2) {
@@ -388,7 +388,7 @@ java.sql.Connection conn_<%=cid%> = null;
 		}
 %>
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection to '" + url_<%=cid %> + "' has succeeded.");
+			log.debug("<%=cid%> - Connection to '" + url_<%=cid %> + "' has succeeded.");
 		<%}%>
 
 		java.sql.Statement init_<%=cid%> = conn_<%=cid%>.createStatement();

--- a/main/plugins/org.talend.designer.components.localprovider/components/templates/_tableActionForBulk.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/templates/_tableActionForBulk.javajet
@@ -14,20 +14,20 @@ if (!isParallelize) {
 		%>
 			java.sql.Statement stmtDrop_<%=cid%> = conn_<%=cid%>.createStatement();
 			<%if(isLog4jEnabled_tableAction){%>
-				log.info("<%=cid%> - Droping table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
+				log.debug("<%=cid%> - Droping table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
 			<%}%>
 			stmtDrop_<%=cid%>.execute("<%=manager.getDropTableSQL()%>");
 			<%if(isLog4jEnabled_tableAction){%>
-				log.info("<%=cid%> - Drop table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
+				log.debug("<%=cid%> - Drop table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
 			<%}%>
 			stmtDrop_<%=cid%>.close();
 			java.sql.Statement stmtCreate_<%=cid%> = conn_<%=cid%>.createStatement();
 			<%if(isLog4jEnabled_tableAction){%>
-				log.info("<%=cid%> - Creating table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
+				log.debug("<%=cid%> - Creating table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
 			<%}%>
 			stmtCreate_<%=cid%>.execute("<%=manager.getCreateTableSQL(stmtStructure)%>)");
 			<%if(isLog4jEnabled_tableAction){%>
-				log.info("<%=cid%> - Create table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
+				log.debug("<%=cid%> - Create table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
 			<%}%>
 			stmtCreate_<%=cid%>.close();
 		<%
@@ -35,11 +35,11 @@ if (!isParallelize) {
 		%>
 			java.sql.Statement stmtCreate_<%=cid%> = conn_<%=cid%>.createStatement();
 			<%if(isLog4jEnabled_tableAction){%>
-				log.info("<%=cid%> - Creating table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
+				log.debug("<%=cid%> - Creating table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
 			<%}%>
 			stmtCreate_<%=cid%>.execute("<%=manager.getCreateTableSQL(stmtStructure)%>)");
 			<%if(isLog4jEnabled_tableAction){%>
-				log.info("<%=cid%> - Create table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
+				log.debug("<%=cid%> - Create table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
 			<%}%>
 			stmtCreate_<%=cid%>.close();
 		<%
@@ -162,11 +162,11 @@ if (!isParallelize) {
 				if(!whetherExist_<%=cid%>) {
 					java.sql.Statement stmtCreate_<%=cid%> = conn_<%=cid%>.createStatement();
 					<%if(isLog4jEnabled_tableAction){%>
-						log.info("<%=cid%> - Creating table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
+						log.debug("<%=cid%> - Creating table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
 					<%}%>
 					stmtCreate_<%=cid%>.execute("<%=manager.getCreateTableSQL(stmtStructure)%>)");
 					<%if(isLog4jEnabled_tableAction){%>
-						log.info("<%=cid%> - Create table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
+						log.debug("<%=cid%> - Create table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
 					<%}%>
 					stmtCreate_<%=cid%>.close();
 				}
@@ -176,21 +176,21 @@ if (!isParallelize) {
 				if(whetherExist_<%=cid%>) {
 					java.sql.Statement stmtDrop_<%=cid%> = conn_<%=cid%>.createStatement();
 					<%if(isLog4jEnabled_tableAction){%>
-						log.info("<%=cid%> - Droping table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
+						log.debug("<%=cid%> - Droping table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
 					<%}%>
 					stmtDrop_<%=cid%>.execute("<%=manager.getDropTableSQL()%>");
 					<%if(isLog4jEnabled_tableAction){%>
-						log.info("<%=cid%> - Drop table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
+						log.debug("<%=cid%> - Drop table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
 					<%}%>
 					stmtDrop_<%=cid%>.close();
 				}
 				java.sql.Statement stmtCreate_<%=cid%> = conn_<%=cid%>.createStatement();
 				<%if(isLog4jEnabled_tableAction){%>
-					log.info("<%=cid%> - Creating table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
+					log.debug("<%=cid%> - Creating table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>." );
 				<%}%>
 				stmtCreate_<%=cid%>.execute("<%=manager.getCreateTableSQL(stmtStructure)%>)");
 				<%if(isLog4jEnabled_tableAction){%>
-					log.info("<%=cid%> - Create table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
+					log.debug("<%=cid%> - Create table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
 				<%}%>
 				stmtCreate_<%=cid%>.close();
 			<%
@@ -200,11 +200,11 @@ if (!isParallelize) {
 		%>
 			java.sql.Statement stmtClear_<%=cid%> = conn_<%=cid%>.createStatement();
 			<%if(isLog4jEnabled_tableAction){%>
-				log.info("<%=cid%> - Clearing table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
+				log.debug("<%=cid%> - Clearing table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
 			<%}%>
 			stmtClear_<%=cid%>.executeUpdate("<%=manager.getDeleteTableSQL()%>");
 			<%if(isLog4jEnabled_tableAction){%>
-				log.info("<%=cid%>- Clear table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
+				log.debug("<%=cid%>- Clear table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
 			<%}%>
 			stmtClear_<%=cid%>.close();
 		<%
@@ -214,11 +214,11 @@ if (!isParallelize) {
 			java.sql.ResultSet rsTruncCount_<%=cid%> = stmtTruncCount_<%=cid%>.executeQuery("<%=manager.getSelectionSQL()%>");
 			java.sql.Statement stmtTrunc_<%=cid%> = conn_<%=cid%>.createStatement();
 			<%if(isLog4jEnabled_tableAction){%>
-				log.info("<%=cid%> - Trancating table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
+				log.debug("<%=cid%> - Trancating table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%>.");
 			<%}%>
 			stmtTrunc_<%=cid%>.executeUpdate("<%=manager.getTruncateTableSQL()%>");
    	    	<%if(isLog4jEnabled_tableAction){%>
-				log.info("<%=cid%> - Truncate table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
+				log.debug("<%=cid%> - Truncate table <%=manager.getLProtectedChar()%>" + tableName_<%=cid%> + "<%=manager.getRProtectedChar()%> has succeeded.");
 			<%}%>
 			while(rsTruncCount_<%=cid%>.next()) {
 				deletedCount_<%=cid%> += rsTruncCount_<%=cid%>.getInt(1);


### PR DESCRIPTION
These changes are only very small with no side effects. They simply move the former log.info output to log.debug.
The current flood of messages in the info level - the very most only pure technical without any business meaning - let the customer setup their own logging system and simply switch off the Talend based logging.

I have simply changed the call to log.info to log.debug. I have checked that in my project and the translators were build correctly.