### PR TITLE
fix(TDI-38559): Fixed initialization of ComponentReferenceProperties

### DIFF
--- a/main/plugins/org.talend.designer.codegen/jet_stub/generic/component_begin.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/generic/component_begin.javajet
@@ -12,6 +12,7 @@ imports="
         org.talend.components.api.component.ConnectorTopology
         org.talend.components.api.container.RuntimeContainer
         org.talend.components.api.properties.ComponentProperties
+        org.talend.components.api.properties.ComponentReferenceProperties
         org.talend.core.model.metadata.IMetadataColumn
         org.talend.core.model.metadata.IMetadataTable
         org.talend.core.model.metadata.types.JavaType
@@ -64,6 +65,8 @@ List<Component.CodegenPropInfo> propsToProcess = component.getCodegenPropInfos(c
 <%= componentProps.getClass().getName()%> props_<%=cid %> =
         (<%= componentProps.getClass().getName()%>) def_<%=cid %>.createRuntimeProperties();
 <%
+
+final Set<String> referenceProperties = new HashSet<String>();
 
 for (Component.CodegenPropInfo propInfo : propsToProcess) { // propInfo
     List<NamedThing> properties = propInfo.props.getProperties();
@@ -134,10 +137,28 @@ for (Component.CodegenPropInfo propInfo : propsToProcess) { // propInfo
                 props_<%=cid %><%=propInfo.fieldName%>.setValue("<%=property.getName()%>", null);
             <%
             }
-        }//else may be a ComponentProperties so ignore
+        } else if (prop instanceof ComponentReferenceProperties) {
+            final String fieldString = propInfo.fieldName + "." + prop.getName();
+            referenceProperties.add(fieldString);
+        } //else may be a ComponentProperties so ignore
     } // property
 } // propInfo
+
+for (final String fieldString : referenceProperties) {
+    %>
+    if (org.talend.components.api.properties.ComponentReferenceProperties.ReferenceType.COMPONENT_INSTANCE == props_<%=cid %><%=fieldString %>.referenceType.getValue()) {
+        final String referencedComponentInstanceId = props_<%=cid %><%=fieldString %>.componentInstanceId.getStringValue();
+        if (referencedComponentInstanceId != null) {
+            org.talend.daikon.properties.Properties referencedComponentProperties = (org.talend.daikon.properties.Properties) globalMap.get(
+                referencedComponentInstanceId + "_COMPONENT_RUNTIME_PROPERTIES");
+            props_<%=cid %><%=fieldString %>.setReference(referencedComponentProperties);
+        }
+    }
+    <%
+}
 %>
+globalMap.put("<%=cid %>_COMPONENT_RUNTIME_PROPERTIES", props_<%=cid %>);
+
 org.talend.components.api.container.RuntimeContainer container_<%=cid%> = new org.talend.components.api.container.RuntimeContainer() {
     public Object getComponentData(String componentId, String key) {
         return globalMap.get(componentId + "_" + key);

--- a/main/plugins/org.talend.designer.codegen/jet_stub/generic/component_begin.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/generic/component_begin.javajet
@@ -146,11 +146,18 @@ for (Component.CodegenPropInfo propInfo : propsToProcess) { // propInfo
 
 for (final String fieldString : referenceProperties) {
     %>
-    resolveReferencedComponentProperties(props_<%=cid %><%=fieldString %>);
+    if (org.talend.components.api.properties.ComponentReferenceProperties.ReferenceType.COMPONENT_INSTANCE == props_<%=cid %><%=fieldString %>.referenceType.getValue()) {
+        final String referencedComponentInstanceId_<%=cid %> = props_<%=cid %><%=fieldString %>.componentInstanceId.getStringValue();
+        if (referencedComponentInstanceId_<%=cid %> != null) {
+            org.talend.daikon.properties.Properties referencedComponentProperties_<%=cid %> = (org.talend.daikon.properties.Properties) globalMap.get(
+                referencedComponentInstanceId_<%=cid %> + "_COMPONENT_RUNTIME_PROPERTIES");
+            props_<%=cid %><%=fieldString %>.setReference(referencedComponentProperties_<%=cid %>);
+        }
+    }
     <%
 }
 %>
-registerComponentProperties("<%=cid %>", props_<%=cid %>);
+globalMap.put("<%=cid %>_COMPONENT_RUNTIME_PROPERTIES", props_<%=cid %>);
 
 org.talend.components.api.container.RuntimeContainer container_<%=cid%> = new org.talend.components.api.container.RuntimeContainer() {
     public Object getComponentData(String componentId, String key) {

--- a/main/plugins/org.talend.designer.codegen/jet_stub/generic/component_begin.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/generic/component_begin.javajet
@@ -146,18 +146,11 @@ for (Component.CodegenPropInfo propInfo : propsToProcess) { // propInfo
 
 for (final String fieldString : referenceProperties) {
     %>
-    if (org.talend.components.api.properties.ComponentReferenceProperties.ReferenceType.COMPONENT_INSTANCE == props_<%=cid %><%=fieldString %>.referenceType.getValue()) {
-        final String referencedComponentInstanceId_<%=cid %> = props_<%=cid %><%=fieldString %>.componentInstanceId.getStringValue();
-        if (referencedComponentInstanceId_<%=cid %> != null) {
-            org.talend.daikon.properties.Properties referencedComponentProperties_<%=cid %> = (org.talend.daikon.properties.Properties) globalMap.get(
-                referencedComponentInstanceId_<%=cid %> + "_COMPONENT_RUNTIME_PROPERTIES");
-            props_<%=cid %><%=fieldString %>.setReference(referencedComponentProperties_<%=cid %>);
-        }
-    }
+    resolveReferencedComponentProperties(props_<%=cid %><%=fieldString %>);
     <%
 }
 %>
-globalMap.put("<%=cid %>_COMPONENT_RUNTIME_PROPERTIES", props_<%=cid %>);
+registerComponentProperties("<%=cid %>", props_<%=cid %>);
 
 org.talend.components.api.container.RuntimeContainer container_<%=cid%> = new org.talend.components.api.container.RuntimeContainer() {
     public Object getComponentData(String componentId, String key) {

--- a/main/plugins/org.talend.designer.codegen/jet_stub/generic/component_begin.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/generic/component_begin.javajet
@@ -147,11 +147,11 @@ for (Component.CodegenPropInfo propInfo : propsToProcess) { // propInfo
 for (final String fieldString : referenceProperties) {
     %>
     if (org.talend.components.api.properties.ComponentReferenceProperties.ReferenceType.COMPONENT_INSTANCE == props_<%=cid %><%=fieldString %>.referenceType.getValue()) {
-        final String referencedComponentInstanceId = props_<%=cid %><%=fieldString %>.componentInstanceId.getStringValue();
-        if (referencedComponentInstanceId != null) {
-            org.talend.daikon.properties.Properties referencedComponentProperties = (org.talend.daikon.properties.Properties) globalMap.get(
-                referencedComponentInstanceId + "_COMPONENT_RUNTIME_PROPERTIES");
-            props_<%=cid %><%=fieldString %>.setReference(referencedComponentProperties);
+        final String referencedComponentInstanceId_<%=cid %> = props_<%=cid %><%=fieldString %>.componentInstanceId.getStringValue();
+        if (referencedComponentInstanceId_<%=cid %> != null) {
+            org.talend.daikon.properties.Properties referencedComponentProperties_<%=cid %> = (org.talend.daikon.properties.Properties) globalMap.get(
+                referencedComponentInstanceId_<%=cid %> + "_COMPONENT_RUNTIME_PROPERTIES");
+            props_<%=cid %><%=fieldString %>.setReference(referencedComponentProperties_<%=cid %>);
         }
     }
     <%

--- a/main/plugins/org.talend.designer.codegen/jet_stub/header.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/header.javajet
@@ -590,6 +590,24 @@ private class TalendException extends Exception {
 	}
 }
 
+private void registerComponentProperties(String componentInstanceId, org.talend.components.api.properties.ComponentProperties properties) {
+	globalMap.put(componentInstanceId + "_COMPONENT_PROPERTIES", properties);
+}
+
+private void resolveReferencedComponentProperties(org.talend.components.api.properties.ComponentReferenceProperties<?> refProps) {
+    if (refProps.getReference() != null) {
+        return;
+    }
+    if (org.talend.components.api.properties.ComponentReferenceProperties.ReferenceType.COMPONENT_INSTANCE == refProps.referenceType.getValue()) {
+        String referencedComponentInstanceId = refProps.componentInstanceId.getStringValue();
+        if (referencedComponentInstanceId != null) {
+            org.talend.daikon.properties.Properties referencedComponentPropertiesInstance = (org.talend.daikon.properties.Properties) globalMap.get(
+                referencedComponentInstanceId + "_COMPONENT_PROPERTIES");
+            refProps.setReference(referencedComponentPropertiesInstance);
+        }
+    }
+}
+
 <% // Methods for RUN IF Error links %>
 <%
 	for (INode node : processNodes) {

--- a/main/plugins/org.talend.designer.codegen/jet_stub/header.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/header.javajet
@@ -590,24 +590,6 @@ private class TalendException extends Exception {
 	}
 }
 
-private void registerComponentProperties(String componentInstanceId, org.talend.components.api.properties.ComponentProperties properties) {
-	globalMap.put(componentInstanceId + "_COMPONENT_PROPERTIES", properties);
-}
-
-private void resolveReferencedComponentProperties(org.talend.components.api.properties.ComponentReferenceProperties<?> refProps) {
-    if (refProps.getReference() != null) {
-        return;
-    }
-    if (org.talend.components.api.properties.ComponentReferenceProperties.ReferenceType.COMPONENT_INSTANCE == refProps.referenceType.getValue()) {
-        String referencedComponentInstanceId = refProps.componentInstanceId.getStringValue();
-        if (referencedComponentInstanceId != null) {
-            org.talend.daikon.properties.Properties referencedComponentPropertiesInstance = (org.talend.daikon.properties.Properties) globalMap.get(
-                referencedComponentInstanceId + "_COMPONENT_PROPERTIES");
-            refProps.setReference(referencedComponentPropertiesInstance);
-        }
-    }
-}
-
 <% // Methods for RUN IF Error links %>
 <%
 	for (INode node : processNodes) {


### PR DESCRIPTION
* Runtime instance of a component properties are stored in globalMap in order to be refercned by other components
* Implemented lookup of referenced properties in globalMap