### PR TITLE
fix(TDI-38519): IndexOutOfBoundsException When Using tFileOutputMSXML…

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileOutputMSXML/tFileOutputMSXML_begin.inc.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileOutputMSXML/tFileOutputMSXML_begin.inc.javajet
@@ -420,6 +420,7 @@ class GenerateToolByDom4j{
 		
 		if (!orderHelper_<%=cid%>.isLastProcessedField("<%=tool.connName + "_" + currEleName%>") && !orderHelper_<%=cid%>.tailAppend("<%=tool.connName + "_" + currEleName%>")){
 			orderHelper_<%=cid%>.resetIndex("<%=tool.connName + "_" + currEleName%>");	
+			orderHelper_<%=cid%>.fillRecalculateOrderMap("<%=tool.connName + "_" + currEleName%>", true);
 		} else {			
 			orderHelper_<%=cid%>.incrementIndex("<%=tool.connName + "_" + currEleName%>");
 		}


### PR DESCRIPTION
… with Several Inputs

**This is for :**  
https://jira.talendforge.org/browse/TDI-38519

**New behavior**
we need to recalculate the node order when we change the current element to ensure that the order is valid in the XML DOM.
This case happens when we have a loop that change it's order regarding to the prior elements existence in the XML Node

* Root
** Group
*** element (can be absent)
*** loop (the loop order is 1 or 2 regarding of the element presence in the group. So we need to recalculate the loop order for each group node)