### PR TITLE
fix(TDI-38613):the entitySet of MicrosoftCRM can't refresh with V2016(odata)

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmInput/tMicrosoftCrmInput_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmInput/tMicrosoftCrmInput_java.xml
@@ -640,7 +640,7 @@
 			</ITEMS>
         </PARAMETER>
 
-        <PARAMETER NAME="CUSTOM_ENTITY_NAME" FIELD="TEXT" NUM_ROW="50" SHOW_IF="(ENTITYNAME=='CustomEntity') OR (AUTH_TYPE=='ONLINE' AND API_VERSION=='API_2016_ODATA' AND ENTITYSET=='CustomEntitySet')" REQUIRED="true">
+        <PARAMETER NAME="CUSTOM_ENTITY_NAME" FIELD="TEXT" NUM_ROW="50" SHOW_IF="((isShow[ENTITYNAME]) AND (ENTITYNAME=='CustomEntity')) OR ((isShow[ENTITYSET]) AND (ENTITYSET=='CustomEntitySet'))" REQUIRED="true">
             <DEFAULT>"customEntityName"</DEFAULT>
         </PARAMETER>
 
@@ -19446,7 +19446,7 @@
     <COLUMN KEY="false" LENGTH="0" NAME="_sdkmessageid_value" TYPE="id_String"  />
 </TABLE>
 
-<TABLE IF="ENTITYNAME=='CustomEntity'">
+<TABLE IF="((isShow[ENTITYNAME]) AND (ENTITYNAME=='CustomEntity')) OR ((isShow[ENTITYSET]) AND (ENTITYSET=='CustomEntitySet'))">
 </TABLE>
 
         </PARAMETER>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmOutput/tMicrosoftCrmOutput_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmOutput/tMicrosoftCrmOutput_java.xml
@@ -648,7 +648,7 @@
             </ITEMS>
         </PARAMETER>
         
-        <PARAMETER NAME="CUSTOM_ENTITY_NAME" FIELD="TEXT" NUM_ROW="50" SHOW_IF="(ENTITYNAME=='CustomEntity') OR (ENTITYSET=='CustomEntitySet')" REQUIRED="true" REPOSITORY_VALUE="CUSTOM_ENTITY_NAME">
+        <PARAMETER NAME="CUSTOM_ENTITY_NAME" FIELD="TEXT" NUM_ROW="50" SHOW_IF="((isShow[ENTITYNAME]) AND (ENTITYNAME=='CustomEntity')) OR ((isShow[ENTITYSET]) AND (ENTITYSET=='CustomEntitySet'))" REQUIRED="true" REPOSITORY_VALUE="CUSTOM_ENTITY_NAME">
             <DEFAULT>"customEntityName"</DEFAULT>
         </PARAMETER>
 
@@ -28956,12 +28956,12 @@
         </TABLE>
         <!-- update end -->
 <!--2016 odata end-->
-        <TABLE IF="(ENTITYNAME=='CustomEntity') OR (ENTITYSET=='CustomEntitySet')"/>
+        <TABLE IF="((isShow[ENTITYNAME]) AND (ENTITYNAME=='CustomEntity')) OR ((isShow[ENTITYSET]) AND (ENTITYSET=='CustomEntitySet'))"/>
 
         </PARAMETER>
 
         <PARAMETER NAME="LOOKUP_MAPPING" FIELD="TABLE" REQUIRED="false" NUM_ROW="70" NB_LINES="3"
-            SHOW_IF="((ACTION=='insert') OR (ACTION=='update')) AND ((AUTH_TYPE != 'ON_PREMISE') AND (MS_CRM_VERSION != 'CRM_2015'))">
+            SHOW_IF="((ACTION=='insert') OR (ACTION=='update')) AND ((AUTH_TYPE != 'ON_PREMISE') OR (MS_CRM_VERSION != 'CRM_2015'))">
             <ITEMS>
                 <ITEM NAME="INPUT_COLUMN" FIELD="COLUMN_LIST" />
                 <ITEM NAME="TYPE" FIELD="String" SHOW_IF="(AUTH_TYPE!='ONLINE') OR (API_VERSION !='API_2016_ODATA')"/>


### PR DESCRIPTION
For jira: https://jira.talendforge.org/browse/TDI-38613

Fix issues:
- The entitySet of MicrosoftCRM can't refresh with V2016(odata) when the entity of other API Version is customentityset
- The schema of MicrosoftCRM's column isn't empty with customentityset when when the entity of other API Version isn't customentityset