### PR TITLE
fix(TDI-38519): revert the order caching in the tFileOutputMSXML

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileOutputMSXML/tFileOutputMSXML_begin.inc.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileOutputMSXML/tFileOutputMSXML_begin.inc.javajet
@@ -370,16 +370,16 @@ class GenerateToolByDom4j{
 		org.dom4j.QName qname_<%=currEleName%>_<%=cid%> = org.dom4j.DocumentHelper.createQName("<%=localName%>",org.dom4j.DocumentHelper.createNamespace("<%=prefix%>","<%=uri%>"));
 		<%touchXMLNode.putCurrentElementByQName(currEleName);%>
 		
-		if(orderHelper_<%=cid%>.need_recalculate("<%=tool.connName + "_" + currEleName%>")) {
-			java.util.List<org.dom4j.Element> allElements_<%=currEleName%>_<%=cid%> = <%touchXMLNode.getXMLElement(parentName);%>.elements();
-			int order_<%=cid%> = allElements_<%=currEleName%>_<%=cid%>.size();
-			
-    		java.util.List<org.dom4j.Element> elements_<%=currEleName%>_<%=cid%> = <%touchXMLNode.getXMLElement(parentName);%>.elements(qname_<%=currEleName%>_<%=cid%>);
-    		int app_size_<%=cid %> = elements_<%=currEleName%>_<%=cid%>.size();
-    		
-    		if(app_size_<%=cid %> > 0){
-    			order_<%=cid%> = 1 + allElements_<%=currEleName%>_<%=cid%>.indexOf(elements_<%=currEleName%>_<%=cid%>.get(app_size_<%=cid %>-1));
-    		}else{
+		
+		java.util.List<org.dom4j.Element> allElements_<%=currEleName%>_<%=cid%> = <%touchXMLNode.getXMLElement(parentName);%>.elements();
+		int order_<%=cid%> = allElements_<%=currEleName%>_<%=cid%>.size();
+		
+		java.util.List<org.dom4j.Element> elements_<%=currEleName%>_<%=cid%> = <%touchXMLNode.getXMLElement(parentName);%>.elements(qname_<%=currEleName%>_<%=cid%>);
+		int app_size_<%=cid %> = elements_<%=currEleName%>_<%=cid%>.size();
+		
+		if(app_size_<%=cid %> > 0){
+			order_<%=cid%> = 1 + allElements_<%=currEleName%>_<%=cid%>.indexOf(elements_<%=currEleName%>_<%=cid%>.get(app_size_<%=cid %>-1));
+		}else{
 <%
 			List<XMLNode> nextSiblings = node.getNextSiblings();
 			int size = nextSiblings.size();
@@ -391,48 +391,26 @@ class GenerateToolByDom4j{
 				prefix = namespaceHelper.getPrefix();
 				localName = namespaceHelper.getLocalName();
 %>
-    			org.dom4j.QName qname_sibling_<%=currEleName%>_<%=cid%>_<%=i%> = org.dom4j.DocumentHelper.createQName("<%=localName%>",org.dom4j.DocumentHelper.createNamespace("<%=prefix%>","<%=uri%>"));
-    			org.dom4j.Element sibling_<%=currEleName%>_<%=cid%>_<%=i%> = <%touchXMLNode.getXMLElement(parentName);%>.element(qname_sibling_<%=currEleName%>_<%=cid%>_<%=i%>);
-    			int index_sibling_<%=currEleName%>_<%=cid%>_<%=i%> = allElements_<%=currEleName%>_<%=cid%>.indexOf(sibling_<%=currEleName%>_<%=cid%>_<%=i%>);
-    			if(index_sibling_<%=currEleName%>_<%=cid%>_<%=i%> > -1) {
-    				order_<%=cid%> = index_sibling_<%=currEleName%>_<%=cid%>_<%=i%>;
-    			} else {
+			org.dom4j.QName qname_sibling_<%=currEleName%>_<%=cid%>_<%=i%> = org.dom4j.DocumentHelper.createQName("<%=localName%>",org.dom4j.DocumentHelper.createNamespace("<%=prefix%>","<%=uri%>"));
+			org.dom4j.Element sibling_<%=currEleName%>_<%=cid%>_<%=i%> = <%touchXMLNode.getXMLElement(parentName);%>.element(qname_sibling_<%=currEleName%>_<%=cid%>_<%=i%>);
+			int index_sibling_<%=currEleName%>_<%=cid%>_<%=i%> = allElements_<%=currEleName%>_<%=cid%>.indexOf(sibling_<%=currEleName%>_<%=cid%>_<%=i%>);
+			if(index_sibling_<%=currEleName%>_<%=cid%>_<%=i%> > -1) {
+				order_<%=cid%> = index_sibling_<%=currEleName%>_<%=cid%>_<%=i%>;
+			} else {
 <%
 			
 			}//TD512
 			
 			while(size-- > 0) {
 %>
-				}
+			}
 <%
 			}
 %>
-			}
+		}
 			
-			//IF the element is at the end of the xml branch we just append it to the end of the elements list
-			if(order_<%=cid%> == allElements_<%=currEleName%>_<%=cid%>.size()) {
-				orderHelper_<%=cid%>.fillTailAppendMap("<%=tool.connName + "_" + currEleName%>",true);
-			}
-			
-			orderHelper_<%=cid%>.setOrder("<%=tool.connName + "_" + currEleName%>",order_<%=cid%>);
-			orderHelper_<%=cid%>.fillRecalculateOrderMap("<%=tool.connName + "_" + currEleName%>",false);
-		}
-		
-		if (!orderHelper_<%=cid%>.isLastProcessedField("<%=tool.connName + "_" + currEleName%>") && !orderHelper_<%=cid%>.tailAppend("<%=tool.connName + "_" + currEleName%>")){
-			orderHelper_<%=cid%>.resetIndex("<%=tool.connName + "_" + currEleName%>");	
-			orderHelper_<%=cid%>.fillRecalculateOrderMap("<%=tool.connName + "_" + currEleName%>", true);
-		} else {			
-			orderHelper_<%=cid%>.incrementIndex("<%=tool.connName + "_" + currEleName%>");
-		}
-		
-		if(orderHelper_<%=cid%>.tailAppend("<%=tool.connName + "_" + currEleName%>")) {
-			<%touchXMLNode.getXMLElement(parentName);%>.add(<%touchXMLNode.getXMLNode(currEleName);%>);
-		} else {
-			<%touchXMLNode.getXMLElement(parentName);%>.elements().add(orderHelper_<%=cid%>.index("<%=tool.connName + "_" + currEleName%>"),<%touchXMLNode.getXMLNode(currEleName);%>);
-		}
-		
-		orderHelper_<%=cid%>.setLastPorcessedField("<%=tool.connName + "_" + currEleName%>");
-		
+		<%touchXMLNode.getXMLElement(parentName);%>.elements().add(order_<%=cid%>,<%touchXMLNode.getXMLNode(currEleName);%>);
+
 <%
 		}else{
 			

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileOutputMSXML/tFileOutputMSXML_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileOutputMSXML/tFileOutputMSXML_begin.javajet
@@ -129,66 +129,6 @@ final org.dom4j.io.OutputFormat format_<%=cid%> = org.dom4j.io.OutputFormat.crea
 format_<%=cid %>.setEncoding(<%=encoding%>);
 format_<%=cid %>.setTrimText(<%=trimText%>);
 
-class OrderHelper_<%=cid%> {
-    java.util.Map<String,Boolean> recalculateOrderMap = new java.util.HashMap<String,Boolean>();
-	java.util.Map<String,Integer> orderMap = new java.util.HashMap<String,Integer>();
-	java.util.Map<String,Integer> indexMap = new java.util.HashMap<String,Integer>();
-	java.util.Map<String,Boolean> tailAppendMap = new java.util.HashMap<String,Boolean>();
-	String lastProcessedField;
-	
-	boolean need_recalculate(String field) {
-		Boolean result = recalculateOrderMap.get(field);
-		return result == null ? true : result;
-	}
-	
-	boolean tailAppend(String field) {
-		Boolean result = tailAppendMap.get(field);
-		return result == null ? false : result;
-	}
-	
-	int order(String field) {
-		Integer order = orderMap.get(field);
-		return order == null ? 0 : order;
-	}
-	
-	void setOrder(String field,Integer order) {
-		orderMap.put(field,order);
-		indexMap.put(field,order);
-	}
-	
-	void fillRecalculateOrderMap(String field,Boolean value) {
-		recalculateOrderMap.put(field,value);
-	}
-	
-	void fillTailAppendMap(String field,Boolean value) {
-		tailAppendMap.put(field,value);
-	}
-	
-	int index(String field) {
-		Integer i = indexMap.get(field);
-		return i == null ? 0 : i;
-	}
-	
-	void incrementIndex(String field){
-		Integer i = index(field);
-		indexMap.put(field, ++i);
-	}
-	
-	void resetIndex(String field){
-		Integer order = order(field);
-		indexMap.put(field, order);
-	}
-	
-	boolean isLastProcessedField(String field){
-		return (lastProcessedField != null && lastProcessedField.equals(field)) ? true : false;
-	}
-	
-	void setLastPorcessedField(String field){
-		lastProcessedField = field;
-	}
-}
-
-final OrderHelper_<%=cid%> orderHelper_<%=cid%> = new OrderHelper_<%=cid%>();
 
 <%@ include file="tFileOutputMSXML_begin.inc.javajet"%>
 


### PR DESCRIPTION
This is for : 
https://jira.talendforge.org/browse/TDI-38519

We can't cache the xml element order because it's not a fix order and it's may change in branch
by caching the order we get bas insert position for the element causing IndexOutOfBoundsException.

this will revert the solution implemented here : 
https://jira.talendforge.org/browse/TDI-34433