### PR TITLE
Revert "TDQ-13464: fix running the match analysis with "Store on disk" option"

### DIFF
--- a/main/plugins/org.talend.libraries.jboss/META-INF/MANIFEST.MF
+++ b/main/plugins/org.talend.libraries.jboss/META-INF/MANIFEST.MF
@@ -19,4 +19,3 @@ Export-Package: org.jboss.serial,
  org.jboss.serial.util
 Bundle-ActivationPolicy: lazy
 Eclipse-BundleShape: dir
-Require-Bundle: org.apache.log4j


### PR DESCRIPTION
Reverts Talend/tdi-studio-se#1165