### PR TITLE
Bugfix/tdi 38316 logical types support

### DIFF
--- a/main/plugins/org.talend.designer.codegen/jet_stub/generic/component_main.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/generic/component_main.javajet
@@ -90,23 +90,25 @@ if(hasInput){
 
             if (dynamicPos != -1)  {
                 %>
-                if (current_<%=cid%>.needsInitDynamicColumns()) {
+                if (!current_<%=cid%>.areDynamicFieldsInitialized()) {
                     // Initialize the dynamic columns when they are first encountered.
                     for (routines.system.DynamicMetadata dm_<%=cid%> : <%=inputConn.getName()%>.<%=input_columnList.get(dynamicPos).getLabel()%>.metadatas) {
-                        current_<%=cid%>.initDynamicColumn(
-                                dm_<%=cid%>.getName(), dm_<%=cid%>.getDbName(),
-                                dm_<%=cid%>.getType(), dm_<%=cid%>.getDbType(),
-                                dm_<%=cid%>.getDbTypeId(), dm_<%=cid%>.getLength(),
-                                dm_<%=cid%>.getPrecision(), dm_<%=cid%>.getFormat(),
-                                dm_<%=cid%>.getDescription(), dm_<%=cid%>.isKey(),
-                                dm_<%=cid%>.isNullable(),
-                                dm_<%=cid%>.getRefFieldName(), dm_<%=cid%>.getRefModuleName());
+                        current_<%=cid%>.addDynamicField(
+                                dm_<%=cid%>.getName(),
+                                dm_<%=cid%>.getType(),
+                                dm_<%=cid%>.getLogicalType(),
+                                dm_<%=cid%>.getFormat(),
+                                dm_<%=cid%>.getDescription(),
+                                dm_<%=cid%>.isNullable());
                     }
-                    current_<%=cid%>.initDynamicColumnsFinished();
+                    current_<%=cid%>.recreateRuntimeSchema();
                 }
                 <%
             }
 
+            %>
+            current_<%=cid%>.createNewRecord();
+            <%
             for (int i = 0; i < input_columnList.size(); i++) { // column
                 IMetadataColumn column = input_columnList.get(i);
                 if (dynamicPos != i) {
@@ -134,7 +136,7 @@ if(hasInput){
             // connections.
 
             %>
-            Object data_<%=cid%> = current_<%=cid%>.createIndexedRecord();
+            org.apache.avro.generic.IndexedRecord data_<%=cid%> = current_<%=cid%>.getCurrentRecord();
 
             writer_<%=cid%>.write(data_<%=cid%>);
             

--- a/main/plugins/org.talend.designer.codegen/jet_stub/generic/component_main.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/generic/component_main.javajet
@@ -101,7 +101,7 @@ if(hasInput){
                                 dm_<%=cid%>.getDescription(),
                                 dm_<%=cid%>.isNullable());
                     }
-                    current_<%=cid%>.recreateRuntimeSchema();
+                    current_<%=cid%>.createRuntimeSchema();
                 }
                 <%
             }

--- a/main/plugins/org.talend.designer.codegen/jet_stub/generic/component_util_indexedrecord_to_rowstruct.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/generic/component_util_indexedrecord_to_rowstruct.javajet
@@ -159,7 +159,8 @@ class IndexedRecordToRowStructGenerator {
                     }
                     dynamicMetadata_<%=cid%>.setType(talendType_<%=cid%>);
                     // set logical type
-                    String logicalType_<%=cid%> = org.talend.daikon.avro.LogicalTypeUtils.getLogicalTypeName(dynamicField_<%=cid%>.schema());
+                    org.apache.avro.Schema unwrappedSchema_<%=cid%> = org.talend.daikon.avro.AvroUtils.unwrapIfNullable(dynamicField_<%=cid%>.schema());
+                    String logicalType_<%=cid%> = org.talend.daikon.avro.LogicalTypeUtils.getLogicalTypeName(unwrappedSchema_<%=cid%>);
                     dynamicMetadata_<%=cid%>.setLogicalType(logicalType_<%=cid%>);
                     // set length
                     Object length_<%=cid%> = dynamicField_<%=cid%>.getProp(org.talend.daikon.avro.SchemaConstants.TALEND_COLUMN_DB_LENGTH);


### PR DESCRIPTION
Related to https://jira.talendforge.org/browse/TDI-38316

- It fixes logical type setting (schema was not unwrapped before)

- Calls to DiIncomingSchemaEnforcer are replaced to new API

This PR SHOULD be merged ONLY AFTER https://github.com/Talend/daikon/pull/226