### PR TITLE
fix(TDI-38441): set failOn default value to true tFileCopy

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileCopy/tFileCopy_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileCopy/tFileCopy_java.xml
@@ -137,7 +137,7 @@
      FIELD="CHECK"
      NUM_ROW="70"
     >
-    <DEFAULT>false</DEFAULT>
+    <DEFAULT>true</DEFAULT>
     </PARAMETER>
   </PARAMETERS>
   


### PR DESCRIPTION
As simple as possible

Change default value of new property to 'true'