### PR TITLE
fix(TUP-17123): Build as War will miss wsdd and wsdl folder if

### DIFF
--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/JobJavaScriptsWSManager.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/JobJavaScriptsWSManager.java
@@ -304,7 +304,7 @@ public class JobJavaScriptsWSManager extends JobJavaScriptsManager {
 
             String jobFolderName = JavaResourcesHelper.getJobFolderName(escapeFileNameSpace(processItem), selectedProcessVersion);
 
-            String classRoot = getClassRootLocation();
+            String classRoot = FilesUtils.getFileRealPath(getClassRootLocation());
 
             String wsdlFilePath = getTmpFolder() + PATH_SEPARATOR + jobName + ".wsdl"; //$NON-NLS-1$
             String classFileName = classRoot + PATH_SEPARATOR + projectName + PATH_SEPARATOR + jobFolderName + PATH_SEPARATOR


### PR DESCRIPTION
fix(TUP-17123): Build as War will miss wsdd and wsdl folder if studio patch include blank
https://jira.talendforge.org/browse/TUP-17123