### PR TITLE
fix(TDI-38441): Fix migration task

### DIFF
--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/model/migration/AddFailOnErrorOnTFileCopyTDI38441.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/model/migration/AddFailOnErrorOnTFileCopyTDI38441.java
@@ -48,13 +48,12 @@ public class AddFailOnErrorOnTFileCopyTDI38441 extends AbstractJobMigrationTask 
                         ComponentUtilities.addNodeProperty(node, propertyName, propertyType);
                     }
                     ElementParameterType copyingDirectory = ComponentUtilities.getNodeProperty(node, isCopyDirectoryPropertyName);
-                    if (copyingDirectory != null) {
-                        if ("true".equals(copyingDirectory.getValue())) { //$NON-NLS-1$
-                            ComponentUtilities.setNodeValue(node, propertyName, "false"); //$NON-NLS-1$
-                            return;
-                        }
-                        ComponentUtilities.setNodeValue(node, propertyName, "true"); //$NON-NLS-1$
+                    if ((copyingDirectory != null) && ("true".equals(copyingDirectory.getValue()))) { //$NON-NLS-1$
+                        ComponentUtilities.setNodeValue(node, propertyName, "false"); //$NON-NLS-1$
+                        return;
                     }
+
+                    ComponentUtilities.setNodeValue(node, propertyName, "true"); //$NON-NLS-1$
 
                 }
 


### PR DESCRIPTION
* tFileCopy will have failOn set to true even if copydir was absent before