### PR TITLE
fix(TDI-38009):compile error on tSSH component if use context expression on port field

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tSSH/tSSH_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSSH/tSSH_begin.javajet
@@ -81,7 +81,7 @@ if ((metadatas!=null)&&(metadatas.size()>0)) {
 
 	/* Create a connection instance */
 		<%if(isLog4jEnabled){%>
-			log.info("<%=cid%> - Connection attempt to '" +hostname_<%=cid%> + "' on the port '<%=port%>' as '" + username_<%=cid%> + "'.");
+			log.info("<%=cid%> - Connection attempt to '" +hostname_<%=cid%> + "' on the port '"+<%=port%>+"' as '" + username_<%=cid%> + "'.");
 		<%}%>
 <%
         if(("").equals(port)){


### PR DESCRIPTION
For https://jira.talendforge.org/browse/TDI-38009

When use context expression on port field and active log4j, it would got compile in generated code.