### PR TITLE
fix(TDI-38801):tAdvancedFileOutputXML throws null pointer if there is more then one component in a flow and one appends the xml file

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tAdvancedFileOutputXML/tAdvancedFileOutputXML_begin.inc.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tAdvancedFileOutputXML/tAdvancedFileOutputXML_begin.inc.javajet
@@ -609,7 +609,7 @@ class GenerateToolByDom4j{
 
 //----------** add by wliu dom4j to genenrate get function for node **-------//
 class GenerateExprCmpByDom4j{
-//	String cid = null;
+	String cid = null;
 	XMLTool tool = null;
 	XMLNode groupNode = null;
 	boolean needEmptyNode = true;
@@ -625,19 +625,19 @@ class GenerateExprCmpByDom4j{
 		if(node.relatedColumn != null){
 %> && (<%
 			if(!needEmptyNode){
-%>(<%tool.getValue(node); %>==null && <%generateCmnExpr(arrNames, parentName); %> == null) || (true &&
+%>(<%tool.getValue(node); %>==null && <%generateCmnExpr(arrNames, parentName,cid); %> == null) || (true &&
 <%			}%>
- <%generateCmnExpr(arrNames, parentName); %>!=null
+ <%generateCmnExpr(arrNames, parentName,cid); %>!=null
  <%
  if(isSaveDocAsNode && "id_Document".equals(node.relatedColumn.getTalendType())){
  %>
- && <%generateCmnExpr(arrNames, parentName); %>.hasContent()
- && ((org.dom4j.Node)<%generateCmnExpr(arrNames, parentName); %>.content().get(0)).asXML().equals(<%tool.getValue(node); %>)
+ && <%generateCmnExpr(arrNames, parentName,cid); %>.hasContent()
+ && ((org.dom4j.Node)<%generateCmnExpr(arrNames, parentName,cid); %>.content().get(0)).asXML().equals(<%tool.getValue(node); %>)
 <%
 }else{
 %>
- && <%generateCmnExpr(arrNames, parentName); %>.getText()!=null
- && <%generateCmnExpr(arrNames, parentName); %>.getText().equals(<%tool.getValue(node); %>)
+ && <%generateCmnExpr(arrNames, parentName,cid); %>.getText()!=null
+ && <%generateCmnExpr(arrNames, parentName,cid); %>.getText().equals(<%tool.getValue(node); %>)
 <%
 }
 %>
@@ -652,11 +652,11 @@ class GenerateExprCmpByDom4j{
 				if(attri.relatedColumn !=null){
 %> && (<%
 					if(!needEmptyNode){
-%>(<%tool.getValue(attri); %>==null && <%generateCmnExpr(arrNames, parentName); %>.attribute("<%=attri.name %>") == null) || (true && 
+%>(<%tool.getValue(attri); %>==null && <%generateCmnExpr(arrNames, parentName,cid); %>.attribute("<%=attri.name %>") == null) || (true && 
 <%					}%>
- <%generateCmnExpr(arrNames, parentName); %>.attribute("<%=attri.name %>")!=null
-&& <%generateCmnExpr(arrNames, parentName); %>.attribute("<%=attri.name %>").getText()!=null
-&& <%generateCmnExpr(arrNames, parentName); %>.attribute("<%=attri.name %>").getText().equals(<%tool.getValue(attri); %>)
+ <%generateCmnExpr(arrNames, parentName,cid); %>.attribute("<%=attri.name %>")!=null
+&& <%generateCmnExpr(arrNames, parentName,cid); %>.attribute("<%=attri.name %>").getText()!=null
+&& <%generateCmnExpr(arrNames, parentName,cid); %>.attribute("<%=attri.name %>").getText().equals(<%tool.getValue(attri); %>)
 <%
 					if(!needEmptyNode){%>)<%}
 %>)<%
@@ -673,14 +673,24 @@ class GenerateExprCmpByDom4j{
 		}		
 	}
 	
-	private void generateCmnExpr(String[] arrNames, String parentName){
-%>
-<%=parentName %>
-<%
+	private void generateCmnExpr(String[] arrNames, String parentName,String cid){
+	%>
+		nestXMLTool_<%=cid%>.getElement(<%=parentName %>,new String[]{
+		<%
 		for(int i=1;arrNames != null && i<arrNames.length; i++){
-%>.element(<%=parentName%>.getQName("<%=arrNames[i]%>"))
-<%
+			if(i!=1){
+			%>
+				,"<%=arrNames[i]%>"
+			<%
+			}else{
+			%>		
+				"<%=arrNames[i]%>"
+			<%
+			}
 		}
+		%>
+		})
+		<%
 	}
 }
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tAdvancedFileOutputXML/tAdvancedFileOutputXML_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tAdvancedFileOutputXML/tAdvancedFileOutputXML_begin.javajet
@@ -219,6 +219,22 @@ if ((metadatas != null) && (metadatas.size() > 0)) {
 						}
 					}
 				}
+				/**
+				 * Get element by QNames which get from the path
+				 */
+				public org.dom4j.Element getElement(org.dom4j.Element parent,String[] elemNames){
+					if(parent==null){
+						return null;
+					}
+					org.dom4j.Element tempElem = parent;
+					for(int i=0;elemNames != null && i<elemNames.length; i++){
+						tempElem=tempElem.element(parent.getQName(elemNames[i]));
+						if(tempElem==null){
+							return null;
+						}
+					}
+					return tempElem;
+				}
 			}
 
 			final NestXMLTool_<%=cid%> nestXMLTool_<%=cid%> = new NestXMLTool_<%=cid%>();
@@ -509,6 +525,7 @@ if ((metadatas != null) && (metadatas.size() > 0)) {
 										generateExprCmpByDom4j.groupNode = groupNode;
 										generateExprCmpByDom4j.isSaveDocAsNode = isSaveDocAsNode;
 										generateExprCmpByDom4j.needEmptyNode = ("true").equals(allowEmpty);
+										generateExprCmpByDom4j.cid=cid;
 								
 %>
 				public boolean generateCodeDom4j_FindInsertNode<%=i%>(org.dom4j.Element tempElem,java.util.Map<String,String> valueMap_<%=cid%>){

--- a/main/plugins/org.talend.designer.components.localprovider/components/tAdvancedFileOutputXML/tAdvancedFileOutputXML_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tAdvancedFileOutputXML/tAdvancedFileOutputXML_main.javajet
@@ -240,6 +240,7 @@ if(groupTable.size()>0){					//init the generate tool.
 			generateExprCmpByDom4j.groupNode = groupNode;
 			generateExprCmpByDom4j.isSaveDocAsNode = isSaveDocAsNode;
 			generateExprCmpByDom4j.needEmptyNode = ("true").equals(allowEmpty);
+			generateExprCmpByDom4j.cid=cid;
 %>
 		if(bl_<%=cid %>==false){
 			java.util.List<org.dom4j.Element> listNodes= <%generateToolByDom4j.touchXMLNode.getXMLElement("subTreeRootParent");%>.elements();


### PR DESCRIPTION
For https://jira.talendforge.org/browse/TDI-38801

Avoid NPE when append xml file node included all elements defined in the xml tree.