### PR TITLE
fix(TUP-17869): routines dependencies cannot be added to newly created job automatically even tick the checkbox

### DIFF
--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/process/Process.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/process/Process.java
@@ -1912,8 +1912,7 @@ public class Process extends Element implements IProcess2, IGEFProcess, ILastVer
         }
     }
 
-    private void saveRoutinesDependencies(ProcessType process) {
-        routinesDependencies = new ArrayList<RoutinesParameterType>();
+    protected void saveRoutinesDependencies(ProcessType process) {
         /* if process is joblet,parameters will be null,so that create a new parametertype for joblet */
         if (process.getParameters() == null) {
             ParametersType parameterType = TalendFileFactory.eINSTANCE.createParametersType();


### PR DESCRIPTION
fix(TUP-17869): routines dependencies cannot be added to newly created job automatically even tick the checkbox
https://jira.talendforge.org/browse/TUP-17869