### PR TITLE
fix(TDI-38894): Escape command args for sub-job which is run as indep…

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tRunJob/tRunJob_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tRunJob/tRunJob_main.javajet
@@ -509,7 +509,8 @@ String inputConnName = null;
 	%>
 		Runtime runtime_<%=cid %> = Runtime.getRuntime();
 		final Process ps_<%=cid %>;
-		ps_<%=cid %> = runtime_<%=cid %>.exec((String[])paraList_<%=cid %>.toArray(new String[paraList_<%=cid %>.size()]));
+		final java.util.List<String> runtimeExecCommandArgs_<%=cid %> = routines.system.ProcessUtils.escapeRuntimeExecCommandArgs(paraList_<%=cid %>);
+		ps_<%=cid %> = runtime_<%=cid %>.exec((String[]) runtimeExecCommandArgs_<%=cid %>.toArray(new String[runtimeExecCommandArgs_<%=cid %>.size()]));
 
 		Thread normal_<%=cid %> = new Thread() {
 			public void run() {


### PR DESCRIPTION
…endent Java process.

* tRunJob modified to escape command args for a sub-job which is run as independent Java process

This PR depends on https://github.com/Talend/tcommon-studio-se/pull/1067.

JIRA issue: https://jira.talendforge.org/browse/TDI-38894