### PR TITLE
bug(TBD-5111/components): tBigQueryBulkExec component does not report error when failures happen - fixed

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryBulkExec/tBigQueryBulkExec_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryBulkExec/tBigQueryBulkExec_begin.javajet
@@ -366,6 +366,12 @@
 		}
 
 		com.google.api.services.bigquery.model.Job doneJob_<%=cid%> = pollJob_<%=cid%>;
+
+		if ((doneJob_<%=cid%>.getStatus() != null) && (doneJob_<%=cid%>.getStatus().getErrors() != null)) {
+			status = "failure";
+			throw new Exception(doneJob_<%=cid%>.getStatus().getErrors().toString());
+		}
+
 		System.out.println("Done: " + doneJob_<%=cid%>.toString());
 		com.google.api.services.bigquery.model.JobStatistics jobStatistics_<%=cid%>= doneJob_<%=cid%>.getStatistics();
 		if(jobStatistics_<%=cid%>!=null && jobStatistics_<%=cid%>.getLoad() != null){


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [X] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [X] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [X] Docs have been added / updated (for bug fixes / features) ?
- [X] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)
When an error is detected in BigQueryBulkExec, a component is not reported.
https://jira.talendforge.org/browse/TBD-5111

**What is the new behavior?**
Error is reported correctly

**Other information**: