### PR TITLE
chore(TDI-37213): switch talend-codegen-utils lib to the latest 0.20.…

### DIFF
--- a/main/plugins/org.talend.designer.core.generic/src/main/java/org/talend/designer/core/generic/model/Component.java
+++ b/main/plugins/org.talend.designer.core.generic/src/main/java/org/talend/designer/core/generic/model/Component.java
@@ -1184,7 +1184,7 @@ public class Component extends AbstractBasicComponent {
         }
         ModuleNeeded moduleNeeded = new ModuleNeeded(getName(), "", true, "mvn:org.talend.libraries/slf4j-log4j12-1.7.2/6.0.0");
         componentImportNeedsList.add(moduleNeeded);
-        moduleNeeded = new ModuleNeeded(getName(), "", true, "mvn:org.talend.libraries/talend-codegen-utils/0.17.0-SNAPSHOT");
+        moduleNeeded = new ModuleNeeded(getName(), "", true, "mvn:org.talend.libraries/talend-codegen-utils/0.20.0");
         componentImportNeedsList.add(moduleNeeded);
         return componentImportNeedsList;
     }


### PR DESCRIPTION
… version

Related to https://jira.talendforge.org/browse/TDI-37213

https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceRelease/org/talend/libraries/talend-codegen-utils/0.20.0/ released

It has extended API (di enforcers were moved to it) in comparison with 0.17.0-SNAPSHOT
I am going to replace calls in codegen from Daikon to this library