### PR TITLE
fix(TDI-39045) improve the error message when when used the tMicrosoftCRMOutput to do the update without key column is set

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmOutput/tMicrosoftCrmOutput_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmOutput/tMicrosoftCrmOutput_begin.javajet
@@ -6,6 +6,8 @@ imports="
         org.talend.core.model.process.ElementParameterParser
         org.talend.core.model.process.INode
         org.talend.designer.codegen.config.CodeGeneratorArgument
+        org.talend.core.model.metadata.IMetadataColumn
+        org.talend.core.model.metadata.IMetadataTable
         "
 %>
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmOutput/tMicrosoftCrmOutput_begin_odata.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmOutput/tMicrosoftCrmOutput_begin_odata.javajet
@@ -1,10 +1,3 @@
-<%@ jet
-imports="
-        org.talend.core.model.process.ElementParameterParser
-        org.talend.core.model.process.INode
-        org.talend.designer.codegen.config.CodeGeneratorArgument
-		"
-%>
 <%
 	String authType = ElementParameterParser.getValue(node, "__AUTH_TYPE__");
 	String userName = ElementParameterParser.getValue(node, "__USERNAME__");
@@ -29,6 +22,32 @@ imports="
 		String entitySetName_<%=cid%>="<%=entitySetName%>";
 	<%	
 	}
+	 String action = ElementParameterParser.getValue(node,"__ACTION__");
+	 if("update".equals(action)){
+	    List<IMetadataTable> metadatas = node.getMetadataList();
+	    if ((metadatas!=null)&&(metadatas.size()>0)) {
+	        IMetadataTable metadata = metadatas.get(0);
+	        if (metadata!=null) {
+			      List<IMetadataColumn> columns = metadata.getListColumns();
+			      int sizeColumns = columns.size();
+			      boolean hasKeyColumn=false;
+			      for(int i = 0; i < sizeColumns; i++){
+	        		    IMetadataColumn column = columns.get(i);
+                   if(column.isKey()){
+                        hasKeyColumn = true;
+                        break;
+                    }
+                }
+                if(!hasKeyColumn){
+                %>
+                    if(true){
+                        throw new RuntimeException("No key column is specified in the schema!");
+                    }
+                <%
+                }
+            }
+        }
+    }
 	%>
 
 	<%@ include file="@{org.talend.designer.components.localprovider}/components/templates/password.javajet"%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmOutput/tMicrosoftCrmOutput_main_odata.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmOutput/tMicrosoftCrmOutput_main_odata.javajet
@@ -66,9 +66,11 @@
                     		client_<%=cid%>.insertEntity(entity_<%=cid%>);
                     	<%
                     	}else if("update".equals(action)){
-                    	%>
-                 			client_<%=cid%>.updateEntity( entity_<%=cid%>, <%=connName%>.<%=idColumnName%>);
-                    	<%
+                    		if(idColumnName!=null){
+                    		%>
+                 				client_<%=cid%>.updateEntity( entity_<%=cid%>, <%=connName%>.<%=idColumnName%>);
+                    		<%
+                    		}
                     	} else if ("delete".equals(action)){
                     	%>
                     		client_<%=cid%>.deleteEntity(<%=connName%>.Id);


### PR DESCRIPTION
For https://jira.talendforge.org/browse/TDI-39045

**Problem**： When tMicrosoftCRMOutput use update with no key column in the schema. The code generate would get compiler error.

**Solution**: Avoid the compiler error. and throw a runtime exception when the schema is not set a key column for update.
And put the check in begin part and before connection for performance.

