### PR TITLE
[TESB-18845] DI service  used JMS and ActiveMQ does not produce log output

### DIFF
--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/esb/JobJavaScriptOSGIForESBManager.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/esb/JobJavaScriptOSGIForESBManager.java
@@ -750,6 +750,12 @@ public class JobJavaScriptOSGIForESBManager extends JobJavaScriptsManager {
         }
 
 
+        if (requireBundle != null && !requireBundle.isEmpty()) {
+            requireBundle += (", org.ops4j.pax.logging.pax-logging-api");
+        } else {
+            requireBundle = "org.ops4j.pax.logging.pax-logging-api";
+        }
+
         if (requireBundle != null) {
             analyzer.setProperty(Analyzer.REQUIRE_BUNDLE, requireBundle);
         }


### PR DESCRIPTION
 When job contains jar in it's bundle class path that contains log4j classes in it, log4j classes for the job are getting resolved with classes from inside the bundle but not pax-logging classes, which leads to completely broken logging in the bundle. 

This fix adds Require-Bundle manifest entry to job's manifest which enforces resolution of log4j classes from pax-logging.