### PR TITLE
fix(TDI-39089): Add uri encoding in tFileFetch

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileFetch/tFileFetch_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileFetch/tFileFetch_main.javajet
@@ -47,7 +47,20 @@ if ("http".equals(protocol) || "https".equals(protocol)) {
 %>	
 	java.net.URI encodedURI_<%=cid %> = null;
 	try {
-		java.net.URL url_<%=cid %> = new java.net.URL(<%=uri %>);
+		//when user input already encoded (contains '%' uri - need try to decode it using URLDecoder for correct processing
+<%
+		if (uri.contains("%")) {
+%>
+			java.net.URL url_<%=cid %> = new java.net.URL(java.net.URLDecoder.decode(<%=uri %>, "UTF-8"));
+<%
+		} else {
+%>
+			java.net.URL url_<%=cid %> = new java.net.URL(<%=uri %>);
+<%
+		}
+%>
+		
+		
 		encodedURI_<%=cid %> = new java.net.URI(
                 url_<%=cid %>.getProtocol(),
                 url_<%=cid %>.getAuthority(),
@@ -55,7 +68,7 @@ if ("http".equals(protocol) || "https".equals(protocol)) {
                 url_<%=cid %>.getQuery(),
                 url_<%=cid %>.getRef());
 	} 
-	catch (java.net.URISyntaxException | java.net.MalformedURLException e) {
+	catch (java.io.IOException e) {
 <%
 			String unsupportedEncodingErrorMessage = "URI is not correct, please input a valid one";
 		if (isLog4jEnabled) {

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileFetch/tFileFetch_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileFetch/tFileFetch_main.javajet
@@ -44,9 +44,35 @@ if ("http".equals(protocol) || "https".equals(protocol)) {
 	boolean useProxy = "true".equals(ElementParameterParser.getValue(node, "__USE_PROXY__"));
 	boolean useProxyNTLM = "true".equals(ElementParameterParser.getValue(node, "__PROXY_NTLM__"));
 	boolean addHeader = "true".equals(ElementParameterParser.getValue(node, "__ADD_HEADER__"));
-
+%>	
+	java.net.URI encodedURI_<%=cid %> = null;
+	try {
+		java.net.URL url_<%=cid %> = new java.net.URL(<%=uri %>);
+		encodedURI_<%=cid %> = new java.net.URI(
+                url_<%=cid %>.getProtocol(),
+                url_<%=cid %>.getAuthority(),
+                url_<%=cid %>.getPath(),
+                url_<%=cid %>.getQuery(),
+                url_<%=cid %>.getRef());
+	} 
+	catch (java.net.URISyntaxException | java.net.MalformedURLException e) {
+<%
+			String unsupportedEncodingErrorMessage = "URI is not correct, please input a valid one";
+		if (isLog4jEnabled) {
+%>
+			log.warn("<%=unsupportedEncodingErrorMessage %>");
+<%
+		} else {
+%>
+			System.err.println("<%= unsupportedEncodingErrorMessage %>");
+<%
+		}
+%>
+	}
+	<%
 	if ("https".equals(protocol)) {
 	%>
+	
 		class SocketFactory_<%=cid%> implements org.apache.commons.httpclient.protocol.SecureProtocolSocketFactory {
 
 			private javax.net.ssl.SSLContext sslcontext = null;
@@ -127,11 +153,11 @@ if ("http".equals(protocol) || "https".equals(protocol)) {
 			}
 		}
 
-		if ((<%=uri %>).toLowerCase().startsWith("https://")) {
 			org.apache.commons.httpclient.protocol.Protocol myhttps = new org.apache.commons.httpclient.protocol.Protocol("https", new SocketFactory_<%=cid%>(), 443);
 			org.apache.commons.httpclient.protocol.Protocol.registerProtocol("https", myhttps);
-		}
-	<%}%>
+<%
+	}
+%>
 	org.apache.commons.httpclient.HttpClient client_<%=cid %> = new org.apache.commons.httpclient.HttpClient();
 	<%if(isLog4jEnabled){%>
 		log.info("<%=cid%> - Connection attempt to '" + <%=uri %>);
@@ -234,7 +260,7 @@ if ("http".equals(protocol) || "https".equals(protocol)) {
 
 	if (post) {
 	%>
-		org.apache.commons.httpclient.methods.PostMethod method_<%=cid%> = new org.apache.commons.httpclient.methods.PostMethod(<%=uri %>);
+		org.apache.commons.httpclient.methods.PostMethod method_<%=cid%> = new org.apache.commons.httpclient.methods.PostMethod(encodedURI_<%=cid %>.toASCIIString());
 		<%
 		List<Map<String, String>> commonParams = (List<Map<String,String>>)ElementParameterParser.getObjectValue(node, "__COMMON_PARAMS__");	
 		List<String> varPartList = new ArrayList<String>();	//common string parameter part	
@@ -270,7 +296,7 @@ if ("http".equals(protocol) || "https".equals(protocol)) {
 		org.apache.commons.httpclient.methods.multipart.Part[] parts_<%=cid %> = new org.apache.commons.httpclient.methods.multipart.Part[]{<%for(String var: varPartList){%><%=var %>,<%}%>};    
 		method_<%=cid%>.setRequestEntity(new org.apache.commons.httpclient.methods.multipart.MultipartRequestEntity(parts_<%=cid %>, method_<%=cid%>.getParams()));          
 	<%} else {%>
-		org.apache.commons.httpclient.methods.GetMethod method_<%=cid%> = new org.apache.commons.httpclient.methods.GetMethod(<%=uri %>);
+		org.apache.commons.httpclient.methods.GetMethod method_<%=cid%> = new org.apache.commons.httpclient.methods.GetMethod(encodedURI_<%=cid %>.toASCIIString());
 	<%}
 
 	if (addHeader) {
@@ -285,7 +311,7 @@ if ("http".equals(protocol) || "https".equals(protocol)) {
 	%>
 	boolean isContinue_<%=cid%> = true;
 	int status_<%=cid%>;
-	String finalURL_<%=cid%> = <%=uri%>;
+	String finalURL_<%=cid%> = encodedURI_<%=cid %>.toASCIIString();
 
 	try { // B_01
 		<%if (redirect) { //Bug13155, add support of redirection%>

--- a/main/plugins/org.talend.repository/plugin.xml
+++ b/main/plugins/org.talend.repository/plugin.xml
@@ -2923,23 +2923,23 @@
               id="org.talend.repository.model.migration.UnselectChangeEqualsAndHashcodeForBigDecimalInTMap"
               name="Set the 'skip tailing zeros for BigDecimal' setting to false if it was null"
               version="6.5.0">
-	</projecttask>
-	<projecttask
+        </projecttask>
+        <projecttask
               beforeLogon="false"
               breaks="6.4.1"
               class="org.talend.repository.model.migration.DecodeURIInTFileFetch"
               id="org.talend.repository.model.migration.DecodeURIInTFileFetch"
               name="Decode URI to save functionality of component correct"
               version="6.5.0">
-    </projecttask>
-    <projecttask
+        </projecttask>
+        <projecttask
               beforeLogon="false"
               breaks="6.5.0"
               class="org.talend.repository.model.migration.ChangeColumnDelimiter4tExaBulkExec"
               id="org.talend.repository.model.migration.ChangeColumnDelimiter4tExaBulkExec"
               name="reset the 'COLUMN_DELIMITER' parameter"
               version="6.5.0">
-    </projecttask>
+        </projecttask>
    </extension>
 
    <extension

--- a/main/plugins/org.talend.repository/plugin.xml
+++ b/main/plugins/org.talend.repository/plugin.xml
@@ -2924,6 +2924,14 @@
               name="Set the 'skip tailing zeros for BigDecimal' setting to false if it was null"
               version="6.5.0">
 		</projecttask>
+		<projecttask
+		beforeLogon="false"
+		breaks="6.5.0"
+		class="org.talend.repository.model.migration.DecodeURIInTFileFetch"
+        id="org.talend.repository.model.migration.DecodeURIInTFileFetch"
+        name="Decode URI to save functionality of component correct"
+        version="6.5.0">
+		</projecttask>
    </extension>
 
    <extension

--- a/main/plugins/org.talend.repository/plugin.xml
+++ b/main/plugins/org.talend.repository/plugin.xml
@@ -2923,15 +2923,15 @@
               id="org.talend.repository.model.migration.UnselectChangeEqualsAndHashcodeForBigDecimalInTMap"
               name="Set the 'skip tailing zeros for BigDecimal' setting to false if it was null"
               version="6.5.0">
-		</projecttask>
-		<projecttask
-		          beforeLogon="false"
-		          breaks="6.4.1"
-		          class="org.talend.repository.model.migration.DecodeURIInTFileFetch"
+	</projecttask>
+	<projecttask
+              beforeLogon="false"
+              breaks="6.4.1"
+              class="org.talend.repository.model.migration.DecodeURIInTFileFetch"
               id="org.talend.repository.model.migration.DecodeURIInTFileFetch"
               name="Decode URI to save functionality of component correct"
               version="6.5.0">
-    <projecttask>
+    </projecttask>
     <projecttask
               beforeLogon="false"
               breaks="6.5.0"
@@ -2939,7 +2939,7 @@
               id="org.talend.repository.model.migration.ChangeColumnDelimiter4tExaBulkExec"
               name="reset the 'COLUMN_DELIMITER' parameter"
               version="6.5.0">
-		</projecttask>
+    </projecttask>
    </extension>
 
    <extension

--- a/main/plugins/org.talend.repository/plugin.xml
+++ b/main/plugins/org.talend.repository/plugin.xml
@@ -2926,7 +2926,7 @@
 		</projecttask>
 		<projecttask
 		beforeLogon="false"
-		breaks="6.5.0"
+		breaks="6.4.1"
 		class="org.talend.repository.model.migration.DecodeURIInTFileFetch"
         id="org.talend.repository.model.migration.DecodeURIInTFileFetch"
         name="Decode URI to save functionality of component correct"

--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/model/migration/DecodeURIInTFileFetch.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/model/migration/DecodeURIInTFileFetch.java
@@ -1,0 +1,82 @@
+package org.talend.repository.model.migration;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+import org.talend.commons.exception.ExceptionHandler;
+import org.talend.core.language.ECodeLanguage;
+import org.talend.core.model.components.ComponentUtilities;
+import org.talend.core.model.components.ModifyComponentsAction;
+import org.talend.core.model.components.conversions.IComponentConversion;
+import org.talend.core.model.components.filters.IComponentFilter;
+import org.talend.core.model.components.filters.NameComponentFilter;
+import org.talend.core.model.migration.AbstractJobMigrationTask;
+import org.talend.core.model.properties.Item;
+import org.talend.designer.core.model.utils.emf.talendfile.ElementParameterType;
+import org.talend.designer.core.model.utils.emf.talendfile.NodeType;
+import org.talend.designer.core.model.utils.emf.talendfile.ProcessType;
+
+public class DecodeURIInTFileFetch extends AbstractJobMigrationTask {
+
+    @Override
+    public Date getOrder() {
+        GregorianCalendar gc = new GregorianCalendar(2017, 7, 3, 14, 0, 0);
+        return gc.getTime();
+    }
+
+    @Override
+    public ExecutionResult execute(Item item) {
+        ProcessType processType = getProcessType(item);
+        if (getProject().getLanguage() != ECodeLanguage.JAVA || processType == null) {
+            return ExecutionResult.NOTHING_TO_DO;
+        }
+        try {
+            String componentsName = new String("tFileFetch"); //$NON-NLS-1$
+
+            IComponentFilter filter = new NameComponentFilter(componentsName);
+            IComponentConversion addOption = new IComponentConversion() {
+
+                @Override
+                public void transform(NodeType node) {
+
+                    String uriPropertyType = "TEXT"; //$NON-NLS-1$
+                    String uriPropertyName = "URI"; //$NON-NLS-1$
+                    String protocolPropertyName = "PROTO"; //$NON-NLS-1$
+
+                    ElementParameterType uriProperty = ComponentUtilities.getNodeProperty(node, uriPropertyName);
+                    ElementParameterType protocolName = ComponentUtilities.getNodeProperty(node, protocolPropertyName);
+
+                    // decode URI using URLDecoder
+                    if ((protocolName != null)
+                            && (("http".equals(protocolName.getValue())) || ("https".equals(protocolName.getValue())))) { //$NON-NLS-1$
+
+                        if (uriProperty == null) {
+                            ComponentUtilities.addNodeProperty(node, uriPropertyName, uriPropertyType);
+                            return; // no need to decode URI
+                        }
+
+                        String URI = uriProperty.getValue();
+                        try {
+                            URI = URLDecoder.decode(URI, "UTF-8");
+                            ComponentUtilities.setNodeValue(node, uriPropertyName, URI); // $NON-NLS-1$
+                        } catch (UnsupportedEncodingException e) {
+                            ExceptionHandler.process(e);
+                        }
+                    }
+
+                }
+
+            };
+            ModifyComponentsAction.searchAndModify(item, processType, filter, Arrays.<IComponentConversion> asList(addOption));
+            return ExecutionResult.SUCCESS_NO_ALERT;
+        } catch (Exception e) {
+            ExceptionHandler.process(e);
+            return ExecutionResult.FAILURE;
+        }
+
+    }
+
+}


### PR DESCRIPTION
* Incorrect uri would become correct in the job using URI.toASCIIString method

* No changes for ftp and smb protocol due to they should work OK with special characters

* Already correct uri become incorrect-encoded in properties (migration task)