### PR TITLE
fix(TUP-18213): set correct connection bean if logon studio using parameters instead of logon dialog

### DIFF
--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/RepositoryService.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/RepositoryService.java
@@ -394,6 +394,7 @@ public class RepositoryService implements IRepositoryService, IRepositoryContext
                         bean = ConnectionBean.getDefaultConnectionBean();
                     }
                 }
+                LoginHelper.getInstance().setCurrentSelectedConnBean(bean);
 
                 Context ctx = CorePlugin.getContext();
                 RepositoryContext repositoryContext = new RepositoryContext();

--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/login/LoginHelper.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/login/LoginHelper.java
@@ -388,6 +388,7 @@ public class LoginHelper {
         if (connBean == null || project == null || project.getLabel() == null) {
             return false;
         }
+        setCurrentSelectedConnBean(connBean);
         try {
             if (!project.getEmfProject().isLocal() && factory.isLocalConnectionProvider()) {
                 List<IRepositoryFactory> rfList = RepositoryFactoryProvider.getAvailableRepositories();


### PR DESCRIPTION
fix(TUP-18213): set correct connection bean if logon studio using parameters instead of logon dialog
https://jira.talendforge.org/browse/TUP-18213