### PR TITLE
fix(TBD-4416/components): Cann't run job that use joblet use existing connection for tHiveInput - fixed

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/templates/Log4j/Log4jDBConnUtil.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/templates/Log4j/Log4jDBConnUtil.javajet
@@ -69,7 +69,7 @@ imports="
 			%>
 				if(conn_<%=cid%> != null) {
 					if(conn_<%=cid%>.getMetaData() != null) {
-						<%if (cid.startsWith("tImpala") || cid.startsWith("tHive")) {%>
+						<%if (cid.contains("tImpala") || cid.contains("tHive")) {%>
 						log.debug("<%=cid%> - Uses an existing connection <%=connection %>.");
 						<%} else {%>
 						log.debug("<%=cid%> - Uses an existing connection with username '" + conn_<%=cid%>.getMetaData().getUserName() + "'. Connection URL: " + conn_<%=cid%>.getMetaData().getURL() + ".");


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [X] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [X] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [X] Docs have been added / updated (for bug fixes / features) ?
- [X] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)
Cann't run job that use joblet use existing connection for tHiveInput 
https://jira.talendforge.org/browse/TBD-4416

**What is the new behavior?**
Joblet with tHiveInput using existing connection runs succesfully
