### PR TITLE
fix(TDI-39101) : Don't send null for rejected

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tGoogleDriveGet/tGoogleDriveGet_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tGoogleDriveGet/tGoogleDriveGet_begin.javajet
@@ -207,4 +207,7 @@ com.google.api.services.drive.Drive <%=cid%>_client;
 		}
 %>
 			}
+			else {
+	              <%=dataOutputConnection%>.content = null;
+			}
 		}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tGoogleDriveGet/tGoogleDriveGet_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tGoogleDriveGet/tGoogleDriveGet_begin.javajet
@@ -208,6 +208,6 @@ com.google.api.services.drive.Drive <%=cid%>_client;
 %>
 			}
 			else {
-	              <%=dataOutputConnection%>.content = null;
+			    <%=dataOutputConnection%>.content = null;
 			}
 		}


### PR DESCRIPTION
**What is the current behavior? (You can also link to an open issue here)**
https://jira.talendforge.org/browse/TDI-39101

When the tGoogleDriveGet try to retreive an undownloadable file (maps, form, site, ...) the outputSchema.content was null or take the value of the previous file.

**What is the new behavior?**
No row send to the output flow

**What kind of change does this PR introduce?**
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No