### PR TITLE
fix(TUP-18440):added quotes to ReferenceProperties object during code generation

### DIFF
--- a/main/plugins/org.talend.designer.core.generic/src/main/java/org/talend/designer/core/generic/model/Component.java
+++ b/main/plugins/org.talend.designer.core.generic/src/main/java/org/talend/designer/core/generic/model/Component.java
@@ -92,6 +92,7 @@ import org.talend.core.utils.TalendQuoteUtils;
 import org.talend.daikon.NamedThing;
 import org.talend.daikon.exception.TalendRuntimeException;
 import org.talend.daikon.properties.Properties;
+import org.talend.daikon.properties.ReferenceProperties;
 import org.talend.daikon.properties.presentation.Form;
 import org.talend.daikon.properties.property.Property;
 import org.talend.daikon.properties.property.SchemaProperty;
@@ -1338,10 +1339,13 @@ public class Component extends AbstractBasicComponent {
     protected void processCodegenPropInfos(List<CodegenPropInfo> propList, Properties props, String fieldString) {
         for (NamedThing prop : props.getProperties()) {
             if (prop instanceof Properties) {
+                if (prop instanceof ReferenceProperties) {
+                    ReferenceProperties rp = (ReferenceProperties) prop;
+                    rp.referenceDefinitionName.setTaggedValue(IGenericConstants.ADD_QUOTES, true);
+                }
                 if (prop instanceof ComponentReferenceProperties) {
                     ComponentReferenceProperties crp = (ComponentReferenceProperties) prop;
                     crp.componentInstanceId.setTaggedValue(IGenericConstants.ADD_QUOTES, true);
-                    crp.referenceDefinitionName.setTaggedValue(IGenericConstants.ADD_QUOTES, true);
                 }
                 CodegenPropInfo childPropInfo = new CodegenPropInfo();
                 if (fieldString.equals("")) {//$NON-NLS-1$

--- a/test/plugins/org.talend.designer.core.generic.test/src/main/java/org/talend/designer/core/generic/model/ComponentTest.java
+++ b/test/plugins/org.talend.designer.core.generic.test/src/main/java/org/talend/designer/core/generic/model/ComponentTest.java
@@ -31,6 +31,7 @@ import org.talend.core.model.process.INode;
 import org.talend.core.model.repository.FakePropertyImpl;
 import org.talend.core.ui.component.ComponentsFactoryProvider;
 import org.talend.daikon.properties.Properties;
+import org.talend.daikon.properties.ReferenceProperties;
 import org.talend.daikon.properties.presentation.Form;
 import org.talend.daikon.properties.property.Property;
 import org.talend.designer.core.generic.constants.IGenericConstants;
@@ -88,14 +89,19 @@ public class ComponentTest {
     public void testGetCodegenPropInfosWithReferencePropertiesObject() {
         TestProperties props = (TestProperties) new TestProperties("test").init(); //$NON-NLS-1$
         props.referencePros.setReference(new TestReferencedProperties("reference").init());
+        props.simpleReferencePros.setReference(new TestReferencedProperties("reference").init());
 
         List<CodegenPropInfo> propInfos = component.getCodegenPropInfos(props);
         for (CodegenPropInfo propInfo : propInfos) {
             Properties properties = propInfo.props;
-            if (properties instanceof ComponentReferenceProperties) {
-                ComponentReferenceProperties crp = (ComponentReferenceProperties) properties;
-                assertEquals(Boolean.TRUE, crp.componentInstanceId.getTaggedValue(IGenericConstants.ADD_QUOTES));
+            if (properties instanceof ReferenceProperties) {
+                ReferenceProperties<?> crp = (ReferenceProperties<?>) properties;
                 assertEquals(Boolean.TRUE, crp.referenceDefinitionName.getTaggedValue(IGenericConstants.ADD_QUOTES));
+                assertNotNull(crp.getReference());
+            }
+            if (properties instanceof ComponentReferenceProperties) {
+                ComponentReferenceProperties<?> crp = (ComponentReferenceProperties<?>) properties;
+                assertEquals(Boolean.TRUE, crp.componentInstanceId.getTaggedValue(IGenericConstants.ADD_QUOTES));
                 assertNotNull(crp.getReference());
             }
         }

--- a/test/plugins/org.talend.designer.core.generic.test/src/main/java/org/talend/designer/core/generic/utils/TestProperties.java
+++ b/test/plugins/org.talend.designer.core.generic.test/src/main/java/org/talend/designer/core/generic/utils/TestProperties.java
@@ -22,6 +22,7 @@ import org.talend.components.api.component.Connector;
 import org.talend.components.api.component.PropertyPathConnector;
 import org.talend.components.api.properties.ComponentReferenceProperties;
 import org.talend.components.common.FixedConnectorsComponentProperties;
+import org.talend.daikon.properties.ReferenceProperties;
 import org.talend.daikon.properties.presentation.Form;
 import org.talend.daikon.properties.presentation.Widget;
 import org.talend.daikon.properties.property.Property;
@@ -45,6 +46,9 @@ public class TestProperties extends FixedConnectorsComponentProperties {
             "referencePros", //$NON-NLS-1$
             TestReferencedProperties.TEST_DEFINTION_NAME);
 
+    public ReferenceProperties<TestReferencedProperties> simpleReferencePros = new ReferenceProperties<>(
+            "simpleReferencePros", //$NON-NLS-1$
+            TestReferencedProperties.TEST_DEFINTION_NAME);
     protected transient PropertyPathConnector MAIN_CONNECTOR = new PropertyPathConnector(Connector.MAIN_NAME, "schema"); //$NON-NLS-1$
 
     public TestProperties(String name) {


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
during the code generation of tcomp components, those that use the daikon ReferenceProperties class do not compile because of the field *referenceDefinitionName* not escaped with quotes
 
**What is the chosen solution to this problem?**
escape the string value for *referenceDefinitionName* of ReferenceProperties
 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TUP-18440
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->