### PR TITLE
Fix(TBD-5655) Can't use contexts in Spark Yarn cluster mode

### DIFF
--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/BDJobReArchieveCreator.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/BDJobReArchieveCreator.java
@@ -124,7 +124,6 @@ public class BDJobReArchieveCreator {
                 }
             }
         }
-
         return isStormJob || isSparkWithHDInsight;
     }
 
@@ -219,7 +218,6 @@ public class BDJobReArchieveCreator {
     }
 
     public void create(File file, boolean isExport) {
-
         if (file == null || !file.exists() || (isExport && !file.isFile()) || fatherProcessItem == null) {
             return;
         }
@@ -236,7 +234,6 @@ public class BDJobReArchieveCreator {
         JavaJobExportReArchieveCreator creator = new JavaJobExportReArchieveCreator(file.getAbsolutePath(), label);
         String jobJarName = JavaResourcesHelper.getJobJarName(property.getLabel(), property.getVersion())
                 + FileExtensions.JAR_FILE_SUFFIX;
-
         try {
             if (isExport) {
                 // If we are in an export context, we first unzip the archive, then we modify the jar.
@@ -261,7 +258,6 @@ public class BDJobReArchieveCreator {
                 creator.deleteTempFiles(); // clean temp folder
                 File jarTmpFolder = new File(creator.getTmpFolder(), "jar-" + label + "_" + version); //$NON-NLS-1$ //$NON-NLS-2$
                 jarTmpFolder.mkdirs();
-
                 if (GlobalServiceRegister.getDefault().isServiceRegistered(IRunProcessService.class)) {
                     IRunProcessService service = (IRunProcessService) GlobalServiceRegister.getDefault().getService(
                             IRunProcessService.class);

--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/BDJobReArchieveCreator.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/BDJobReArchieveCreator.java
@@ -196,7 +196,6 @@ public class BDJobReArchieveCreator {
             jarbuilder.setFatJar(true);
         } else if (isSparkWithYarnClusterMode()) {
             jarbuilder.setFatJar(false);
-            // Copy context properties
             if (isSparkWithYarnClusterMode()) {
                 // Copy contexts (*.properties)
                 HashSet<FilterInfo> propertiesFilter = new HashSet<FilterInfo>(Arrays.asList(new FilterInfo(null,

--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/JarBuilder.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/JarBuilder.java
@@ -218,7 +218,7 @@ public class JarBuilder {
                 FileChannel dstChannel = null;
                 try {
                     srcChannel = new FileInputStream(subf.getAbsoluteFile()).getChannel();
-                    // Create intermediate folders if needed
+                    // Create intermediate folders (needed for contexts folder)
                     new File(tempFolderPath + File.separatorChar + desFileName).getParentFile().mkdirs();
                     dstChannel = new FileOutputStream(tempFolderPath + File.separatorChar + desFileName).getChannel();
                     dstChannel.transferFrom(srcChannel, 0, srcChannel.size());

--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/JarBuilder.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/JarBuilder.java
@@ -218,6 +218,8 @@ public class JarBuilder {
                 FileChannel dstChannel = null;
                 try {
                     srcChannel = new FileInputStream(subf.getAbsoluteFile()).getChannel();
+                    // Create intermediate folders if needed
+                    new File(tempFolderPath + File.separatorChar + desFileName).getParentFile().mkdirs();
                     dstChannel = new FileOutputStream(tempFolderPath + File.separatorChar + desFileName).getChannel();
                     dstChannel.transferFrom(srcChannel, 0, srcChannel.size());
                 } finally {


### PR DESCRIPTION
Add the contexts properties files inside the job jar so these contexts are usable in Yarn cluster mode