### PR TITLE
fix(TDI-39566): prevent throwing an Exception all the time we do not need it.

### DIFF
--- a/main/plugins/org.talend.designer.codegen/jet_stub/subprocess_header.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/subprocess_header.javajet
@@ -1114,10 +1114,13 @@ public void <%=subTree.getName() %>Process(final java.util.Map<String, Object> g
 	java.util.Map<String, Object> resourceMap = new java.util.HashMap<String, Object>();
 
 	try {
-
-			String currentMethodName = new java.lang.Exception().getStackTrace()[0].getMethodName();
-			boolean resumeIt = currentMethodName.equals(resumeEntryMethodName);
-			if( resumeEntryMethodName == null || resumeIt || globalResumeTicket){//start the resume
+			// TDI-39566 avoid throwing an useless Exception
+			boolean resumeIt = true;
+			if (globalResumeTicket == false && resumeEntryMethodName != null) {
+				String currentMethodName = new java.lang.Exception().getStackTrace()[0].getMethodName();
+				resumeIt = resumeEntryMethodName.equals(currentMethodName);
+			}
+			if (resumeIt || globalResumeTicket) { //start the resume
 				globalResumeTicket = true;
 
 <%


### PR DESCRIPTION
This code change prevents throwing an Exception only to get the method name even in the case we do not need that because no resuming is running.
We have figured out, these Exceptions have serious impact to the performance of jobs in case of using DI jobs in services.