### PR TITLE
TDI-39567 improve performance in log4j code

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/templates/Log4j/LogUtil.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/templates/Log4j/LogUtil.javajet
@@ -102,11 +102,12 @@ class LogUtil extends BasicLogUtil{
     
     public void logCompSetting(){
     %>
+    			<%
+       		if(log4jEnabled){
+       		%>
+    if (log.isDebugEnabled()) {
     	class BytesLimit65535_<%=cid%>{
     		public void limitLog4jByte() throws Exception{
-    			<%
-       			 if(log4jEnabled){
-       			 %>
             StringBuilder <%=var("log4jParamters")%> = new StringBuilder();
             <%=var("log4jParamters")%>.append("Parameters:");
             <%
@@ -170,15 +171,17 @@ class LogUtil extends BasicLogUtil{
                 <%=var("log4jParamters")%>.append(" | ");
             <%
             }
-        }
-		debug(var("log4jParamters"));
+	   		debug(var("log4jParamters")); 
+	   		%>
+    		} // limitLog4jByte()
+    	} // BytesLimit65535_<%=cid%>
+      new BytesLimit65535_<%=cid%>().limitLog4jByte();
+   } // if (log.isDebugEnabled())
+		<%
+        } // if(log4jEnabled)
 		%>
-    		}
-    	}
-    	
-        new BytesLimit65535_<%=cid%>().limitLog4jByte();
         <%
-    }
+    } // end method logCompSetting()
     
     //no use for now, because we log the data by rowStruct
     public void traceData(String rowStruct, java.util.List<org.talend.core.model.metadata.IMetadataColumn> columnList, String nbline){

--- a/main/plugins/org.talend.designer.components.localprovider/components/templates/Log4j/LogUtil.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/templates/Log4j/LogUtil.javajet
@@ -173,15 +173,15 @@ class LogUtil extends BasicLogUtil{
             }
 	   		debug(var("log4jParamters")); 
 	   		%>
-    		} // limitLog4jByte()
-    	} // BytesLimit65535_<%=cid%>
+    		} 
+    	} 
       new BytesLimit65535_<%=cid%>().limitLog4jByte();
-   } // if (log.isDebugEnabled())
+   } 
 		<%
-        } // if(log4jEnabled)
+        } 
 		%>
         <%
-    } // end method logCompSetting()
+    } 
     
     //no use for now, because we log the data by rowStruct
     public void traceData(String rowStruct, java.util.List<org.talend.core.model.metadata.IMetadataColumn> columnList, String nbline){


### PR DESCRIPTION
This change improves the log4j code.
For the open studio it prevents the creation of useless Byte65335Limit classes.
For the enterprise studio it improves the performance and decrease the memory allocation of jobs. 