### PR TITLE
fix(TBD-5548): change default value for tOracleOutput varchar2 field

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/templates/db_output_bulk.skeleton
+++ b/main/plugins/org.talend.designer.components.localprovider/components/templates/db_output_bulk.skeleton
@@ -388,6 +388,9 @@ public class CLASS {
                                 && (column.getColumn().getPrecision() == null || 0 == column.getColumn().getPrecision())
                         ) {}
                         else {
+							if ( ("oracle_id".equalsIgnoreCase(getDBMSId()))
+	                            && (length == 0)
+	                        ){ length = 1; }
                             if (mappingType.isPreBeforeLength(getDBMSId(), dataType)) {
                                 if (!precisionIgnored) {
                                     prefix = "(";


### PR DESCRIPTION
The default length value for a VARCHAR2 field must be > 0.