### PR TITLE
fix(TDI-39571): Set navigation link to null

### DIFF
--- a/main/plugins/org.talend.designer.components.libs/libs_src/talend-mscrm/pom.xml
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/talend-mscrm/pom.xml
@@ -134,6 +134,14 @@
 					</execution>
 				</executions>
 			</plugin>
-		</plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
 	</build>
 </project>

--- a/main/plugins/org.talend.designer.components.libs/libs_src/talend-mscrm/pom.xml
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/talend-mscrm/pom.xml
@@ -111,7 +111,7 @@
 			<artifactId>junit</artifactId>
 			<version>4.0</version>
 			<type>jar</type>
-			<optional>true</optional>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 	<build>

--- a/main/plugins/org.talend.designer.components.libs/libs_src/talend-mscrm/pom.xml
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/talend-mscrm/pom.xml
@@ -106,13 +106,6 @@
             <artifactId>adal4j</artifactId>
             <version>1.1.1</version>
         </dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.0</version>
-			<type>jar</type>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 	<build>
 		<resources>

--- a/main/plugins/org.talend.designer.components.libs/libs_src/talend-mscrm/pom.xml
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/talend-mscrm/pom.xml
@@ -101,13 +101,18 @@
             <artifactId>junit</artifactId>
             <version>4.12</version>
         </dependency>
-
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>adal4j</artifactId>
             <version>1.1.1</version>
         </dependency>
-		
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.0</version>
+			<type>jar</type>
+			<optional>true</optional>
+		</dependency>
 	</dependencies>
 	<build>
 		<resources>

--- a/main/plugins/org.talend.designer.components.libs/libs_src/talend-mscrm/src/main/java/org/talend/ms/crm/odata/DynamicsCRMClient.java
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/talend-mscrm/src/main/java/org/talend/ms/crm/odata/DynamicsCRMClient.java
@@ -344,6 +344,15 @@ public class DynamicsCRMClient implements IHttpClientFactoryObserver {
 
     }
 
+    /**
+     * This setter has been added for unit tests to avoid some http requests.
+     *
+     * @param entityType
+     */
+    public void setEntityType(String entityType){
+        this.entityType = entityType;
+    }
+
     public void addEntityNavigationLink(ClientEntity entity, String lookupEntitySet, String lookupName,
             String linkedEntityId, boolean emptyLookupIntoNull, boolean ignoreNull) {
 
@@ -375,6 +384,10 @@ public class DynamicsCRMClient implements IHttpClientFactoryObserver {
         }
     }
 
+    public int getNbNavigationLinkToRemove(){
+        return navigationLinksToNull.size();
+    }
+
     /**
      * Get the navigation link name from a lookup one.
      * MSCRM auto-generates lookup properties from navigation links.
@@ -386,7 +399,7 @@ public class DynamicsCRMClient implements IHttpClientFactoryObserver {
      */
     public String extractNavigationLinkName(String lookupName){
         final int nameSize = lookupName.length();
-        if(nameSize < LOOKUP_NAME_MINSIZE){
+        if(nameSize <= LOOKUP_NAME_MINSIZE){
             return lookupName;
         }
 

--- a/main/plugins/org.talend.designer.components.libs/libs_src/talend-mscrm/src/test/java/org/talend/ms/crm/odata/DynamicsCRMClientTest.java
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/talend-mscrm/src/test/java/org/talend/ms/crm/odata/DynamicsCRMClientTest.java
@@ -1,0 +1,100 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.ms.crm.odata;
+
+
+import org.apache.olingo.client.api.domain.ClientEntity;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.naming.AuthenticationException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+
+public class DynamicsCRMClientTest {
+
+    private final static Map<String, String> lookupNames = new HashMap<String, String>();
+    static{
+        lookupNames.put("_mylookup_value", "mylookup");
+        lookupNames.put("mylookup", "mylookup");
+        lookupNames.put("_x_value", "x");
+        lookupNames.put("__value", "__value");
+    }
+
+    private DynamicsCRMClient client = null;
+
+
+    @Before
+    public void init() {
+        ClientConfiguration configuration =
+                ClientConfigurationFactory.buildNtlmClientConfiguration("username", "password", "host", "domain");
+
+        client = null;
+        try {
+            client = new DynamicsCRMClient(configuration, "http://crm.dmnmscrm2016f.com:5555/oumscrm2016/api/data/v8.1",
+                    "accounts");
+            client.setEntityType("account");
+        } catch (AuthenticationException e) {
+            e.printStackTrace();
+        }
+
+        assertNotNull(client);
+    }
+
+    @Test
+    public void testLookupNameExtractionMinSize() {
+        for(Map.Entry<String, String> lookupName: lookupNames.entrySet()){
+            assertEquals(lookupName.getValue(), client.extractNavigationLinkName(lookupName.getKey()));
+        }
+    }
+
+    @Test
+    public void testNbNavigationLinkToRemove(){
+        ClientEntity clientEntity = client.newEntity();
+        client.addEntityNavigationLink(clientEntity, "lookupEntitySet1", "lookupName1", null, false, false); // To remove
+        client.addEntityNavigationLink(clientEntity, "lookupEntitySet2", "lookupName2", "id2", false, false); // To update
+        client.addEntityNavigationLink(clientEntity, "lookupEntitySet3", "lookupName3", null, false, false); // To remove
+        int n = client.getNbNavigationLinkToRemove();
+
+        assertEquals(2, n);
+    }
+
+    @Test
+    public void testEmptyLookupIntoNull(){
+        ClientEntity clientEntity = client.newEntity();
+        client.addEntityNavigationLink(clientEntity, "lookupEntitySet1", "lookupName1", null, false, false); // To remove
+        client.addEntityNavigationLink(clientEntity, "lookupEntitySet2", "lookupName2", "", true, false); // To remove (empty to null)
+        client.addEntityNavigationLink(clientEntity, "lookupEntitySet3", "lookupName3", "notNull", false, false); // To update
+        int n = client.getNbNavigationLinkToRemove();
+
+        assertEquals(2, n);
+    }
+
+    @Test
+    public void testLookupIgnoreNull(){
+        ClientEntity clientEntity = client.newEntity();
+
+        boolean ignoreNull = true;
+        client.addEntityNavigationLink(clientEntity, "lookupEntitySet1", "lookupName1", null, false, ignoreNull); // Ignored
+        client.addEntityNavigationLink(clientEntity, "lookupEntitySet2", "lookupName2", "", true, ignoreNull); // Ignored (since empty to null && ignore null)
+        client.addEntityNavigationLink(clientEntity, "lookupEntitySet3", "lookupName3", "notNull", false, ignoreNull); // To update
+        client.addEntityNavigationLink(clientEntity, "lookupEntitySet3", "lookupName3", null, false, !ignoreNull); // To remove
+        int n = client.getNbNavigationLinkToRemove();
+
+        assertEquals(1, n);
+    }
+
+}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmOutput/tMicrosoftCrmOutput_main_odata.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmOutput/tMicrosoftCrmOutput_main_odata.javajet
@@ -1,6 +1,6 @@
 <%
     String action = ElementParameterParser.getValue(node,"__ACTION__");
-	 boolean emptyLookupIntoNull = "true".equals(ElementParameterParser.getValue(node,"__EMPTY_LOOKUP_TO_NULL__"));
+	boolean emptyLookupIntoNull = "true".equals(ElementParameterParser.getValue(node,"__EMPTY_LOOKUP_TO_NULL__"));
     List<IMetadataTable> metadatas = node.getMetadataList();
     if ((metadatas!=null)&&(metadatas.size()>0)) {//1
         IMetadataTable metadata = metadatas.get(0);
@@ -36,21 +36,19 @@
                             
 		  			    			if(lookupMaps.containsKey(column.getLabel())){
                            %>
-                            		if(<%=connName%>.<%=column.getLabel()%> != null<%if(emptyLookupIntoNull) {%> && !(String.valueOf(<%=connName%>.<%=column.getLabel()%>).isEmpty())<%}%>){
-	                            		client_<%=cid%>.addEntityNavigationLink(entity_<%=cid%>, <%=lookupMaps.get(column.getLabel())%>,"<%=column.getOriginalDbColumnName()%>", <%=connName%>.<%=column.getLabel()%>);
-	                            	}
+	                            	client_<%=cid%>.addEntityNavigationLink(entity_<%=cid%>, <%=lookupMaps.get(column.getLabel())%>,"<%=column.getOriginalDbColumnName()%>", <%=connName%>.<%=column.getLabel()%>, <%=emptyLookupIntoNull%>, <%=ignoreNull%>);
                            <%
                            }else{
 	                           if(!isPrimitive && ignoreNull) {
 			  							%>   				
 			  			    				if(<%=connName%>.<%=column.getLabel()%> != null){
-			  			    				
+
 			  			    			<%
 			  			    			}
 
                           String columnValue = connName+"."+column.getLabel();
                           if("Guid".equals(column.getType())){
-                                columnValue = "java.util.UUID.fromString("+columnValue+")";
+                                columnValue = "(("+columnValue+" == null) ? null : java.util.UUID.fromString("+columnValue+"))";
                           }
 	                           %>
                            		client_<%=cid%>.addEntityProperty(entity_<%=cid%>, "<%=column.getLabel()%>", org.apache.olingo.commons.api.edm.EdmPrimitiveTypeKind.<%=column.getType()%>, 	<%=columnValue%>);


### PR DESCRIPTION
**What is the current behavior? (You can also link to an open issue here)**
https://jira.talendforge.org/browse/TDI-39571

**What is the new behavior?**
Navigation links can be set to null. 
The advanced parameter 'Empty Lookup to null' is effective.

**What kind of change does this PR introduce?**
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No