### PR TITLE
fix(TDI-39662):"log4jSb_tGreenplumGPLoad_1" cannot be resolved

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tGreenplumGPLoad/tGreenplumGPLoad_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tGreenplumGPLoad/tGreenplumGPLoad_main.javajet
@@ -187,9 +187,7 @@ skeleton="../templates/db_output_bulk.skeleton"
 		%>
 		outputStream_<%=cid%>.write(sb_<%=cid%>.toString().getBytes());
 		<%if(isLog4jEnabled){%>
-            log4jSb_<%=cid%>.append(sb_<%=cid%>.toString());
-			log.debug("<%=cid%> - Loading the record :" + log4jSb_<%=cid%>);
-			log4jSb_<%=cid%>.delete(0,log4jSb_<%=cid%>.length());
+			log.debug("<%=cid%> - Loading the record :" + sb_<%=cid%>);
 		<%}%>
 		sb_<%=cid%> = null;
 		<%


### PR DESCRIPTION
For https://jira.talendforge.org/browse/TDI-39662

`log4jSb_<%=cid%>` declear is removed TDI-28637
I found that we can avoid the compiler error by using another variable(`sb_<%=cid%>`)