### PR TITLE
Ypiel/tdi39578 binary properties

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmInput/tMicrosoftCrmInput_begin_odata.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmInput/tMicrosoftCrmInput_begin_odata.javajet
@@ -190,7 +190,14 @@ if ((metadatas != null) && (metadatas.size() > 0)) {
 		        					<%
 		        					}else if(javaType == JavaTypesManager.BYTE_ARRAY){ // Byte[]
 		        					%>
-		        						<%=outgoingConn.getName()%>.<%=columnList.get(i).getLabel()%> = (byte[])property_<%=column.getLabel()%>_<%=cid%>.getValue().asPrimitive().toValue();
+		        					    String property_<%=column.getLabel()%>_<%=cid%>_type = property_<%=column.getLabel()%>_<%=cid%>.getValue().getTypeName();
+		        						if("Edm.Binary".equals(property_<%=column.getLabel()%>_<%=cid%>_type)){
+		        						    <%=outgoingConn.getName()%>.<%=columnList.get(i).getLabel()%> = (byte[])property_<%=column.getLabel()%>_<%=cid%>.getValue().asPrimitive().toValue();
+		        						}
+		        						else{
+		        						    org.apache.olingo.commons.api.edm.EdmPrimitiveType edmpt = org.apache.olingo.commons.core.edm.primitivetype.EdmPrimitiveTypeFactory.getInstance(org.apache.olingo.commons.api.edm.EdmPrimitiveTypeKind.Binary);
+                                            <%=outgoingConn.getName()%>.<%=columnList.get(i).getLabel()%> = (byte[])edmpt.valueOfString(property_<%=column.getLabel()%>_<%=cid%>.getValue().toString(), null, null, org.apache.olingo.commons.api.Constants.DEFAULT_PRECISION, org.apache.olingo.commons.api.Constants.DEFAULT_SCALE, null, byte[].class);
+		        						}
 		        					<%
 		        					}else{ // other
 		        					%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmInput/tMicrosoftCrmInput_begin_odata.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmInput/tMicrosoftCrmInput_begin_odata.javajet
@@ -188,6 +188,10 @@ if ((metadatas != null) && (metadatas.size() > 0)) {
 		        					%>
 		        						<%=outgoingConn.getName()%>.<%=columnList.get(i).getLabel()%> = ParserUtils.parseTo_Date(property_<%=column.getLabel()%>_<%=cid%>.getValue().toString(), <%= patternValue %>);
 		        					<%
+		        					}else if(javaType == JavaTypesManager.BYTE_ARRAY){ // Byte[]
+		        					%>
+		        						<%=outgoingConn.getName()%>.<%=columnList.get(i).getLabel()%> = (byte[])property_<%=column.getLabel()%>_<%=cid%>.getValue().asPrimitive().toValue();
+		        					<%
 		        					}else{ // other
 		        					%>
 		        						<%=outgoingConn.getName()%>.<%=columnList.get(i).getLabel()%> = ParserUtils.parseTo_<%=typeToGenerate%>(property_<%=column.getLabel()%>_<%=cid%>.getValue().toString());

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmInput/tMicrosoftCrmInput_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmInput/tMicrosoftCrmInput_java.xml
@@ -11697,7 +11697,7 @@
     <COLUMN KEY="false" LENGTH="0" NAME="emailaddress1" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="emailaddress2" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="emailaddress3" TYPE="id_String"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_timestamp" TYPE="id_Long"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_url" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimageid" TYPE="id_String"  />
@@ -11781,7 +11781,7 @@
     <COLUMN KEY="false" LENGTH="0" NAME="attachmentcontentid" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="attachmentnumber" TYPE="id_Integer"  />
     <COLUMN KEY="false" LENGTH="0" NAME="body" TYPE="id_String"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="body_binary" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="body_binary" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="componentstate" TYPE="id_Integer"  />
     <COLUMN KEY="false" LENGTH="0" NAME="filename" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="filesize" TYPE="id_Integer"  />
@@ -11876,7 +11876,7 @@
     <COLUMN KEY="true" LENGTH="0" NAME="annotationid" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="createdon" TYPE="id_Date" PATTERN="&quot;yyyy-MM-dd&apos;T&apos;HH:mm:ss&apos;Z&apos;&quot;" />
     <COLUMN KEY="false" LENGTH="0" NAME="documentbody" TYPE="id_String"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="documentbody_binary" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="documentbody_binary" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="filename" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="filesize" TYPE="id_Integer"  />
     <COLUMN KEY="false" LENGTH="0" NAME="importsequencenumber" TYPE="id_Integer"  />
@@ -12032,7 +12032,7 @@
 <TABLE IF="(ENTITYSET=='attachments') AND (((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2016_ODATA')) OR ((AUTH_TYPE=='ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016')))">
     <COLUMN KEY="true" LENGTH="0" NAME="attachmentid" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="body" TYPE="id_String"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="body_binary" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="body_binary" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="filename" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="filesize" TYPE="id_Integer"  />
     <COLUMN KEY="false" LENGTH="0" NAME="mimetype" TYPE="id_String"  />
@@ -12689,7 +12689,7 @@
     <COLUMN KEY="false" LENGTH="0" NAME="codename" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="createdon" TYPE="id_Date" PATTERN="&quot;yyyy-MM-dd&apos;T&apos;HH:mm:ss&apos;Z&apos;&quot;" />
     <COLUMN KEY="false" LENGTH="0" NAME="description" TYPE="id_String"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_timestamp" TYPE="id_Long"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_url" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimageid" TYPE="id_String"  />
@@ -12879,7 +12879,7 @@
     <COLUMN KEY="false" LENGTH="0" NAME="address2_utcoffset" TYPE="id_Integer"  />
     <COLUMN KEY="true" LENGTH="0" NAME="competitorid" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="createdon" TYPE="id_Date" PATTERN="&quot;yyyy-MM-dd&apos;T&apos;HH:mm:ss&apos;Z&apos;&quot;" />
-    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_timestamp" TYPE="id_Long"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_url" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimageid" TYPE="id_String"  />
@@ -12970,7 +12970,7 @@
     <COLUMN KEY="false" LENGTH="0" NAME="description" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="effectiveend" TYPE="id_Date" PATTERN="&quot;yyyy-MM-dd&apos;T&apos;HH:mm:ss&apos;Z&apos;&quot;" />
     <COLUMN KEY="false" LENGTH="0" NAME="effectivestart" TYPE="id_Date" PATTERN="&quot;yyyy-MM-dd&apos;T&apos;HH:mm:ss&apos;Z&apos;&quot;" />
-    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_timestamp" TYPE="id_Long"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_url" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimageid" TYPE="id_String"  />
@@ -13151,7 +13151,7 @@
     <COLUMN KEY="false" LENGTH="0" NAME="emailaddress2" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="emailaddress3" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="employeeid" TYPE="id_String"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_timestamp" TYPE="id_Long"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_url" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimageid" TYPE="id_String"  />
@@ -13299,7 +13299,7 @@
     <COLUMN KEY="false" LENGTH="0" NAME="createdon" TYPE="id_Date" PATTERN="&quot;yyyy-MM-dd&apos;T&apos;HH:mm:ss&apos;Z&apos;&quot;" />
     <COLUMN KEY="false" LENGTH="0" NAME="duration" TYPE="id_Integer"  />
     <COLUMN KEY="false" LENGTH="0" NAME="effectivitycalendar" TYPE="id_String"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_timestamp" TYPE="id_Long"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_url" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimageid" TYPE="id_String"  />
@@ -13708,7 +13708,7 @@
     <COLUMN KEY="true" LENGTH="0" NAME="emailserverprofileid" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="emailservertypename" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="encodingcodepage" TYPE="id_String"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_timestamp" TYPE="id_Long"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_url" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimageid" TYPE="id_String"  />
@@ -14266,7 +14266,7 @@
     <COLUMN KEY="false" LENGTH="0" NAME="customrollupfieldmoney_base" TYPE="id_BigDecimal"  />
     <COLUMN KEY="false" LENGTH="0" NAME="customrollupfieldstring" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="depth" TYPE="id_Integer"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_timestamp" TYPE="id_Long"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_url" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimageid" TYPE="id_String"  />
@@ -14587,7 +14587,7 @@
     <COLUMN KEY="false" LENGTH="0" NAME="customersatisfactioncode" TYPE="id_Integer"  />
     <COLUMN KEY="false" LENGTH="0" NAME="decremententitlementterm" TYPE="id_Boolean"  />
     <COLUMN KEY="false" LENGTH="0" NAME="description" TYPE="id_String"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_timestamp" TYPE="id_Long"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_url" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimageid" TYPE="id_String"  />
@@ -14756,7 +14756,7 @@
     <COLUMN KEY="false" LENGTH="0" NAME="discountamount_base" TYPE="id_BigDecimal"  />
     <COLUMN KEY="false" LENGTH="0" NAME="discountpercentage" TYPE="id_BigDecimal"  />
     <COLUMN KEY="false" LENGTH="0" NAME="duedate" TYPE="id_Date" PATTERN="&quot;yyyy-MM-dd&apos;T&apos;HH:mm:ss&apos;Z&apos;&quot;" />
-    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_timestamp" TYPE="id_Long"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_url" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimageid" TYPE="id_String"  />
@@ -14848,7 +14848,7 @@
     <COLUMN KEY="false" LENGTH="0" NAME="content" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="createdon" TYPE="id_Date" PATTERN="&quot;yyyy-MM-dd&apos;T&apos;HH:mm:ss&apos;Z&apos;&quot;" />
     <COLUMN KEY="false" LENGTH="0" NAME="description" TYPE="id_String"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_timestamp" TYPE="id_Long"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_url" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimageid" TYPE="id_String"  />
@@ -15156,7 +15156,7 @@
     <COLUMN KEY="false" LENGTH="0" NAME="emailaddress1" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="emailaddress2" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="emailaddress3" TYPE="id_String"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_timestamp" TYPE="id_Long"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_url" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimageid" TYPE="id_String"  />
@@ -15368,7 +15368,7 @@
     <COLUMN KEY="false" LENGTH="0" NAME="enabledforact" TYPE="id_Boolean"  />
     <COLUMN KEY="false" LENGTH="0" NAME="enabledforincomingemail" TYPE="id_Boolean"  />
     <COLUMN KEY="false" LENGTH="0" NAME="enabledforoutgoingemail" TYPE="id_Boolean"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_timestamp" TYPE="id_Long"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_url" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimageid" TYPE="id_String"  />
@@ -15866,7 +15866,7 @@
     <COLUMN KEY="false" LENGTH="0" NAME="baseamount_base" TYPE="id_BigDecimal"  />
     <COLUMN KEY="false" LENGTH="0" NAME="createdon" TYPE="id_Date" PATTERN="&quot;yyyy-MM-dd&apos;T&apos;HH:mm:ss&apos;Z&apos;&quot;" />
     <COLUMN KEY="false" LENGTH="0" NAME="description" TYPE="id_String"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_timestamp" TYPE="id_Long"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_url" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimageid" TYPE="id_String"  />
@@ -16043,7 +16043,7 @@
     <COLUMN KEY="false" LENGTH="0" NAME="enablepricingoncreate" TYPE="id_Boolean"  />
     <COLUMN KEY="false" LENGTH="0" NAME="enablesmartmatching" TYPE="id_Boolean"  />
     <COLUMN KEY="false" LENGTH="0" NAME="enforcereadonlyplugins" TYPE="id_Boolean"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_timestamp" TYPE="id_Long"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_url" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimageid" TYPE="id_String"  />
@@ -16329,7 +16329,7 @@
 <TABLE IF="(ENTITYSET=='pluginassemblies') AND (((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2016_ODATA')) OR ((AUTH_TYPE=='ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016')))">
     <COLUMN KEY="false" LENGTH="0" NAME="componentstate" TYPE="id_Integer"  />
     <COLUMN KEY="false" LENGTH="0" NAME="content" TYPE="id_String"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="content_binary" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="content_binary" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="createdon" TYPE="id_Date" PATTERN="&quot;yyyy-MM-dd&apos;T&apos;HH:mm:ss&apos;Z&apos;&quot;" />
     <COLUMN KEY="false" LENGTH="0" NAME="culture" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="customizationlevel" TYPE="id_Integer"  />
@@ -16621,7 +16621,7 @@
     <COLUMN KEY="false" LENGTH="0" NAME="currentcost_base" TYPE="id_BigDecimal"  />
     <COLUMN KEY="false" LENGTH="0" NAME="description" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="dmtimportstate" TYPE="id_Integer"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_timestamp" TYPE="id_Long"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_url" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimageid" TYPE="id_String"  />
@@ -16789,7 +16789,7 @@
     <COLUMN KEY="false" LENGTH="0" NAME="customizationprefix" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="description" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="emailaddress" TYPE="id_String"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_timestamp" TYPE="id_Long"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_url" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimageid" TYPE="id_String"  />
@@ -16873,7 +16873,7 @@
     <COLUMN KEY="false" LENGTH="0" NAME="description" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="emailaddress" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="emailrouteraccessapproval" TYPE="id_Integer"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_timestamp" TYPE="id_Long"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_url" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimageid" TYPE="id_String"  />
@@ -17333,7 +17333,7 @@
 </TABLE>
 <TABLE IF="(ENTITYSET=='reports') AND (((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2016_ODATA')) OR ((AUTH_TYPE=='ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016')))">
     <COLUMN KEY="false" LENGTH="0" NAME="bodybinary" TYPE="id_String"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="bodybinary_binary" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="bodybinary_binary" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="bodytext" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="bodyurl" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="componentstate" TYPE="id_Integer"  />
@@ -17393,7 +17393,7 @@
 <TABLE IF="(ENTITYSET=='resources') AND (((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2016_ODATA')) OR ((AUTH_TYPE=='ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016')))">
     <COLUMN KEY="false" LENGTH="0" NAME="calendarid" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="displayinserviceviews" TYPE="id_Boolean"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_timestamp" TYPE="id_Long"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_url" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimageid" TYPE="id_String"  />
@@ -17482,7 +17482,7 @@
     <COLUMN KEY="false" LENGTH="0" NAME="authorname" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="createdon" TYPE="id_Date" PATTERN="&quot;yyyy-MM-dd&apos;T&apos;HH:mm:ss&apos;Z&apos;&quot;" />
     <COLUMN KEY="false" LENGTH="0" NAME="documentbody" TYPE="id_String"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="documentbody_binary" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="documentbody_binary" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="filename" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="filesize" TYPE="id_Integer"  />
     <COLUMN KEY="false" LENGTH="0" NAME="filetypecode" TYPE="id_Integer"  />
@@ -17505,7 +17505,7 @@
 <TABLE IF="(ENTITYSET=='salesliteratures') AND (((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2016_ODATA')) OR ((AUTH_TYPE=='ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016')))">
     <COLUMN KEY="false" LENGTH="0" NAME="createdon" TYPE="id_Date" PATTERN="&quot;yyyy-MM-dd&apos;T&apos;HH:mm:ss&apos;Z&apos;&quot;" />
     <COLUMN KEY="false" LENGTH="0" NAME="description" TYPE="id_String"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_timestamp" TYPE="id_Long"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_url" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimageid" TYPE="id_String"  />
@@ -17623,7 +17623,7 @@
     <COLUMN KEY="false" LENGTH="0" NAME="discountamount" TYPE="id_BigDecimal"  />
     <COLUMN KEY="false" LENGTH="0" NAME="discountamount_base" TYPE="id_BigDecimal"  />
     <COLUMN KEY="false" LENGTH="0" NAME="discountpercentage" TYPE="id_BigDecimal"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_timestamp" TYPE="id_Long"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_url" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimageid" TYPE="id_String"  />
@@ -18575,7 +18575,7 @@
     <COLUMN KEY="false" LENGTH="0" NAME="domainname" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="emailrouteraccessapproval" TYPE="id_Integer"  />
     <COLUMN KEY="false" LENGTH="0" NAME="employeeid" TYPE="id_String"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_timestamp" TYPE="id_Long"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_url" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimageid" TYPE="id_String"  />
@@ -18816,7 +18816,7 @@
 <TABLE IF="(ENTITYSET=='territories') AND (((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2016_ODATA')) OR ((AUTH_TYPE=='ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016')))">
     <COLUMN KEY="false" LENGTH="0" NAME="createdon" TYPE="id_Date" PATTERN="&quot;yyyy-MM-dd&apos;T&apos;HH:mm:ss&apos;Z&apos;&quot;" />
     <COLUMN KEY="false" LENGTH="0" NAME="description" TYPE="id_String"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_timestamp" TYPE="id_Long"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_url" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimageid" TYPE="id_String"  />
@@ -18975,7 +18975,7 @@
     <COLUMN KEY="false" LENGTH="0" NAME="currencyname" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="currencyprecision" TYPE="id_Integer"  />
     <COLUMN KEY="false" LENGTH="0" NAME="currencysymbol" TYPE="id_String"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_timestamp" TYPE="id_Long"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_url" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimageid" TYPE="id_String"  />
@@ -19195,7 +19195,7 @@
     <COLUMN KEY="false" LENGTH="0" NAME="canbedeleted" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="componentstate" TYPE="id_Integer"  />
     <COLUMN KEY="false" LENGTH="0" NAME="content" TYPE="id_String"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="content_binary" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="content_binary" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="createdon" TYPE="id_Date" PATTERN="&quot;yyyy-MM-dd&apos;T&apos;HH:mm:ss&apos;Z&apos;&quot;" />
     <COLUMN KEY="false" LENGTH="0" NAME="description" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="displayname" TYPE="id_String"  />
@@ -19273,7 +19273,7 @@
     <COLUMN KEY="false" LENGTH="0" NAME="createstage" TYPE="id_Integer"  />
     <COLUMN KEY="false" LENGTH="0" NAME="deletestage" TYPE="id_Integer"  />
     <COLUMN KEY="false" LENGTH="0" NAME="description" TYPE="id_String"  />
-    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_String"  />
+    <COLUMN KEY="false" LENGTH="0" NAME="entityimage" TYPE="id_byte[]"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_timestamp" TYPE="id_Long"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimage_url" TYPE="id_String"  />
     <COLUMN KEY="false" LENGTH="0" NAME="entityimageid" TYPE="id_String"  />

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmOutput/tMicrosoftCrmOutput_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmOutput/tMicrosoftCrmOutput_java.xml
@@ -17430,7 +17430,7 @@
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="attachmentcontentid" TYPE="id_String" />
             <COLUMN DBTYPE="Int32" KEY="false" LENGTH="0" NAME="attachmentnumber" TYPE="id_Integer" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="body" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="body_binary" TYPE="id_byte[]" />
+            <COLUMN DBTYPE="Binary" KEY="false" LENGTH="0" NAME="body_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="filename" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="mimetype" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="objecttypecode" TYPE="id_String" />
@@ -17493,7 +17493,7 @@
         </TABLE>
         <TABLE IF="(ACTION=='insert') AND (ENTITYSET=='annotations') AND (((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2016_ODATA')) OR ((AUTH_TYPE == 'ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016')))">
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="documentbody" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="documentbody_binary" TYPE="id_byte[]" />
+            <COLUMN DBTYPE="Binary" KEY="false" LENGTH="0" NAME="documentbody_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="filename" TYPE="id_String" />
             <COLUMN DBTYPE="Int32" KEY="false" LENGTH="0" NAME="importsequencenumber" TYPE="id_Integer" />
             <COLUMN DBTYPE="Boolean" KEY="false" LENGTH="0" NAME="isdocument" TYPE="id_Boolean" />
@@ -17612,7 +17612,7 @@
         </TABLE>
         <TABLE IF="(ACTION=='insert') AND (ENTITYSET=='attachments') AND (((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2016_ODATA')) OR ((AUTH_TYPE == 'ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016')))">
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="body" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="body_binary" TYPE="id_byte[]" />
+            <COLUMN DBTYPE="Binary" KEY="false" LENGTH="0" NAME="body_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="filename" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="mimetype" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="subject" TYPE="id_String" />
@@ -20724,7 +20724,7 @@
         </TABLE>
         <TABLE IF="(ACTION=='insert') AND (ENTITYSET=='pluginassemblies') AND (((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2016_ODATA')) OR ((AUTH_TYPE == 'ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016')))">
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="content" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="content_binary" TYPE="id_byte[]" />
+            <COLUMN DBTYPE="Binary" KEY="false" LENGTH="0" NAME="content_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="culture" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="description" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="introducedversion" TYPE="id_String" />
@@ -21438,7 +21438,7 @@
         </TABLE>
         <TABLE IF="(ACTION=='insert') AND (ENTITYSET=='reports') AND (((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2016_ODATA')) OR ((AUTH_TYPE == 'ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016')))">
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="bodybinary" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="bodybinary_binary" TYPE="id_byte[]" />
+            <COLUMN DBTYPE="Binary" KEY="false" LENGTH="0" NAME="bodybinary_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="bodytext" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="bodyurl" TYPE="id_String" />
             <COLUMN DBTYPE="Int32" KEY="false" LENGTH="0" NAME="createdinmajorversion" TYPE="id_Integer" />
@@ -21533,7 +21533,7 @@
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="attacheddocumenturl" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="authorname" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="documentbody" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="documentbody_binary" TYPE="id_byte[]" />
+            <COLUMN DBTYPE="Binary" KEY="false" LENGTH="0" NAME="documentbody_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="filename" TYPE="id_String" />
             <COLUMN DBTYPE="Int32" KEY="false" LENGTH="0" NAME="filetypecode" TYPE="id_Integer" />
             <COLUMN DBTYPE="Int32" KEY="false" LENGTH="0" NAME="importsequencenumber" TYPE="id_Integer" />
@@ -22814,7 +22814,7 @@
         <TABLE IF="(ACTION=='insert') AND (ENTITYSET=='webresourceset') AND (((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2016_ODATA')) OR ((AUTH_TYPE == 'ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016')))">
             <COLUMN DBTYPE="Boolean" KEY="false" LENGTH="0" NAME="canbedeleted" TYPE="id_Boolean" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="content" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="content_binary" TYPE="id_byte[]" />
+            <COLUMN DBTYPE="Binary" KEY="false" LENGTH="0" NAME="content_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="description" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="displayname" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="introducedversion" TYPE="id_String" />
@@ -23051,7 +23051,7 @@
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="attachmentcontentid" TYPE="id_String" />
             <COLUMN DBTYPE="Int32" KEY="false" LENGTH="0" NAME="attachmentnumber" TYPE="id_Integer" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="body" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="body_binary" TYPE="id_byte[]" />
+            <COLUMN DBTYPE="Binary" KEY="false" LENGTH="0" NAME="body_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="filename" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="mimetype" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="objecttypecode" TYPE="id_String" />
@@ -23117,7 +23117,7 @@
         <TABLE IF="(ACTION=='update') AND (ENTITYSET=='annotations') AND (((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2016_ODATA')) OR ((AUTH_TYPE == 'ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016')))">
             <COLUMN DBTYPE="Guid" KEY="true" LENGTH="0" NAME="annotationid" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="documentbody" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="documentbody_binary" TYPE="id_byte[]" />
+            <COLUMN DBTYPE="Binary" KEY="false" LENGTH="0" NAME="documentbody_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="filename" TYPE="id_String" />
             <COLUMN DBTYPE="Int32" KEY="false" LENGTH="0" NAME="importsequencenumber" TYPE="id_Integer" />
             <COLUMN DBTYPE="Boolean" KEY="false" LENGTH="0" NAME="isdocument" TYPE="id_Boolean" />
@@ -23240,7 +23240,7 @@
         <TABLE IF="(ACTION=='update') AND (ENTITYSET=='attachments') AND (((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2016_ODATA')) OR ((AUTH_TYPE == 'ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016')))">
             <COLUMN DBTYPE="Guid" KEY="true" LENGTH="0" NAME="attachmentid" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="body" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="body_binary" TYPE="id_byte[]" />
+            <COLUMN DBTYPE="Binary" KEY="false" LENGTH="0" NAME="body_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="filename" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="mimetype" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="subject" TYPE="id_String" />
@@ -26468,7 +26468,7 @@
         <TABLE IF="(ACTION=='update') AND (ENTITYSET=='pluginassemblies') AND (((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2016_ODATA')) OR ((AUTH_TYPE == 'ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016')))">
             <COLUMN DBTYPE="Guid" KEY="true" LENGTH="0" NAME="pluginassemblyid" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="content" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="content_binary" TYPE="id_byte[]" />
+            <COLUMN DBTYPE="Binary" KEY="false" LENGTH="0" NAME="content_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="culture" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="description" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="introducedversion" TYPE="id_String" />
@@ -27219,7 +27219,7 @@
         <TABLE IF="(ACTION=='update') AND (ENTITYSET=='reports') AND (((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2016_ODATA')) OR ((AUTH_TYPE == 'ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016')))">
             <COLUMN DBTYPE="Guid" KEY="true" LENGTH="0" NAME="reportid" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="bodybinary" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="bodybinary_binary" TYPE="id_byte[]" />
+            <COLUMN DBTYPE="Binary" KEY="false" LENGTH="0" NAME="bodybinary_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="bodytext" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="bodyurl" TYPE="id_String" />
             <COLUMN DBTYPE="Int32" KEY="false" LENGTH="0" NAME="createdinmajorversion" TYPE="id_Integer" />
@@ -27322,7 +27322,7 @@
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="attacheddocumenturl" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="authorname" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="documentbody" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="documentbody_binary" TYPE="id_byte[]" />
+            <COLUMN DBTYPE="Binary" KEY="false" LENGTH="0" NAME="documentbody_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="filename" TYPE="id_String" />
             <COLUMN DBTYPE="Int32" KEY="false" LENGTH="0" NAME="filetypecode" TYPE="id_Integer" />
             <COLUMN DBTYPE="Int32" KEY="false" LENGTH="0" NAME="importsequencenumber" TYPE="id_Integer" />
@@ -28650,7 +28650,7 @@
             <COLUMN DBTYPE="Guid" KEY="true" LENGTH="0" NAME="webresourceid" TYPE="id_String" />
             <COLUMN DBTYPE="Boolean" KEY="false" LENGTH="0" NAME="canbedeleted" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="content" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="content_binary" TYPE="id_byte[]" />
+            <COLUMN DBTYPE="Binary" KEY="false" LENGTH="0" NAME="content_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="description" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="displayname" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="introducedversion" TYPE="id_String" />

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmOutput/tMicrosoftCrmOutput_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmOutput/tMicrosoftCrmOutput_java.xml
@@ -17430,7 +17430,7 @@
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="attachmentcontentid" TYPE="id_String" />
             <COLUMN DBTYPE="Int32" KEY="false" LENGTH="0" NAME="attachmentnumber" TYPE="id_Integer" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="body" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="body_binary" TYPE="id_String" />
+            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="body_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="filename" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="mimetype" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="objecttypecode" TYPE="id_String" />
@@ -17493,7 +17493,7 @@
         </TABLE>
         <TABLE IF="(ACTION=='insert') AND (ENTITYSET=='annotations') AND (((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2016_ODATA')) OR ((AUTH_TYPE == 'ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016')))">
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="documentbody" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="documentbody_binary" TYPE="id_String" />
+            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="documentbody_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="filename" TYPE="id_String" />
             <COLUMN DBTYPE="Int32" KEY="false" LENGTH="0" NAME="importsequencenumber" TYPE="id_Integer" />
             <COLUMN DBTYPE="Boolean" KEY="false" LENGTH="0" NAME="isdocument" TYPE="id_Boolean" />
@@ -17612,7 +17612,7 @@
         </TABLE>
         <TABLE IF="(ACTION=='insert') AND (ENTITYSET=='attachments') AND (((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2016_ODATA')) OR ((AUTH_TYPE == 'ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016')))">
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="body" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="body_binary" TYPE="id_String" />
+            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="body_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="filename" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="mimetype" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="subject" TYPE="id_String" />
@@ -20724,7 +20724,7 @@
         </TABLE>
         <TABLE IF="(ACTION=='insert') AND (ENTITYSET=='pluginassemblies') AND (((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2016_ODATA')) OR ((AUTH_TYPE == 'ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016')))">
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="content" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="content_binary" TYPE="id_String" />
+            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="content_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="culture" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="description" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="introducedversion" TYPE="id_String" />
@@ -21438,7 +21438,7 @@
         </TABLE>
         <TABLE IF="(ACTION=='insert') AND (ENTITYSET=='reports') AND (((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2016_ODATA')) OR ((AUTH_TYPE == 'ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016')))">
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="bodybinary" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="bodybinary_binary" TYPE="id_String" />
+            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="bodybinary_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="bodytext" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="bodyurl" TYPE="id_String" />
             <COLUMN DBTYPE="Int32" KEY="false" LENGTH="0" NAME="createdinmajorversion" TYPE="id_Integer" />
@@ -21533,7 +21533,7 @@
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="attacheddocumenturl" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="authorname" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="documentbody" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="documentbody_binary" TYPE="id_String" />
+            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="documentbody_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="filename" TYPE="id_String" />
             <COLUMN DBTYPE="Int32" KEY="false" LENGTH="0" NAME="filetypecode" TYPE="id_Integer" />
             <COLUMN DBTYPE="Int32" KEY="false" LENGTH="0" NAME="importsequencenumber" TYPE="id_Integer" />
@@ -22814,7 +22814,7 @@
         <TABLE IF="(ACTION=='insert') AND (ENTITYSET=='webresourceset') AND (((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2016_ODATA')) OR ((AUTH_TYPE == 'ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016')))">
             <COLUMN DBTYPE="Boolean" KEY="false" LENGTH="0" NAME="canbedeleted" TYPE="id_Boolean" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="content" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="content_binary" TYPE="id_String" />
+            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="content_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="description" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="displayname" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="introducedversion" TYPE="id_String" />
@@ -23051,7 +23051,7 @@
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="attachmentcontentid" TYPE="id_String" />
             <COLUMN DBTYPE="Int32" KEY="false" LENGTH="0" NAME="attachmentnumber" TYPE="id_Integer" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="body" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="body_binary" TYPE="id_String" />
+            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="body_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="filename" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="mimetype" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="objecttypecode" TYPE="id_String" />
@@ -23117,7 +23117,7 @@
         <TABLE IF="(ACTION=='update') AND (ENTITYSET=='annotations') AND (((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2016_ODATA')) OR ((AUTH_TYPE == 'ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016')))">
             <COLUMN DBTYPE="Guid" KEY="true" LENGTH="0" NAME="annotationid" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="documentbody" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="documentbody_binary" TYPE="id_String" />
+            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="documentbody_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="filename" TYPE="id_String" />
             <COLUMN DBTYPE="Int32" KEY="false" LENGTH="0" NAME="importsequencenumber" TYPE="id_Integer" />
             <COLUMN DBTYPE="Boolean" KEY="false" LENGTH="0" NAME="isdocument" TYPE="id_Boolean" />
@@ -23240,7 +23240,7 @@
         <TABLE IF="(ACTION=='update') AND (ENTITYSET=='attachments') AND (((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2016_ODATA')) OR ((AUTH_TYPE == 'ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016')))">
             <COLUMN DBTYPE="Guid" KEY="true" LENGTH="0" NAME="attachmentid" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="body" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="body_binary" TYPE="id_String" />
+            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="body_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="filename" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="mimetype" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="subject" TYPE="id_String" />
@@ -26468,7 +26468,7 @@
         <TABLE IF="(ACTION=='update') AND (ENTITYSET=='pluginassemblies') AND (((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2016_ODATA')) OR ((AUTH_TYPE == 'ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016')))">
             <COLUMN DBTYPE="Guid" KEY="true" LENGTH="0" NAME="pluginassemblyid" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="content" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="content_binary" TYPE="id_String" />
+            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="content_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="culture" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="description" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="introducedversion" TYPE="id_String" />
@@ -27219,7 +27219,7 @@
         <TABLE IF="(ACTION=='update') AND (ENTITYSET=='reports') AND (((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2016_ODATA')) OR ((AUTH_TYPE == 'ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016')))">
             <COLUMN DBTYPE="Guid" KEY="true" LENGTH="0" NAME="reportid" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="bodybinary" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="bodybinary_binary" TYPE="id_String" />
+            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="bodybinary_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="bodytext" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="bodyurl" TYPE="id_String" />
             <COLUMN DBTYPE="Int32" KEY="false" LENGTH="0" NAME="createdinmajorversion" TYPE="id_Integer" />
@@ -27322,7 +27322,7 @@
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="attacheddocumenturl" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="authorname" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="documentbody" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="documentbody_binary" TYPE="id_String" />
+            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="documentbody_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="filename" TYPE="id_String" />
             <COLUMN DBTYPE="Int32" KEY="false" LENGTH="0" NAME="filetypecode" TYPE="id_Integer" />
             <COLUMN DBTYPE="Int32" KEY="false" LENGTH="0" NAME="importsequencenumber" TYPE="id_Integer" />
@@ -28650,7 +28650,7 @@
             <COLUMN DBTYPE="Guid" KEY="true" LENGTH="0" NAME="webresourceid" TYPE="id_String" />
             <COLUMN DBTYPE="Boolean" KEY="false" LENGTH="0" NAME="canbedeleted" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="content" TYPE="id_String" />
-            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="content_binary" TYPE="id_String" />
+            <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="content_binary" TYPE="id_byte[]" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="description" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="displayname" TYPE="id_String" />
             <COLUMN DBTYPE="String" KEY="false" LENGTH="0" NAME="introducedversion" TYPE="id_String" />


### PR DESCRIPTION
**What is the current behavior? (You can also link to an open issue here)**
https://jira.talendforge.org/browse/TDI-39578

**What is the new behavior?**
Binary fields are defined as db_type=Binary, talend_type=id_byte[]
Can download binary fields

**What kind of change does this PR introduce?**
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No