### PR TITLE
fix(TDI-39447) : Save cookie even if there is HTTP error.

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileFetch/tFileFetch_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileFetch/tFileFetch_main.javajet
@@ -334,7 +334,7 @@ if ("http".equals(protocol) || "https".equals(protocol)) {
 				status_<%=cid%> = client_<%=cid %>.executeMethod(method_<%=cid%>);
 
 				if ((status_<%=cid%> == org.apache.commons.httpclient.HttpStatus.SC_MOVED_TEMPORARILY) 
-					|| (status_<%=cid%> == org.apache.commons.httpclient.HttpStatus.SC_MOVED_PERMANENTLY) 
+					|| (status_<%=cid%> == org.apache.commons.httpclient.HttpStatus.SC_MOVED_PERMANENTLY)
 						|| (status_<%=cid%> == org.apache.commons.httpclient.HttpStatus.SC_SEE_OTHER) 
 							|| (status_<%=cid%> == org.apache.commons.httpclient.HttpStatus.SC_TEMPORARY_REDIRECT)) {
 					<%if(isLog4jEnabled){%>
@@ -364,25 +364,6 @@ if ("http".equals(protocol) || "https".equals(protocol)) {
 		<%
 		}
 
-		if (saveCookie) {
-		%>
-			org.apache.commons.httpclient.Cookie[] cookies_<%=cid%> = client_<%=cid %>.getState().getCookies();
-			java.io.File cookieFile_<%=cid%> = new java.io.File(<%=cookieDir%>);
-			java.io.File cookieDir_<%=cid%>= cookieFile_<%=cid%>.getParentFile(); 
-			if(!cookieDir_<%=cid%>.exists()){
-				cookieDir_<%=cid%>.mkdirs();
-			}
-			java.io.FileOutputStream fos_<%=cid%> = new java.io.FileOutputStream(cookieFile_<%=cid%>);
-			java.io.ObjectOutputStream os_<%=cid%> = new java.io.ObjectOutputStream(fos_<%=cid%>);
-
-			for (org.apache.commons.httpclient.Cookie c : cookies_<%=cid%>) {
-				os_<%=cid%>.writeObject(c);
-			}
-			os_<%=cid%>.close();
-			fos_<%=cid%>.close();
-		<%
-		}
-
 		if (!redirect) {
 		%>
 			if (status_<%=cid%> != org.apache.commons.httpclient.HttpStatus.SC_OK) {      
@@ -404,6 +385,24 @@ if ("http".equals(protocol) || "https".equals(protocol)) {
 			isContinue_<%=cid%> = false;
 		<%}%>
 	}
+    <% if(saveCookie){ %>
+	finally {
+        org.apache.commons.httpclient.Cookie[] cookies_<%=cid%> = client_<%=cid %>.getState().getCookies();
+        java.io.File cookieFile_<%=cid%> = new java.io.File(<%=cookieDir%>);
+        java.io.File cookieDir_<%=cid%>= cookieFile_<%=cid%>.getParentFile();
+        if(!cookieDir_<%=cid%>.exists()){
+        	cookieDir_<%=cid%>.mkdirs();
+        }
+        java.io.FileOutputStream fos_<%=cid%> = new java.io.FileOutputStream(cookieFile_<%=cid%>);
+        java.io.ObjectOutputStream os_<%=cid%> = new java.io.ObjectOutputStream(fos_<%=cid%>);
+
+        for (org.apache.commons.httpclient.Cookie c : cookies_<%=cid%>) {
+            os_<%=cid%>.writeObject(c);
+        }
+        os_<%=cid%>.close();
+        fos_<%=cid%>.close();
+	}
+	<% } %>
 
 	if (isContinue_<%=cid%>) {    
 		<%if (printResponse) {%>


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-39447

**What is the new behavior?**
The cookie is saved if __SAVE_COOKIE__ is checked, even if there is HTTP error.

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No