### PR TITLE
fix(TDI-39475): manage codegen when ConnectorTopology is NONE

### DIFF
--- a/main/plugins/org.talend.designer.codegen/jet_stub/generic/component_begin.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/generic/component_begin.javajet
@@ -164,6 +164,7 @@ org.talend.components.api.component.ConnectorTopology topology_<%=cid%> = null;
 <%
 boolean hasOutput = !NodeUtil.getOutgoingConnections(node, IConnectionCategory.DATA).isEmpty();
 boolean hasOutputOnly = hasOutput && !hasInput;
+boolean isTopologyNone = !hasOutput && !hasInput;
 
 if (hasInput && hasOutput) {
 %>
@@ -212,6 +213,10 @@ if(componentRuntime_<%=cid%> instanceof org.talend.components.api.component.runt
 <%
 // Return at this point if there is no metadata.
 if (metadata == null) {
+    return stringBuffer.toString();
+}
+
+if(isTopologyNone) {
     return stringBuffer.toString();
 }
 

--- a/main/plugins/org.talend.designer.codegen/jet_stub/generic/component_end.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/generic/component_end.javajet
@@ -38,6 +38,7 @@ if (metadata == null) {
 boolean hasInput = !NodeUtil.getIncomingConnections(node, IConnectionCategory.DATA).isEmpty();
 boolean hasOutput = !NodeUtil.getOutgoingConnections(node, IConnectionCategory.DATA).isEmpty();
 boolean hasOutputOnly = hasOutput && !hasInput;
+boolean isTopologyNone = !hasOutput && !hasInput;
 
 Set<ConnectorTopology> connectorTopologies = def.getSupportedConnectorTopologies();
 boolean asInputComponent = connectorTopologies!=null && (connectorTopologies.size() < 3) && connectorTopologies.contains(ConnectorTopology.OUTGOING);
@@ -46,7 +47,10 @@ boolean asInputComponent = connectorTopologies!=null && (connectorTopologies.siz
 resourceMap.put("finish_<%=cid%>", Boolean.TRUE);
 
 <%
-if(hasOutputOnly || asInputComponent){
+if(isTopologyNone){
+	return stringBuffer.toString();
+}
+else if(hasOutputOnly || asInputComponent){
 %>
     } // while
     reader_<%=cid%>.close();


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

https://jira.talendforge.org/browse/TDI-39475

When connectorTopology is NONE, a class implementing `ComponentDriverInitialization<ComponentProperties>` is used but the codegen doesn't handle it correctly. It works as if a flow is connected (This leads to a NPE).

**What is the new behavior?**

When we're using a ComponentDriverInitialization runtime, no need to handle the flow.
The return values are also handled correctly by ComponentDriverInitialization class.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
