### PR TITLE
fix(TBD-5317): consistent field separator

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tHiveIn/tHiveIn_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tHiveIn/tHiveIn_main.javajet
@@ -192,7 +192,7 @@ imports="
 %>
         // First we dump the select query of the user into google storage
         // In order to do that we modify the query to add as a prefix:
-        // INSERT OVERWRITE DIRECTORY '$GOOGLE_JARS_BUCKET/hivetmp/' ROW FORMAT DELIMITED FIELDS TERMINATED BY ','
+        // INSERT OVERWRITE DIRECTORY '$GOOGLE_JARS_BUCKET/hivetmp/' ROW FORMAT DELIMITED FIELDS TERMINATED BY '\t'
 
         <%
         String gsTempDir = "";
@@ -208,7 +208,7 @@ imports="
             gsTempDir = ElementParameterParser.getValue(node, "__GOOGLE_JARS_BUCKET__") + " + \"hivetemp\" ";
         }
         %>
-        instance_<%=cid%>.addQuery("INSERT OVERWRITE DIRECTORY '" + <%=gsTempDir%> + "' ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' "
+        instance_<%=cid%>.addQuery("INSERT OVERWRITE DIRECTORY '" + <%=gsTempDir%> + "' ROW FORMAT DELIMITED FIELDS TERMINATED BY '\t' "
                 + <%=dbquery%>.replace("';'", "'\\;'") + ";");
         if (libjars_<%=cid%>.length() > 0) {
             instance_<%=cid%>.addLibJars(libjars_<%=cid%>.toString().substring(0, libjars_<%=cid%>.length()-1));

--- a/main/plugins/org.talend.designer.components.localprovider/components/templates/Hive/GetDataprocConnection.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/templates/Hive/GetDataprocConnection.javajet
@@ -41,6 +41,8 @@ imports="
         if(dbname_<%=cid%>!=null && !"".equals(dbname_<%=cid%>.trim()) && !"default".equals(dbname_<%=cid%>.trim())) {
             connectionCommandList_<%=cid%>.add("use " + dbname_<%=cid%> + ";");
         }
+        
+        stagingBucketPath_<%=cid%> = <%=ElementParameterParser.getValue(node, "__GOOGLE_JARS_BUCKET__")%>;
 
         org.talend.bigdata.launcher.google.dataproc.DataprocHiveJob instance_<%=cid%> =
             new org.talend.bigdata.launcher.google.dataproc.DataprocHiveJob.Builder()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Unit tests for the Java changes have been added (for bug fixes / features) ?
- [ ] TUJ for the JavaJet changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [x] The new code does not introduce new technical issues

**What is the current behavior?** (You can also link to an open issue here)

Field separator are inconsistent : "\t" in the Studio and "," in GCP.
Google Storage path is not set when an existing connection in not used.

**What is the new behavior?**

Fields are consistent and set to "\t" (not "," because "\t" is already used for HDi behavior).
Google Storage path is set when no existing connection is used.