### PR TITLE
fix(TDI-39754) : Retrieve protocol and port from origin

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileFetch/tFileFetch_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileFetch/tFileFetch_main.javajet
@@ -351,7 +351,7 @@ if ("http".equals(protocol) || "https".equals(protocol)) {
 
 					String redirect_url_<%=cid%> = method_<%=cid%>.getResponseHeader("location").getValue();
                     if(!redirect_url_<%=cid%>.startsWith("http")){
-                        redirect_url_<%=cid%> = "http://" + method_<%=cid%>.getURI().getHost() + redirect_url_<%=cid%>;
+                        redirect_url_<%=cid%> = method_tFileFetch_1.getHostConfiguration().getProtocol().getScheme()+"://" + method_<%=cid%>.getURI().getHost() + ":" + method_tFileFetch_1.getURI().getPort() + redirect_url_<%=cid%>;
                     }
 
                     if(status_<%=cid%> == org.apache.commons.httpclient.HttpStatus.SC_SEE_OTHER<% if(redirect_302_as_303) {%> || status_<%=cid%> == org.apache.commons.httpclient.HttpStatus.SC_MOVED_TEMPORARILY<% } %>) {


### PR DESCRIPTION
**What is the current behavior?**
https://jira.talendforge.org/browse/TDI-39754

**What is the new behavior?**
If the redirect url doesn't start by 'http' then it is a relative URL. Then, we get the protocol of the origin url and its port to complete the url.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No