### PR TITLE
fix(TDI-39827): some jars can't be imported or download after cxf upgrade

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmInput/tMicrosoftCrmInput_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmInput/tMicrosoftCrmInput_java.xml
@@ -19446,11 +19446,11 @@
                 <IMPORT NAME="geronimo-stax-api_1.0_spec-1.0.1" MODULE="geronimo-stax-api_1.0_spec-1.0.1.jar" MVN="mvn:org.talend.libraries/geronimo-stax-api_1.0_spec-1.0.1/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.apache.axis2/lib/geronimo-stax-api_1.0_spec-1.0.1.jar" REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')" />
                 <IMPORT NAME="jaxen-1.1.6" MODULE="jaxen-1.1.6.jar" MVN="mvn:org.talend.libraries/jaxen-1.1.6/6.0.0"  REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')" BundleID="" />
                 <IMPORT NAME="mail-1.4" MODULE="mail-1.4.jar" MVN="mvn:org.talend.libraries/mail-1.4/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.apache.axis2/lib/mail-1.4.jar" REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')" />
-                <IMPORT NAME="neethi-3.0.3" MODULE="neethi-3.0.3.jar" MVN="mvn:org.talend.libraries/neethi-3.0.3/6.0.0" REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')" />
+                <IMPORT NAME="neethi-3.0.3" MODULE="neethi-3.0.3.jar" MVN="mvn:org.apache.neethi/neethi/3.0.3" REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')" />
                 <IMPORT NAME="WSDL4J-1_6_3" MODULE="wsdl4j-1.6.3.jar" MVN="mvn:org.talend.libraries/wsdl4j-1.6.3/6.0.0"  REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')" />
                 <IMPORT NAME="wstx-asl-3.2.9" MODULE="wstx-asl-3.2.9.jar" MVN="mvn:org.talend.libraries/wstx-asl-3.2.9/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.apache.axis2/lib/wstx-asl-3.2.9.jar" REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')" />
                 <IMPORT NAME="xmlbeans-2.6.0" MODULE="xmlbeans-2.6.0.jar" MVN="mvn:org.talend.libraries/xmlbeans-2.6.0/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.apache.xml/lib/xmlbeans-2.6.0.jar" REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')" />
-                <IMPORT NAME="xmlschema-core-2.2.1" MODULE="xmlschema-core-2.2.1.jar" MVN="mvn:org.talend.libraries/xmlschema-core-2.2.1/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.apache.axis2/lib/xmlschema-core-2.2.1.jar" REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')"/>
+                <IMPORT NAME="xmlschema-core-2.2.1" MODULE="xmlschema-core-2.2.1.jar" MVN="mvn:org.apache.ws.xmlschema/xmlschema-core/2.2.1" REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')"/>
                 <IMPORT NAME="commons-httpclient-3.1" MODULE="commons-httpclient-3.1.jar" MVN="mvn:org.talend.libraries/commons-httpclient-3.1/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.apache.http/lib/commons-httpclient-3.1.jar" REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')"/>
                 <IMPORT NAME="commons-fileupload-1.3.1" MODULE="commons-fileupload-1.3.1.jar" MVN="mvn:org.talend.libraries/commons-fileupload-1.3.1/6.0.0"  REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')" />
                 <IMPORT NAME="addressing-1.6.2" MODULE="addressing-1.6.2.jar" MVN="mvn:org.talend.libraries/addressing-1.6.2/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.apache.axis2/lib/addressing-1.6.2.jar" REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')" />
@@ -19571,14 +19571,12 @@
                 <IMPORT
                     NAME="jaxb-core-2.2.11"
                     MODULE="jaxb-core-2.2.11.jar"
-                    MVN="mvn:org.talend.libraries/jaxb-core-2.2.11/6.0.0"
-                    UrlPath="platform:/plugin/org.talend.libraries.apache.cxf/lib/jaxb-core-2.2.11.jar"
+                    MVN="mvn:com.sun.xml.bind/jaxb-core/2.2.11"
                     REQUIRED_IF="(AUTH_TYPE == 'ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2015')" />
                 <IMPORT
                     NAME="jaxb-impl-2.2.11"
                     MODULE="jaxb-impl-2.2.11.jar"
-                    MVN="mvn:org.talend.libraries/jaxb-impl-2.2.11/6.0.0"
-                    UrlPath="platform:/plugin/org.talend.libraries.apache.cxf/lib/jaxb-impl-2.2.11.jar"
+                    MVN="mvn:com.sun.xml.bind/jaxb-impl/2.2.11"
                     REQUIRED_IF="(AUTH_TYPE == 'ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2015')" />
                 <IMPORT
                     NAME="jcl-over-slf4j-1.7.12"

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmOutput/tMicrosoftCrmOutput_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmOutput/tMicrosoftCrmOutput_java.xml
@@ -28864,11 +28864,11 @@
             <IMPORT NAME="geronimo-stax-api_1.0_spec-1.0.1" MODULE="geronimo-stax-api_1.0_spec-1.0.1.jar" MVN="mvn:org.talend.libraries/geronimo-stax-api_1.0_spec-1.0.1/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.apache.axis2/lib/geronimo-stax-api_1.0_spec-1.0.1.jar" REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')" />
             <IMPORT NAME="jaxen-1.1.6" MODULE="jaxen-1.1.6.jar" MVN="mvn:org.talend.libraries/jaxen-1.1.6/6.0.0"  REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')" BundleID="" />
             <IMPORT NAME="mail-1.4" MODULE="mail-1.4.jar" MVN="mvn:org.talend.libraries/mail-1.4/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.apache.axis2/lib/mail-1.4.jar" REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')" />
-            <IMPORT NAME="neethi-3.0.3" MODULE="neethi-3.0.3.jar" MVN="mvn:org.talend.libraries/neethi-3.0.3/6.0.0" REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')" />
+            <IMPORT NAME="neethi-3.0.3" MODULE="neethi-3.0.3.jar" MVN="mvn:org.apache.neethi/neethi/3.0.3" REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')" />
             <IMPORT NAME="WSDL4J-1_6_3" MODULE="wsdl4j-1.6.3.jar" MVN="mvn:org.talend.libraries/wsdl4j-1.6.3/6.0.0"  REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')" />
             <IMPORT NAME="wstx-asl-3.2.9" MODULE="wstx-asl-3.2.9.jar" MVN="mvn:org.talend.libraries/wstx-asl-3.2.9/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.apache.axis2/lib/wstx-asl-3.2.9.jar" REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')" />
             <IMPORT NAME="xmlbeans-2.6.0" MODULE="xmlbeans-2.6.0.jar" MVN="mvn:org.talend.libraries/xmlbeans-2.6.0/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.apache.xml/lib/xmlbeans-2.6.0.jar" REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')" />
-            <IMPORT NAME="xmlschema-core-2.2.1" MODULE="xmlschema-core-2.2.1.jar" MVN="mvn:org.talend.libraries/xmlschema-core-2.2.1/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.apache.axis2/lib/xmlschema-core-2.2.1.jar" REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')"/>
+            <IMPORT NAME="xmlschema-core-2.2.1" MODULE="xmlschema-core-2.2.1.jar" MVN="mvn:org.apache.ws.xmlschema/xmlschema-core/2.2.1" REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')"/>
             <IMPORT NAME="commons-httpclient-3.1" MODULE="commons-httpclient-3.1.jar" MVN="mvn:org.talend.libraries/commons-httpclient-3.1/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.apache.http/lib/commons-httpclient-3.1.jar" REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')"/>
             <IMPORT NAME="commons-fileupload-1.3.1" MODULE="commons-fileupload-1.3.1.jar" MVN="mvn:org.talend.libraries/commons-fileupload-1.3.1/6.0.0"  REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')" />
             <IMPORT NAME="addressing-1.6.2" MODULE="addressing-1.6.2.jar" MVN="mvn:org.talend.libraries/addressing-1.6.2/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.apache.axis2/lib/addressing-1.6.2.jar" REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')" />
@@ -28989,14 +28989,12 @@
             <IMPORT
                 NAME="jaxb-core-2.2.11"
                 MODULE="jaxb-core-2.2.11.jar"
-                MVN="mvn:org.talend.libraries/jaxb-core-2.2.11/6.0.0"
-                UrlPath="platform:/plugin/org.talend.libraries.apache.cxf/lib/jaxb-core-2.2.11.jar"
+                MVN="mvn:com.sun.xml.bind/jaxb-core/2.2.11"
                 REQUIRED_IF="(AUTH_TYPE == 'ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2015')" />
             <IMPORT
                 NAME="jaxb-impl-2.2.11"
                 MODULE="jaxb-impl-2.2.11.jar"
-                MVN="mvn:org.talend.libraries/jaxb-impl-2.2.11/6.0.0"
-                UrlPath="platform:/plugin/org.talend.libraries.apache.cxf/lib/jaxb-impl-2.2.11.jar"
+                MVN="mvn:com.sun.xml.bind/jaxb-impl/2.2.11"
                 REQUIRED_IF="(AUTH_TYPE == 'ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2015')" />
             <IMPORT
                 NAME="jcl-over-slf4j-1.7.12"


### PR DESCRIPTION
For https://jira.talendforge.org/browse/TDI-39827

After upgrade CXF, this thow some wrong dependency of jar.
Provide download those jars.