### PR TITLE
fix(TDI-39932): tLDAPXX components does not close TLS connection

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tLDAPAttributesInput/tLDAPAttributesInput_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLDAPAttributesInput/tLDAPAttributesInput_end.javajet
@@ -42,6 +42,24 @@ if ((metadatas!=null)&&(metadatas.size()>0)&&(metadatas.get(0) != null)) {
 rootSchema_<%=cid%>.close();
 <%
 if(("false").equals(useExistingConn)){
+    String protocol=ElementParameterParser.getValue(node, "__PROTOCOL__");
+    
+    if("TLS".equals(protocol)){
+        if(isLog4jEnabled){
+%>
+	         log.info("<%=cid%> - Closing the TLS connection.");
+<%
+        }
+%>
+        tls_<%=cid%>.close();
+
+<%
+        if(isLog4jEnabled){
+%>
+	         log.info("<%=cid%> - TLS connection closed.");
+<%
+        }
+    }
 %>
 	<%if(isLog4jEnabled){%>
 		log.info("<%=cid%> - Closing the connection to the server.");

--- a/main/plugins/org.talend.designer.components.localprovider/components/tLDAPClose/tLDAPClose_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLDAPClose/tLDAPClose_main.javajet
@@ -3,6 +3,7 @@ imports="
     org.talend.core.model.process.INode 
     org.talend.core.model.process.ElementParameterParser 
     org.talend.designer.codegen.config.CodeGeneratorArgument
+    org.talend.core.model.utils.NodeUtil
 " 
 %>
 	<%@ include file="../templates/Log4j/Log4jFileUtil.javajet"%> 
@@ -12,8 +13,31 @@ imports="
     String cid = node.getUniqueName();
     String connection = ElementParameterParser.getValue(node,"__CONNECTION__");
     String conn = "conn_" + connection;
-	boolean isLog4jEnabled = ("true").equals(ElementParameterParser.getValue(node.getProcess(), "__LOG4J_ACTIVATE__"));
+	 boolean isLog4jEnabled = ("true").equals(ElementParameterParser.getValue(node.getProcess(), "__LOG4J_ACTIVATE__"));
+	 INode connectionNode = NodeUtil.getNodeByUniqueName(node.getProcess(),connection);
+    String protocol=ElementParameterParser.getValue(connectionNode, "__PROTOCOL__");
+    
+    if("TLS".equals(protocol)){
+        if(isLog4jEnabled){
 %>
+	         log.info("<%=cid%> - Closing the TLS connection.");
+<%
+        }
+%>
+        javax.naming.ldap.StartTlsResponse tls_<%=cid%> =(javax.naming.ldap.StartTlsResponse)globalMap.get("tls_<%=connection%>");
+        if(tls_<%=cid%>!=null){
+            tls_<%=cid%>.close();
+        }
+
+<%
+        if(isLog4jEnabled){
+%>
+	         log.info("<%=cid%> - TLS connection closed.");
+<%
+        }
+    }
+%>
+
 	javax.naming.ldap.InitialLdapContext ctx_<%=cid%> = (javax.naming.ldap.InitialLdapContext)globalMap.get("<%=conn%>");
 	if(ctx_<%=cid%> != null)
 	{

--- a/main/plugins/org.talend.designer.components.localprovider/components/tLDAPConnection/ldapconnect.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLDAPConnection/ldapconnect.javajet
@@ -46,6 +46,7 @@ if("TLS".equals(protocol)){
   ctx_<%=cid%>.addToEnvironment(javax.naming.Context.SECURITY_PRINCIPAL, <%=user%>);
   ctx_<%=cid%>.addToEnvironment(javax.naming.Context.SECURITY_CREDENTIALS, decryptedPassword_<%=cid%>);
   <%}%>
+  globalMap.put("tls_<%=cid%>",tls_<%=cid%>);
 <%
 }
 %>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tLDAPInput/tLDAPInput_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLDAPInput/tLDAPInput_end.javajet
@@ -58,6 +58,27 @@ if ((metadatas!=null)&&(metadatas.size()>0)&&(metadatas.get(0) != null)) {
 	}finally{
 <%
 if(("false").equals(useExistingConn)){
+    String protocol=ElementParameterParser.getValue(node, "__PROTOCOL__");
+    
+    if("TLS".equals(protocol)){
+        if(isLog4jEnabled){
+%>
+	         log.info("<%=cid%> - Closing the TLS connection.");
+<%
+        }
+%>
+        javax.naming.ldap.StartTlsResponse tls_<%=cid%> =(javax.naming.ldap.StartTlsResponse)globalMap.get("tls_<%=cid%>");
+        if(tls_<%=cid%>!=null){
+            tls_<%=cid%>.close();
+        }
+
+<%
+        if(isLog4jEnabled){
+%>
+	         log.info("<%=cid%> - TLS connection closed.");
+<%
+        }
+    }
 %>  
 		if(ctx_<%=cid%>!=null){
 			<%if(isLog4jEnabled){%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tLDAPOutput/tLDAPOutput_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLDAPOutput/tLDAPOutput_end.javajet
@@ -14,6 +14,24 @@
 %>
 <%
 if(("false").equals(useExistingConn)){
+    String protocol=ElementParameterParser.getValue(node, "__PROTOCOL__");
+    
+    if("TLS".equals(protocol)){
+        if(isLog4jEnabled){
+%>
+	         log.info("<%=cid%> - Closing the TLS connection.");
+<%
+        }
+%>
+        tls_<%=cid%>.close();
+
+<%
+        if(isLog4jEnabled){
+%>
+	         log.info("<%=cid%> - TLS connection closed.");
+<%
+        }
+    }
 %>
 	<%if(isLog4jEnabled){%>
 		log.info("<%=cid%> - Closing the connection to the server.");

--- a/main/plugins/org.talend.designer.components.localprovider/components/tLDAPRenameEntry/tLDAPRenameEntry_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLDAPRenameEntry/tLDAPRenameEntry_end.javajet
@@ -14,6 +14,24 @@
 %>
 <%
 if(("false").equals(useExistingConn)){
+    String protocol=ElementParameterParser.getValue(node, "__PROTOCOL__");
+    
+    if("TLS".equals(protocol)){
+        if(isLog4jEnabled){
+%>
+	         log.info("<%=cid%> - Closing the TLS connection.");
+<%
+        }
+%>
+        tls_<%=cid%>.close();
+
+<%
+        if(isLog4jEnabled){
+%>
+	         log.info("<%=cid%> - TLS connection closed.");
+<%
+        }
+    }
 %>
 	<%if(isLog4jEnabled){%>
 		log.info("<%=cid%> - Closing the connection to the server.");


### PR DESCRIPTION
For https://jira.talendforge.org/browse/TDI-39932

- Close TLS connection in LDAP components.

**NOTE:
This PR would merge after support validate the unoffical patch..**
 