### PR TITLE
feat(TDI-39981) : Add template for github PR comments

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,19 @@
-**What is the current behavior? (You can also link to an open issue here)**
+**What is the current behavior?** (You can also link to an open issue here)
+
 
 **What is the new behavior?**
 
+
+**Please check if the PR fulfills these requirements**
+
+- [ ] The commit message follows Talend standard
+- [ ] Tests for the changes have been added (for bug fixes / features)
+- [ ] Docs have been added / updated (for bug fixes / features) ?
+- [ ] The code coverage on new code >75%
+- [ ] The new code does not introduce new technical issues (sonar / eslint)
+
 **What kind of change does this PR introduce?**
+
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
@@ -11,5 +22,13 @@
 - [ ] Other... Please describe:
 
 **Does this PR introduce a breaking change?**
+
 - [ ] Yes
-- [x] No
+- [ ] No
+
+If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
+
+
+**Other information**:
+
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+**What is the current behavior? (You can also link to an open issue here)**
+
+**What is the new behavior?**
+
+**What kind of change does this PR introduce?**
+- [ ] Bugfix
+- [ ] Feature
+- [ ] Code style update (formatting, local variables)
+- [ ] Refactoring (no functional changes, no api changes)
+- [ ] Build / CI related changes
+- [ ] Other... Please describe:
+
+**Does this PR introduce a breaking change?**
+- [ ] Yes
+- [x] No


### PR DESCRIPTION
**What is the current behavior? (You can also link to an open issue here)**
https://jira.talendforge.org/browse/TDI-39981

**What is the new behavior?**
When a PR is created, the default template is used as description.

**What kind of change does this PR introduce?**
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No