### PR TITLE
fix(TCOMP-681): remove unrelated code when tacokit component is used

### DIFF
--- a/main/plugins/org.talend.designer.codegen/jet_stub/footer.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/footer.javajet
@@ -1,6 +1,7 @@
 <%@ jet
     package="org.talend.designer.codegen.translators"
     imports="
+        org.talend.core.model.general.ModuleNeeded
         org.talend.core.model.process.IProcess
         org.talend.core.model.process.INode
         org.talend.designer.codegen.config.CodeGeneratorArgument
@@ -260,11 +261,14 @@
     
     <%
     boolean containGenericComponents = false;
+    nodeloop:
 	for(INode node : process.getGeneratingNodes()) {
 		IComponent component = node.getComponent();
-		if(EComponentType.GENERIC.equals(component.getComponentType())) {
-			containGenericComponents = true;
-			break;
+		for (ModuleNeeded module : component.getModulesNeeded(node)) {
+		    if (module.getModuleName() != null && module.getModuleName().startsWith("components-common")) {
+		        containGenericComponents = true;
+		        break nodeloop;
+		    }
 		}
 	}
 	if(containGenericComponents) {


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

SharedConnectionPool code (which is required for TCOMP component) is generated for the job where there is TaCoKit component, but there is no TCOMP component, because they both have GENERIC type

**What is the new behavior?**

Code is not generated when there is no TCOMP component in the job

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


