### PR TITLE
TESB-21298 Missing Beans are added to Routines pkg

### DIFF
--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/esb/JobJavaScriptOSGIForESBManager.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/esb/JobJavaScriptOSGIForESBManager.java
@@ -36,6 +36,7 @@ import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.runtime.Status;
 import org.talend.commons.exception.ExceptionHandler;
 import org.talend.commons.exception.PersistenceException;
+import org.talend.commons.runtime.utils.io.FileCopyUtils;
 import org.talend.commons.utils.generation.JavaUtils;
 import org.talend.commons.utils.io.FilesUtils;
 import org.talend.core.GlobalServiceRegister;
@@ -253,6 +254,7 @@ public class JobJavaScriptOSGIForESBManager extends JobJavaScriptsManager {
         if (classRootFileLocation == null) {
             return;
         }
+        FileCopyUtils.copyFolder(getCodeClassRootFileLocation(ERepositoryObjectType.valueOf("BEANS")), classRootFileLocation);
         try {
             JarBuilder jarbuilder = new JarBuilder(classRootFileLocation, jarFile);
             jarbuilder.setIncludeDir(getRoutinesPaths());


### PR DESCRIPTION
At this moment generated Routines package does not have Beans inside. The reason is - Beans and Routines are generated now as separate projects with different "target" location. There are few different ways to resolve issue: 

1. Include Beans as separate library to generated Route;
2. Copy Beans classes to Routines package to make it consistent with previous behaviour (before moving to single maven build);

Current fix contains implementation of approach № 2.