### PR TITLE
TESB-21304 NPE during importing of Route is fixed

### DIFF
--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/DefaultRunProcessService.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/DefaultRunProcessService.java
@@ -58,6 +58,7 @@ import org.talend.core.model.properties.RoutineItem;
 import org.talend.core.model.repository.ERepositoryObjectType;
 import org.talend.core.model.runprocess.data.PerformanceData;
 import org.talend.core.repository.model.ProxyRepositoryFactory;
+import org.talend.core.repository.seeker.RepositorySeekerManager;
 import org.talend.core.repository.utils.Log4jUtil;
 import org.talend.core.runtime.process.ITalendProcessJavaProject;
 import org.talend.core.runtime.process.TalendProcessArgumentConstant;
@@ -246,7 +247,8 @@ public class DefaultRunProcessService implements IRunProcessService {
                     }
                 }
             } else {
-                if (routeService != null) {
+            	boolean isImportedRoute = RepositorySeekerManager.getInstance().searchRepoViewNode(property.getId(), false) == null;
+                if (routeService != null && !isImportedRoute ) {
                     return routeService.createJavaProcessor(process, property, filenameFromLabel, false);
                 }
             }


### PR DESCRIPTION
At this moment we have NPE during invocation of "JavaCamelJobScriptsExportWSAction" from "BundleJavaProcessor".
The reason of NPE is   "repositoryNode" (from BundleJavaProcessor) is null because of Eclipse somehow refreshes TreeView after finishing of Workspace operation only. And imported element can not be retrived from TreeView before Import operation is finished. Current fix is just workaround for such situation. It will be necessary to review this code when propagation of Build Type will be fully implemented (we must avoid using BundleJavaProcessor for imported Routes).