### PR TITLE
bug(TDI-40026) : Get only exception msg from subjob

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tRunJob/tRunJob_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tRunJob/tRunJob_main.javajet
@@ -426,7 +426,7 @@ String inputConnName = null;
 	  
 			<%if (dieOnError) { %> 
 				if (childJob_<%=cid %>.getErrorCode() != null || ("failure").equals(childJob_<%=cid %>.getStatus())) {
-	        		throw new RuntimeException("Child job running failed.\n"+childJob_<%=cid %>.getExceptionStackTrace());
+	        		throw new RuntimeException("Child job running failed.\n"+childJob_<%=cid %>.getException().getClass().getName() + ": " + childJob_<%=cid %>.getException().getMessage());
 				}
 			<%}
 		}%>


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-40026
All the stacktrace of a subjob exception where logged.

**What is the new behavior?**
Only the exception class and its message are logged (as if it was a normal job).

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
