### PR TITLE
fix(TDI-40106): avoid ConcurrentModificationException

### DIFF
--- a/main/plugins/org.talend.designer.codegen/src/main/java/org/talend/designer/codegen/config/NodesSubTree.java
+++ b/main/plugins/org.talend.designer.codegen/src/main/java/org/talend/designer/codegen/config/NodesSubTree.java
@@ -512,7 +512,7 @@ public class NodesSubTree {
             });
         }
 
-        return mergeBranchStarts;
+        return new ArrayList<>(mergeBranchStarts);
     }
 
     public boolean isMergeSubTree() {


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

https://jira.talendforge.org/browse/TDI-40106

**What is the new behavior?**
Now returning a copy of the `List<INode>` instead of the original reference.
This avoids the exception due to the `modCount` changes during iterations on the reference.

Need to be backported to 6.4 and 6.5.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


