### PR TITLE
TESB-21314 NPE during Routes import is corrected

### DIFF
--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/JobErrorsChecker.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/JobErrorsChecker.java
@@ -350,6 +350,9 @@ public class JobErrorsChecker {
     }
 
     private static void checkRoutinesCompilationError() throws ProcessorException {
+    	if(LastGenerationInfo.getInstance() == null  || LastGenerationInfo.getInstance().getLastMainJob() == null) {
+    		return;
+    	}
         Set<String> dependentRoutines = LastGenerationInfo.getInstance().getRoutinesNeededWithSubjobPerJob(
                 LastGenerationInfo.getInstance().getLastMainJob().getJobId(),
                 LastGenerationInfo.getInstance().getLastMainJob().getJobVersion());
@@ -420,6 +423,9 @@ public class JobErrorsChecker {
     }
     
     protected static void checkSubJobMultipleVersionsError() throws ProcessorException {
+    	if(LastGenerationInfo.getInstance() == null  || LastGenerationInfo.getInstance().getLastGeneratedjobs() == null) {
+    		return;
+    	}
         Set<JobInfo> jobInfos = LastGenerationInfo.getInstance().getLastGeneratedjobs();
         Map<String, Set<String>> jobInfoMap = new HashMap<>();
         for (JobInfo jobInfo : jobInfos) {


### PR DESCRIPTION
At this moment we have NPE during importing of Route (or during saving of new Route). It happends due to missing compillation logs (it is expected because of Route was not compiled previously). 

Verification for "null" condition is added.