### PR TITLE
TESB-20833 Missing "Deployment" tab is added

### DIFF
--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/views/jobsettings/JobSettingsView.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/views/jobsettings/JobSettingsView.java
@@ -613,6 +613,10 @@ public class JobSettingsView extends ViewPart implements IJobSettingsView, ISele
                                     .contains(((IRepositoryViewObject) obj).getRepositoryObjectType()))) {
                 category.add(EComponentCategory.GITHISTORY);
             }
+            if (((IRepositoryViewObject) obj).getRepositoryObjectType().equals(ERepositoryObjectType.PROCESS_ROUTE) ||
+            		((IRepositoryViewObject) obj).getRepositoryObjectType().equals(ERepositoryObjectType.PROCESS)) {
+                category.add(EComponentCategory.DEPLOYMENT);
+            }
         } else if (obj instanceof IEditorPart) {
             if (CorePlugin.getDefault().getDiagramModelService().isBusinessDiagramEditor((IEditorPart) obj)) {
                 category.add(EComponentCategory.MAIN);


### PR DESCRIPTION
At this moment "Deployment" tab is not shown for new or imported Routes (it is shown in case of Route / Job is opened in Editor only). 

Current fix makes "Deployment" tab available. But content will be shown in "Read Only" mode (because of it will not possible to save changes in any case).