### PR TITLE
fix(TUP-19131):Remote project creation without user & password -> HTTP 500 error

### DIFF
--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/login/connections/ConnectionFormComposite.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/login/connections/ConnectionFormComposite.java
@@ -313,12 +313,14 @@ public class ConnectionFormComposite extends Composite {
                 }
             }
         }
+        toActiveDynamicButtons(true);
         if (valid && getRepository() == null) {
             errorMsg = Messages.getString("connections.form.emptyField.repository"); //$NON-NLS-1$
         } else if (valid && getTextName().length() == 0) {
             errorMsg = Messages.getString("connections.form.emptyField.connname"); //$NON-NLS-1$
         } else if (valid && getUser().length() == 0) {
             errorMsg = Messages.getString("connections.form.emptyField.username"); //$NON-NLS-1$
+            toActiveDynamicButtons(false);
         } else if (valid && isLocalConnection() && !Pattern.matches(RepositoryConstants.MAIL_PATTERN, getUser())) {
             errorMsg = Messages.getString("connections.form.malformedField.username"); //$NON-NLS-1$
         } else if (valid && emptyUrl != null) {
@@ -445,6 +447,15 @@ public class ConnectionFormComposite extends Composite {
         layoutData.exclude = hide;
         if (autoLayout) {
             control.getParent().layout();
+        }
+    }
+
+    private void toActiveDynamicButtons(boolean enable) {
+        // Button would only be active if user are filled
+        if (getRepository() != null) {
+            for (Button control : dynamicButtons.get(getRepository()).values()) {
+                control.setEnabled(enable);
+            }
         }
     }
 


### PR DESCRIPTION

**What is the current behavior?** (You can also link to an open issue here)
Remote project creation without user & password -> HTTP 500 error

**What is the new behavior?**
Check url button would only be active if user are filled

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


