### PR TITLE
fix(TDI-40071): Expand migration task

### DIFF
--- a/main/plugins/org.talend.designer.core.generic/src/main/java/org/talend/designer/core/generic/model/migration/NewMarkLogicMigrationTask.java
+++ b/main/plugins/org.talend.designer.core.generic/src/main/java/org/talend/designer/core/generic/model/migration/NewMarkLogicMigrationTask.java
@@ -85,11 +85,16 @@ public class NewMarkLogicMigrationTask extends NewComponentFrameworkMigrationTas
                     }
                 }
             }
+
+            if ("useExternalMLCP".equals(namedThingName)) {
+                Property<Boolean> useExternalMLCP = (Property<Boolean>) currNamedThing;
+                useExternalMLCP.setValue(true);
+            }
         }
     }
 
     private boolean schmemaIsEmpty(NamedThing schemaProperty) {
-        return ((Property<Schema>)schemaProperty).getValue().getFields().size() == 0;
+        return ((Property<Schema>) schemaProperty).getValue().getFields().size() == 0;
     }
 
     private List<ConnectionType> getAllInputMainConnectors(NodeType nodeType) {
@@ -108,8 +113,8 @@ public class NewMarkLogicMigrationTask extends NewComponentFrameworkMigrationTas
     private NodeType getSourceNode(List<ConnectionType> mainConnectors, NodeType target) {
         String sourceNodeUniqueName = null;
         if (!mainConnectors.isEmpty()) {
-          //could be only 1 input main connector
-          sourceNodeUniqueName = mainConnectors.get(0).getSource(); 
+            // could be only 1 input main connector
+            sourceNodeUniqueName = mainConnectors.get(0).getSource();
         }
 
         List<NodeType> allNodes = getProcessType(item).getNode();
@@ -139,7 +144,8 @@ public class NewMarkLogicMigrationTask extends NewComponentFrameworkMigrationTas
         return SchemaUtils.convertTalendSchemaIntoComponentSchema(ConvertionHelper.convert(metadataTable));
     }
 
-    private MetadataType getAppropriateMetadata(List<MetadataType> allSourceNodeMetadatas, List<ConnectionType> allInputMainConnectors) {
+    private MetadataType getAppropriateMetadata(List<MetadataType> allSourceNodeMetadatas,
+            List<ConnectionType> allInputMainConnectors) {
         MetadataType sourceMetadata = null;
         if (allSourceNodeMetadatas.size() == 1) {
             sourceMetadata = allSourceNodeMetadatas.get(0);
@@ -154,7 +160,7 @@ public class NewMarkLogicMigrationTask extends NewComponentFrameworkMigrationTas
         }
         return sourceMetadata;
     }
-    
+
     @Override
     protected ElementParameterType getParameterType(NodeType node, String paramName) {
         ElementParameterType paramType = ParameterUtilTool.findParameterType(node, paramName);

--- a/main/plugins/org.talend.designer.core.generic/src/main/java/org/talend/designer/core/generic/model/migration/NewMarkLogicMigrationTask.java
+++ b/main/plugins/org.talend.designer.core.generic/src/main/java/org/talend/designer/core/generic/model/migration/NewMarkLogicMigrationTask.java
@@ -55,6 +55,8 @@ public class NewMarkLogicMigrationTask extends NewComponentFrameworkMigrationTas
     /*
      * tMarkLogicInput (in tcomp) has 2 new properties: checkbox 'criteriaSearch' (should be true in criteria mode, when
      * component doesn't have input connection) and input schema, which is output schema of source component (if exists)
+     * 
+     * tMarkLogicBulkLoad has 1 new property: useExternalMLCP (when true - call commandline process as before).
      */
     @Override
     protected void processUnmappedElementParameter(Properties props, NodeType nodeType, GenericElementParameter param,


### PR DESCRIPTION
* Remain cmd mode of marklogic bulkload in jobs migrated from javajet

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**

Extend marklogic migration task to set 'use external mlcp' to true after migration

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Migration task for
https://github.com/Talend/components/pull/1164

