### PR TITLE
TESB-20833: Change maven to online when build OSGi type

### DIFF
--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/handler/BuildOSGiBundleHandler.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/handler/BuildOSGiBundleHandler.java
@@ -33,6 +33,7 @@ import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.talend.commons.CommonsPlugin;
 import org.talend.commons.exception.ExceptionHandler;
 import org.talend.core.model.properties.ProcessItem;
 import org.talend.designer.maven.model.MavenSystemFolders;
@@ -99,7 +100,11 @@ public class BuildOSGiBundleHandler extends BuildJobHandler {
      */
     @Override
     public void build(IProgressMonitor monitor) throws Exception {
+        // Change to maven online,
+        // @see MavenCommandLauncher.createLaunchConfiguration(IContainer basedir, String goal)
+        CommonsPlugin.setESBMicorservice(true);
         super.build(monitor);
+        CommonsPlugin.setESBMicorservice(false);
     }
 
     private IFile getTargetFile(String path, String fileName, IProgressMonitor monitor) {


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
Maven need change to online manually.

**What is the new behavior?**
Change Maven to online mode when build to OSGi type

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


