### PR TITLE
[TESB-21378] Issues publishing artifacts with Studio commandline

### DIFF
--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/JobErrorsChecker.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/JobErrorsChecker.java
@@ -271,7 +271,9 @@ public class JobErrorsChecker {
         String errorMessage = null;
         try {
             HashSet<JobInfo> jobInfos = new HashSet<>();
-            jobInfos.add(LastGenerationInfo.getInstance().getLastMainJob());
+            if (LastGenerationInfo.getInstance().getLastMainJob() != null) {
+                jobInfos.add(LastGenerationInfo.getInstance().getLastMainJob());
+            }
             for (JobInfo jobInfo : jobInfos) {
                 if (jobInfo.isTestContainer()) {
                     continue;


### PR DESCRIPTION
**What is the current behavior?** 

When attemp to check for build errors is made on the "last main job", when there is no last main job available, an NPE is thrown.


**What is the new behavior?**

Added null pointer check to avoid the NPE


**What kind of change does this PR introduce?**

- [ ] Bugfix

**Does this PR introduce a breaking change?**

- [ ] No

