### PR TITLE
TUP-19810 : Tycho fix

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/pom.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/pom.xml
@@ -48,6 +48,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-clean-plugin</artifactId>
+                                <version>3.0.0</version>
 				<configuration>
 					<filesets>
 						<fileset>

--- a/main/plugins/org.talend.libraries.crm/pom.xml
+++ b/main/plugins/org.talend.libraries.crm/pom.xml
@@ -19,6 +19,7 @@
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-clean-plugin</artifactId>
+            <version>3.0.0</version>
             <configuration>
                 <filesets>
                     <fileset>


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TUP-19810
When building with tycho, these warning shows up : 
<snip>[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-clean-plugin is missing. </snip>
**What is the new behavior?**
no more warning

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [*] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


