### PR TITLE
fix(TDI-40197): Replace wrong fileseparators in tftpfileList

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPFileList/tFTPFileList_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPFileList/tFTPFileList_begin.javajet
@@ -319,7 +319,7 @@ if (sftp) {// *** sftp *** //
 	List<org.apache.commons.net.ftp.FTPFile> fileListTemp_<%=cid %> = new java.util.ArrayList<>();
 
 	<%/*read files*/ %>
-	String remotedir_<%=cid %> = <%=remotedir%>;
+	String remotedir_<%=cid %> = (<%=remotedir%>).replaceAll("\\\\","/");
 	boolean cwdSuccess_<%=cid %> = ftp_<%=cid %>.changeWorkingDirectory(remotedir_<%=cid %>);
 
 	if (!cwdSuccess_<%=cid %>) {
@@ -421,7 +421,7 @@ if (sftp) {// *** sftp *** //
 			log.info("<%=cid%> - Connect to '" + <%=host %> + "' has succeeded.");
 		<%}%>
 	<%}%>
-	String remotedir_<%=cid %> = <%=remotedir%>;
+	String remotedir_<%=cid %> = (<%=remotedir%>).replaceAll("\\\\","/");
 	ftp_<%=cid %>.chdir(remotedir_<%=cid %>);
 	String[] fileList_<%=cid %>;
 


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
tFTPFileList in FTP and FTPS modes doesn't work with windows path separators

**What is the new behavior?**
tFTPFileList works the same as all another FTP components

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


