### PR TITLE
fix(TDI-40170): Add HANA support to tJDBCSCDELT

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tJDBCSCDELT/sap_hana.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tJDBCSCDELT/sap_hana.javajet
@@ -1,0 +1,178 @@
+<%@ jet%>
+
+<%
+boolean isEnableType1 = ("true").equals(ElementParameterParser.getValue(node, "__USE_L1__"));
+List<Map<String, String>> type1Attributes = new ArrayList<Map<String, String>>();
+if(isEnableType1) {
+    type1Attributes = (List<Map<String, String>>)ElementParameterParser.getObjectValue(node, "__L1_FIELDS__");
+}
+
+boolean isEnableType2 = ("true").equals(ElementParameterParser.getValue(node, "__USE_L2__"));
+List<Map<String, String>> type2Attributes = new ArrayList<Map<String, String>>();
+if(isEnableType2) {
+    type2Attributes = (List<Map<String, String>>)ElementParameterParser.getObjectValue(node, "__L2_FIELDS__");
+}
+
+List<Map<String, String>> sourceKeys = (List<Map<String, String>>)ElementParameterParser.getObjectValue(node, "__SOURCE_KEYS__");
+
+boolean isEqualWithSK = false;
+for(Map<String, String> sk : sourceKeys) {
+    if(surrogateKey.equals(sk.get("NAME"))) {
+        isEqualWithSK = true;
+        break;
+    }
+}
+
+boolean isFieldValueIncNull = ("true").equals(ElementParameterParser.getValue(node, "__FIELD_VALUE_INC_NULL__"));
+
+List<String> joinClause = new ArrayList<String>();
+for(Map<String, String> sk : sourceKeys) {
+    joinClause.add(" d." + text_util.wrap(sk.get("NAME")) + " = t." + text_util.wrap(sk.get("NAME")));
+}
+String joinClauseString = StringUtils.join(joinClause.toArray(), " AND ");
+
+String strFieldName = "";
+String selectColumnString = "";
+String columnNameString = "";
+
+if(isEnableType1) {
+    List<String> columnNames = new ArrayList<String>();
+    List<String> setColumns = new ArrayList<String>();
+    List<String> whereClause = new ArrayList<String>();
+    for(Map<String, String> sk : sourceKeys) {
+        if(isEqualWithSK) {
+            if(!sk.get("NAME").equals(surrogateKey)) {
+                columnNames.add(text_util.wrap(sk.get("NAME")));
+            }
+        } else {
+            columnNames.add(text_util.wrap(sk.get("NAME")));
+        }
+    }
+    for(Map<String, String> type1Attribute : type1Attributes) {
+    	strFieldName = text_util.wrap(type1Attribute.get("NAME"));
+        columnNames.add(strFieldName);
+        setColumns.add(" " + strFieldName + " = t." + strFieldName);
+        if(isFieldValueIncNull){
+            whereClause.add("( d." + strFieldName + " is null AND t." + strFieldName + " is not null )");
+        	whereClause.add("( d." + strFieldName + " is not null AND t." + strFieldName + " is null )");
+       	}
+        whereClause.add("( d." + strFieldName + " <> t." + strFieldName+")");
+    }
+    selectColumnString = StringUtils.join(columnNames.toArray(), ", t.");
+    columnNameString = StringUtils.join(columnNames.toArray(), ", ");
+    String setColumnsString = StringUtils.join(setColumns.toArray(), ", ");
+    String whereClauseString = StringUtils.join(whereClause.toArray(), " OR ");
+    %>
+    String updateForType1_<%=cid%> = "UPDATE d SET <%=setColumnsString%> FROM <%=text_util.wrap("tableName", cid)%> d, <%=text_util.wrap("sourceTable", cid)%> t WHERE <%=joinClauseString%> AND (<%=whereClauseString%>)";
+    
+    java.sql.Statement stmtType1Update_<%=cid%> = conn_<%=cid%>.createStatement();
+    stmtType1Update_<%=cid%>.executeUpdate(updateForType1_<%=cid%>);
+    stmtType1Update_<%=cid%>.close();
+    <%
+    if(isEnableDebug) {
+        %>
+        System.out.println("[<%=cid%>] type1 update sql\n" + updateForType1_<%=cid%> + "\ndone");
+        <%
+    }
+}
+
+String startDateField = ElementParameterParser.getValue(node,"__L2_STARTDATE_FIELD__");
+String endDateField = ElementParameterParser.getValue(node,"__L2_ENDDATE_FIELD__");
+boolean isEnableActive = ("true").equals(ElementParameterParser.getValue(node,"__USE_L2_ACTIVE__"));
+String activeField = ElementParameterParser.getValue(node,"__L2_ACTIVE_FIELD__");
+boolean isEnableVersion = ("true").equals(ElementParameterParser.getValue(node,"__USE_L2_VERSION__"));
+String versionField = ElementParameterParser.getValue(node,"__L2_VERSION_FIELD__");
+
+boolean useSequence = "DB_SEQUENCE".equals(surrogateKeyType);
+String sequenceName = ElementParameterParser.getValue(node,"__SK_DB_SEQUENCE__");
+
+if(isEnableType2) {
+    List<String> whereClause = new ArrayList<String>();
+    for (Map<String, String> type2Attribute : type2Attributes) {
+        strFieldName = text_util.wrap(type2Attribute.get("NAME"));
+    	if(isFieldValueIncNull){
+        	whereClause.add("( d." + strFieldName + " is null AND t." + strFieldName + " is not null )");
+        	whereClause.add("( d." + strFieldName + " is not null AND t." + strFieldName + " is null )");
+     	}
+        whereClause.add("( d." + strFieldName + " <> t." + strFieldName+")");
+    }
+    String whereClauseString = StringUtils.join(whereClause.toArray(), " OR ");
+    %>        
+    String changeDateTime_<%=cid%> = (new java.sql.Timestamp((Long)start_Hash.get("<%=cid %>"))).toString();
+	
+    String updateForType2_<%=cid %> = "UPDATE d SET <%=text_util.wrap(endDateField)%> = '" + (changeDateTime_<%=cid%>) + "'<%if (isEnableActive) {%>, <%=text_util.wrap(activeField)%> = 0<%}%> FROM  <%=text_util.wrap("tableName", cid)%> d, <%=text_util.wrap("sourceTable", cid)%> t WHERE <%=joinClauseString%> AND (<%=whereClauseString%>) AND d.<%=text_util.wrap(endDateField)%> IS NULL"; 
+    <%
+    if(isEnableDebug) {
+        %>
+        System.out.println("[<%=cid%>] type2 update sql\n" + updateForType2_<%=cid%> + "\ndone");
+        <%
+    } %>
+ 
+    java.sql.Statement stmtType2Update_<%=cid%> = conn_<%=cid%>.createStatement();
+    stmtType2Update_<%=cid%>.executeUpdate(updateForType2_<%=cid%>);
+    stmtType2Update_<%=cid%>.close();
+    <%
+    if(isEnableDebug) {
+        %>
+        System.out.println("[<%=cid%>] type2 update sql\n" + updateForType2_<%=cid%> + "\ndone");
+        <%
+    }
+    List<String> columnNames = new ArrayList<String>();
+    for(Map<String, String> sourceKey : sourceKeys) {
+        if(isEqualWithSK) {
+            if(!sourceKey.get("NAME").equals(surrogateKey)) {
+                columnNames.add(text_util.wrap(sourceKey.get("NAME")));
+            }
+        } else {
+            columnNames.add(text_util.wrap(sourceKey.get("NAME")));                
+        }
+    }
+    for(Map<String, String> type1Attribute : type1Attributes) {
+        columnNames.add(text_util.wrap(type1Attribute.get("NAME")));
+    }
+    for(Map<String, String> type2Attribute : type2Attributes) {
+        columnNames.add(text_util.wrap(type2Attribute.get("NAME")));
+    }
+    selectColumnString = StringUtils.join(columnNames.toArray(), ", t.");
+    columnNames.add(text_util.wrap(startDateField));
+    columnNames.add(text_util.wrap(endDateField));
+    if(isEnableActive) {
+        columnNames.add(text_util.wrap(activeField));
+    }
+    if(isEnableVersion) {
+        columnNames.add(text_util.wrap(versionField));
+    }
+    columnNameString = StringUtils.join(columnNames.toArray(), ", ");
+    %>
+    String insertForType2_<%=cid%> = "INSERT INTO <%=text_util.wrap("tableName", cid)%> (<%if(useSequence) {%><%=text_util.wrap(surrogateKey)%>, <%}%><%=columnNameString%>) SELECT " + <%if(useSequence) {%>sequenceValueFetchPattern_<%=cid%> + ", " + <%}%>" t.<%=selectColumnString%>, '" + 
+    (changeDateTime_<%=cid%>) + "', NULL<%if(isEnableActive) {%>, 1<%}%><%if(isEnableVersion) {%>, d.<%=text_util.wrap(versionField)%> + 1<%}%> FROM <%=text_util.wrap("sourceTable", cid)%> t, <%=text_util.wrap("tableName", cid)%> d WHERE <%=joinClauseString%> AND (<%=whereClauseString%>) AND d.<%=text_util.wrap(endDateField)%> = '" + (changeDateTime_<%=cid%>) + "'";
+    java.sql.Statement stmtType2Insert_<%=cid%> = conn_<%=cid%>.createStatement();
+    stmtType2Insert_<%=cid%>.executeUpdate(insertForType2_<%=cid%>);
+    stmtType2Insert_<%=cid%>.close();
+    <%
+    if(isEnableDebug) {
+        %>
+        System.out.println("[<%=cid%>] type2 new active row slq\n" + insertForType2_<%=cid %> + "\ndone");
+        <%
+    }
+}
+
+List<String> outerWhereClause = new ArrayList<String>();
+for (Map<String, String> sk : sourceKeys) {
+    outerWhereClause.add(" d." + text_util.wrap(sk.get("NAME")) + " IS NULL");
+}
+String outerWhereClauseString = StringUtils.join(outerWhereClause.toArray(), " AND ");
+%>
+String insert_<%=cid%> = "INSERT INTO <%=text_util.wrap("tableName", cid)%> (<%if(useSequence) {%><%=text_util.wrap(surrogateKey)%>, <%}%><%=columnNameString%>) SELECT " + <%if(useSequence) {%>sequenceValueFetchPattern_<%=cid%> + ", " + <%}%>" t.<%=selectColumnString%>"<%if(isEnableType2) {%> + ", '" + (changeDateTime_<%=cid%>) + "', NULL"<%}%>
++ "<%if(isEnableType2 && isEnableActive) {%>, 1<%}%><%if(isEnableType2 && isEnableVersion) {%>, 1<%}%> FROM <%=text_util.wrap("sourceTable", cid)%> t LEFT JOIN <%=text_util.wrap("tableName", cid)%> d ON <%=joinClauseString%> WHERE (<%=outerWhereClauseString%>)";
+
+java.sql.Statement stmtInsert_<%=cid%> = conn_<%=cid%>.createStatement();
+stmtInsert_<%=cid%>.executeUpdate(insert_<%=cid%>);
+stmtInsert_<%=cid%>.close();
+<%
+if(isEnableDebug) {
+    %>
+    System.out.println("[<%=cid%>] new rows sql\n" + insert_<%=cid %> + "\ndone");
+    <%
+}
+%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tJDBCSCDELT/sap_hana.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tJDBCSCDELT/sap_hana.javajet
@@ -63,7 +63,7 @@ if(isEnableType1) {
     String setColumnsString = StringUtils.join(setColumns.toArray(), ", ");
     String whereClauseString = StringUtils.join(whereClause.toArray(), " OR ");
     %>
-    String updateForType1_<%=cid%> = "UPDATE d SET <%=setColumnsString%> FROM <%=text_util.wrap("tableName", cid)%> d, <%=text_util.wrap("sourceTable", cid)%> t WHERE <%=joinClauseString%> AND (<%=whereClauseString%>)";
+    String updateForType1_<%=cid%> = "UPDATE <%=text_util.wrap("tableName", cid)%> d SET <%=setColumnsString%> FROM <%=text_util.wrap("tableName", cid)%> d, <%=text_util.wrap("sourceTable", cid)%> t WHERE <%=joinClauseString%> AND (<%=whereClauseString%>)";
     
     java.sql.Statement stmtType1Update_<%=cid%> = conn_<%=cid%>.createStatement();
     stmtType1Update_<%=cid%>.executeUpdate(updateForType1_<%=cid%>);
@@ -100,13 +100,7 @@ if(isEnableType2) {
     %>        
     String changeDateTime_<%=cid%> = (new java.sql.Timestamp((Long)start_Hash.get("<%=cid %>"))).toString();
 	
-    String updateForType2_<%=cid %> = "UPDATE d SET <%=text_util.wrap(endDateField)%> = '" + (changeDateTime_<%=cid%>) + "'<%if (isEnableActive) {%>, <%=text_util.wrap(activeField)%> = 0<%}%> FROM  <%=text_util.wrap("tableName", cid)%> d, <%=text_util.wrap("sourceTable", cid)%> t WHERE <%=joinClauseString%> AND (<%=whereClauseString%>) AND d.<%=text_util.wrap(endDateField)%> IS NULL"; 
-    <%
-    if(isEnableDebug) {
-        %>
-        System.out.println("[<%=cid%>] type2 update sql\n" + updateForType2_<%=cid%> + "\ndone");
-        <%
-    } %>
+    String updateForType2_<%=cid %> = "UPDATE <%=text_util.wrap("tableName", cid)%> d SET <%=text_util.wrap(endDateField)%> = '" + (changeDateTime_<%=cid%>) + "'<%if (isEnableActive) {%>, <%=text_util.wrap(activeField)%> = 0<%}%> FROM  <%=text_util.wrap("tableName", cid)%> d, <%=text_util.wrap("sourceTable", cid)%> t WHERE <%=joinClauseString%> AND (<%=whereClauseString%>) AND d.<%=text_util.wrap(endDateField)%> IS NULL"; 
  
     java.sql.Statement stmtType2Update_<%=cid%> = conn_<%=cid%>.createStatement();
     stmtType2Update_<%=cid%>.executeUpdate(updateForType2_<%=cid%>);

--- a/main/plugins/org.talend.designer.components.localprovider/components/tJDBCSCDELT/tJDBCSCDELT_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tJDBCSCDELT/tJDBCSCDELT_begin.javajet
@@ -178,6 +178,8 @@ String sequenceValueFetchPattern_<%=cid%> = "NEXT VALUE FOR <%=text_util.wrap("s
 	<%@ include file="./common_scd_pattern2.javajet"%>
 <%} else if("vertica_id".equals(dbmsId)){%>
 	<%@ include file="./vertica.javajet"%>
+<%} else if("saphana_id".equals(dbmsId)){%>
+    <%@ include file="./sap_hana.javajet"%>
 <%} else {%>
 	<%@ include file="./common_scd_pattern1.javajet"%>
 <%}%>


### PR DESCRIPTION
Adding support for SAP Hana.
Amended the begin template to conditionally include SAP Hana specific template if the appropriate mapping is selected.
Added a SAP HANA specific javajet template,

**What is the current behavior?** (You can also link to an open issue here)
When HANA mapping is selected the component generates SQL that is incompatible with SAP HANA.
See - TDI-40170
**What is the new behavior?**
Adding support for SAP Hana.
Amended the begin template to conditionally include SAP Hana specific template if the appropriate mapping is selected.
Added a SAP HANA specific javajet template,

When HANA is selected as mapping the correct SQL is generated. 

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


