### PR TITLE
fix(TDI-40217) tMSSqlOutput component fails while writing exponential notation data using Dynamic Schema

### DIFF
--- a/main/plugins/org.talend.designer.codegen/jet_stub/generic/component_util_indexedrecord_to_rowstruct.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/generic/component_util_indexedrecord_to_rowstruct.javajet
@@ -144,6 +144,8 @@ class IndexedRecordToRowStructGenerator {
                         talendType_<%=cid%> = "<%=JavaTypesManager.FLOAT.getId()%>";
                     } else if (type_<%=cid%> == org.apache.avro.Schema.Type.INT) {
                         talendType_<%=cid%> = "<%=JavaTypesManager.INTEGER.getId()%>";
+                    } else if (org.talend.daikon.avro.AvroUtils.isSameType(org.talend.daikon.avro.AvroUtils.unwrapIfNullable(dynamicField_<%=cid%>.schema()),org.talend.daikon.avro.AvroUtils._decimal())) {
+                        talendType_tSalesforceInput_1 = "<%=JavaTypesManager.BIGDECIMAL.getId()%>";
                     } else if (type_<%=cid%> == org.apache.avro.Schema.Type.LONG) {
                     	String pattern_<%=cid%> = dynamicField_<%=cid%>.getProp(org.talend.daikon.avro.SchemaConstants.TALEND_COLUMN_PATTERN);
                     	if(pattern_<%=cid%>!=null && !pattern_<%=cid%>.trim().isEmpty()){


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
For JIRA: https://jira.talendforge.org/browse/TDI-40217
When Avro convert to DI for dynamic, the bigdecimal type didn't have correct mapping.
It map to String type.

**What is the new behavior?**

Add correct mapping for bigdecimal type

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No


