### PR TITLE
fix: fix reject schema name

### DIFF
--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/SettingsCreator.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/SettingsCreator.java
@@ -319,12 +319,10 @@ public class SettingsCreator implements PropertyVisitor {
 
     private TaCoKitElementParameter visitSchema(final PropertyNode node) {
         final String connectorName = node.getProperty().getConnection().getValue();
-        final EConnectionType connectorType = connectorName.equalsIgnoreCase("reject") ? EConnectionType.REJECT
-                : EConnectionType.FLOW_MAIN;
         final String connectionName;
         if (connectorName.equals("__default__")) {
             connectionName = EConnectionType.FLOW_MAIN.getName();
-        } else if (connectorType == EConnectionType.REJECT) {
+        } else if (connectorName.equalsIgnoreCase(EConnectionType.REJECT.getName())) {
             connectionName = EConnectionType.REJECT.getName();
         } else {
             connectionName = connectorName;

--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/SettingsCreator.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/SettingsCreator.java
@@ -319,8 +319,16 @@ public class SettingsCreator implements PropertyVisitor {
 
     private TaCoKitElementParameter visitSchema(final PropertyNode node) {
         final String connectorName = node.getProperty().getConnection().getValue();
-        final String connectionName =
-                connectorName.equals("__default__") ? EConnectionType.FLOW_MAIN.getName() : connectorName;
+        final EConnectionType connectorType = connectorName.equalsIgnoreCase("reject") ? EConnectionType.REJECT
+                : EConnectionType.FLOW_MAIN;
+        final String connectionName;
+        if (connectorName.equals("__default__")) {
+            connectionName = EConnectionType.FLOW_MAIN.getName();
+        } else if (connectorType == EConnectionType.REJECT) {
+            connectionName = EConnectionType.REJECT.getName();
+        } else {
+            connectionName = connectorName;
+        }
         final String schemaName = node.getProperty().getSchemaName();
         return createSchemaParameter(connectionName, schemaName, true);
     }


### PR DESCRIPTION
* Use REJECT connector name for reject schemas

**What is the current behavior?** (You can also link to an open issue here)
Reject schema is not set for reject connectors, due to difference of connector name for reject schema and and existing REJECT connector name.

**What is the new behavior?**
Reject schema connector name is always set to REJECT

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Schema was not set to configuration for processor components. 

