### PR TITLE
TESB-21702 Excluding camel-talendjob from OSGi pkg

### DIFF
--- a/main/plugins/org.talend.repository/resources/osgi-exclude.properties
+++ b/main/plugins/org.talend.repository/resources/osgi-exclude.properties
@@ -2,6 +2,7 @@
 # format: [module_name_start_with] # [comment]
 
 camel-core # org.talend.camel.testcontainer
+camel-talendjob 
 
 # SalesForce
 slf4j


### PR DESCRIPTION
At this moment we have ClassCastException in Runtime  because of "camel-talendjob" package is included to generatd OSGi bundle (Runtime has this library also)

