### PR TITLE
fix(TDI-40321): The query clause, externalTableRejectOptions, is always generated even reject options is not checked

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tSQLDWHBulkExec/tSQLDWHBulkExec_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSQLDWHBulkExec/tSQLDWHBulkExec_begin.javajet
@@ -273,13 +273,16 @@ skeleton="../templates/db_output_bulk.skeleton"
     } else {
         tableName_<%=cid%> = dbschema_<%=cid%> + "].[" + <%=table%>;
     }
-
-    externalTableRejectOptions_<%=cid%> = "REJECT_TYPE = <%=rejectType%>" + ",REJECT_VALUE = " + <%=rejectValue%>;
 <%
-    if("Percentage".equals(rejectType)){
+    if(isEnabledExtTableOptions){
 %>
-        externalTableRejectOptions_<%=cid%> += ",REJECT_SAMPLE_VALUE = " + <%=rejectSampleValue%>;
+        externalTableRejectOptions_<%=cid%> = "REJECT_TYPE = <%=rejectType%>" + ",REJECT_VALUE = " + <%=rejectValue%>;
+<%
+        if("Percentage".equals(rejectType)){
+%>
+            externalTableRejectOptions_<%=cid%> += ",REJECT_SAMPLE_VALUE = " + <%=rejectSampleValue%>;
 <%    
+        }
     }
 
     if(("DROP_CREATE").equals(tableAction) || ("CREATE").equals(tableAction) || ("CREATE_IF_NOT_EXISTS").equals(tableAction) || ("DROP_IF_EXISTS_AND_CREATE").equals(tableAction)) {   


### PR DESCRIPTION

**What is the current behavior?** (You can also link to an open issue here)
For JIRA: https://jira.talendforge.org/browse/TDI-40321
The query clause, externalTableRejectOptions, is always generated even reject options is not checked

**What is the new behavior?**

Ungenerated those code when `externalTableRejectOptions` unchecked

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

