### PR TITLE
fix(TUP-19921) set correctly MR Required flags

### DIFF
--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/JavaProcessUtil.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/JavaProcessUtil.java
@@ -83,6 +83,7 @@ public class JavaProcessUtil {
 
         Set<String> dedupModulesList = new HashSet<String>();
         Iterator<ModuleNeeded> it = modulesNeeded.iterator();
+        ModuleNeeded previousModule = null;
         while (it.hasNext()) {
             ModuleNeeded module = it.next();
             // try to keep only real files (with extension, no matter be jar or other)
@@ -90,9 +91,13 @@ public class JavaProcessUtil {
             if (!module.getModuleName().contains(".")) { //$NON-NLS-1$
                 it.remove();
             } else if (dedupModulesList.contains(module.getModuleName())) {
+                if (module.isMrRequired() && previousModule != null && previousModule.getModuleName().equals(module.getModuleName())) {
+                    previousModule.setMrRequired(Boolean.TRUE);
+                }
                 it.remove();
             } else {
                 dedupModulesList.add(module.getModuleName());
+                previousModule = module;
             }
         }
 


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
MR Required flag is not set for every module for now, only some.
The order doesn't set them especially as first (it might have some esb definition module without MR Required)

**What is the new behavior?**
Simply apply MR Required flag to other modules with the same name, to ensure to have the correct flag.