### PR TITLE
fix(TCOMP-755): fix sync columns issue

### DIFF
--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/cmd/ChangeMetadataCommand.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/cmd/ChangeMetadataCommand.java
@@ -642,9 +642,20 @@ public class ChangeMetadataCommand extends Command {
      */
     private boolean hasSameSchema(final INodeConnector connector) {
         return (!connector.getName().equals(currentConnector)) && connector.getBaseSchema().equals(currentConnector)
-                && !(connector instanceof IAdditionalInfo);
+                && !isTacokit(connector);
     }
-
+    
+    /**
+     * Checks whethere specified INodeConnector is Tacokit connector
+     * 
+     * @param connector node connecto to check
+     * @return true if it is Tacokit connector
+     */
+    private boolean isTacokit(final INodeConnector connector) {
+        return (IAdditionalInfo.class.isInstance(connector))
+                && "tacokit".equals(IAdditionalInfo.class.cast(connector).getInfo("CONNECTOR_TYPE"));
+    }
+    
     private void updateComponentSchema(INode selectedNode, IMetadataTable table) {
         IGenericWizardService wizardService = null;
         if (GlobalServiceRegister.getDefault().isServiceRegistered(IGenericWizardService.class)) {


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

"Sync columns" button pushed for FLOW schema also updates REJECT schema which correct for javaject and TCOMP components, but is not correct for Tacokit components.

**What is the new behavior?**

"Sync columns" button pushed for FLOW schema doesn't updates REJECT schema for Tacokit components. For javajet and TCOMP components behavior remains the same.

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
https://jira.talendforge.org/browse/TCOMP-755

