### PR TITLE
fix (TUP-20007) : set a correct category

### DIFF
--- a/main/plugins/org.talend.designer.runtime.visualization.tools/plugin.xml
+++ b/main/plugins/org.talend.designer.runtime.visualization.tools/plugin.xml
@@ -34,7 +34,7 @@
    <extension
          point="org.eclipse.ui.preferencePages">
       <page
-            category="org.talend.designer.runtime.visualization.internal.ui.JavaMonitorPreferencePage"
+            category="org.talend.core.prefs"
             class="org.talend.designer.runtime.visualization.internal.tools.ToolsPreferencePage"
             id="org.talend.designer.runtime.visualization.internal.tools.ToolsPreferencePage"
             name="Tools">


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TUP-20007

**What is the new behavior?**
'Tools' peference page is now located in the 'Talend' category

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


