### PR TITLE
TESB-21832 Problems with job/route exec. with local runtime in Studio

### DIFF
--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/IESBRunContainerService.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/IESBRunContainerService.java
@@ -24,8 +24,6 @@ import org.talend.designer.runprocess.java.JavaProcessor;
  */
 public interface IESBRunContainerService extends IService {
 
-    void enableRuntime(boolean valueOf);
-
     boolean isRuntimeEnable();
 
     JavaProcessor createJavaProcessor(IProcess process, Property property, boolean filenameFromLabel);

--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/RunProcessContext.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/RunProcessContext.java
@@ -191,8 +191,6 @@ public class RunProcessContext {
 
     private List<PerformanceMonitor> perMonitorList = new ArrayList<PerformanceMonitor>();
 
-    protected IProcessor processor;
-
     /** trace mananger */
     private TraceConnectionsManager traceConnectionsManager;
 
@@ -735,11 +733,8 @@ public class RunProcessContext {
      * @return
      */
     protected IProcessor getProcessor(IProcess process, Property property) {
-        if (processor == null) {
-            processor = ProcessorUtilities.getProcessor(process, property);
+        return ProcessorUtilities.getProcessor(process, property);
         }
-        return processor;
-    }
 
     public synchronized int kill() {
         return kill(null);
@@ -859,7 +854,7 @@ public class RunProcessContext {
     }
 
     private boolean isESBRuntimeProcessor() {
-        return "runtimeProcessor".equals(processor.getProcessorType()); //$NON-NLS-1$
+        return "runtimeProcessor".equals(getProcessor(process, process.getProperty()).getProcessorType()); //$NON-NLS-1$
     }
 
     // private int getWatchPort() {


### PR DESCRIPTION
Local runtime for Studio job/routes execution should not be used in some
cases: build type has to be checked to define the best execution
processor. As execution processor must change when build type is updated
in deployment tab, processor can not be persisted anymore.

**What is the current behavior?**
Persisted "processor" class variable was returned in getProcessor method. But "processor" instance was sometimes unappropriate as build type can be changed in deployment tab without closing & reopening process editor.

**What is the new behavior?**
Now processor is (re)calculated at each getProcessor call.

**What kind of change does this PR introduce?**

- [ x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x ] No
