### PR TITLE
TESB-21804: Filter out camel-alldeps in MANIFEST for OSGi type export

### DIFF
--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/build/StandardJobOSGiBundleBuildProvider.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/build/StandardJobOSGiBundleBuildProvider.java
@@ -47,7 +47,7 @@ public class StandardJobOSGiBundleBuildProvider extends RepositoryObjectTypeBuil
     private static final List<String> ESB_COMPONENTS;
     static {
         final List<String> esbComponents = Arrays.asList("tESBProviderRequest", "tRESTClient", "tRESTRequest", "tRESTResponse",
-                "tESBConsumer", "tESBProviderFault", "tESBProviderRequest", "tESBProviderResponse", "tRouteInput");
+                "tESBConsumer", "tESBProviderFault", "tESBProviderRequest", "tESBProviderResponse", "tRouteInput", "tREST");
         ESB_COMPONENTS = Collections.unmodifiableList(esbComponents);
     }
 

--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/esb/JobJavaScriptOSGIForESBManager.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/esb/JobJavaScriptOSGIForESBManager.java
@@ -715,6 +715,10 @@ public class JobJavaScriptOSGIForESBManager extends JobJavaScriptsManager {
         for (String path : relativePathList) {
             Set<URL> resources = libResource.getResourcesByRelativePath(path);
             for (URL url : resources) {
+                // TESB-21804:Fail to deploy cMessagingEndpoint with quartz component in runtime for ClassCastException
+                if (url.getPath().matches("(.*)camel-(.*)-alldep-(.*)$")) {
+                    continue;
+                }
                 File dependencyFile = new File(FilesUtils.getFileRealPath(url.getPath()));
                 String relativePath = libResource.getDirectoryName() + PATH_SEPARATOR + dependencyFile.getName();
                 bundleClasspath.append(MANIFEST_ITEM_SEPARATOR).append(relativePath);


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
Kar file run failed in ESB Runtime for the camel-alldeps libraries are confilct

**What is the new behavior?**
Filter out camel-alldeps in MANIFEST for OSGi type export

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


