### PR TITLE
fix(TDI-40464): fix column mapping in servicenowInput component.

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tServiceNowInput/tServiceNowInput_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tServiceNowInput/tServiceNowInput_main.javajet
@@ -48,6 +48,7 @@ if(columnList==null || columnList.isEmpty() || outgoingConns == null || outgoing
 IConnection outgoingConn = outgoingConns.get(0);
 %>
 
+
 nb_line_<%=cid%>++;
 <%=cid%>_result = (org.json.JSONObject) <%=cid%>_resultArray.get(<%=cid%>_i);
 <%
@@ -57,6 +58,9 @@ for (int i = 0; i < columnList.size(); i++) {
 	JavaType javaType = JavaTypesManager.getJavaTypeFromId(column.getTalendType());
 	String pattern = column.getPattern() == null || column.getPattern().trim().length() == 0 ? null : column.getPattern();
 	
+%>
+	<%=outgoingConn.getName()%>.<%=column.getLabel()%> = null; // reset row value
+<%	
 	if("id_Dynamic".equals(column.getTalendType())) {
 %>
 		dynamic_<%=cid %>.clearColumnValues();


### PR DESCRIPTION
with more than one result, tServicenownput returns bad data for resolved_at and closed_at fields

**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-40464

**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


