### PR TITLE
fix(TDI-40495): avoid NPE when LEAD_SELECTOR does not exist

### DIFF
--- a/main/plugins/org.talend.designer.core.generic/src/main/java/org/talend/designer/core/generic/model/migration/NewMarketoMigrationTask.java
+++ b/main/plugins/org.talend.designer.core.generic/src/main/java/org/talend/designer/core/generic/model/migration/NewMarketoMigrationTask.java
@@ -46,8 +46,12 @@ public class NewMarketoMigrationTask extends NewComponentFrameworkMigrationTask 
         // Parameter is unassigned, so "LEAD_SELECTOR" parameter isn't processed yet.
         if ("LEAD_SELECTOR_REST".equals(paramName) && paramType == null) {
             ElementParameterType leadSelector = ParameterUtilTool.findParameterType(node, "LEAD_SELECTOR");
-            Object selValue = ParameterUtilTool.convertParameterValue(leadSelector);
-            ParameterUtilTool.addParameterType(node, "CLOSED_LIST", "LEAD_SELECTOR_REST", String.valueOf(selValue));
+            String lksel = "LeadKeySelector";
+            if (leadSelector != null) {
+                Object selValue = ParameterUtilTool.convertParameterValue(leadSelector);
+                lksel = String.valueOf(selValue);
+            }
+            ParameterUtilTool.addParameterType(node, "CLOSED_LIST", "LEAD_SELECTOR_REST", lksel);
             paramType = ParameterUtilTool.findParameterType(node, paramName);
         }
         //


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

https://jira.talendforge.org/browse/TDI-40495

**What is the new behavior?**

avoid NPE when LEAD_SELECTOR does not exist

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


