### PR TITLE
fix(TESB-22036): Add read access to list of bundles in FeaturesModel.

### DIFF
--- a/main/plugins/org.talend.designer.publish.core/src/org/talend/designer/publish/core/models/FeaturesModel.java
+++ b/main/plugins/org.talend.designer.publish.core/src/org/talend/designer/publish/core/models/FeaturesModel.java
@@ -73,6 +73,10 @@ public class FeaturesModel extends BaseModel {
         return subBundles.add(model);
     }
 
+    public Collection<FeatureModel> getFeatures() {
+        return subFeatures;
+    }
+
     public Collection<BundleModel> getBundles() {
         return subBundles;
     }


### PR DESCRIPTION
Read access to the bundles included in a feature is required in order to determine which dependency modules are bundles and should therefore not be physically included in the route bundle.

**What is the current behavior?** (You can also link to an open issue here)
TESB-22036

**What is the new behavior?**
get accessor added

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


