### PR TITLE
fix(TDI-40513): Fix compile error for concated strings in FileName

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPFileProperties/tFTPFileProperties_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPFileProperties/tFTPFileProperties_begin.javajet
@@ -308,7 +308,7 @@ if (sftp) {  // *** sftp *** //
 	org.apache.commons.net.ftp.FTPFile expectedFile_<%=cid %> = null;
 
 	for (org.apache.commons.net.ftp.FTPFile file_<%=cid %> : allFiles_<%=cid %>) {
-		if (<%=filename%>.equals(file_<%=cid %>.getName())) {
+		if ((<%=filename%>).equals(file_<%=cid %>.getName())) {
 			expectedFile_<%=cid %> = file_<%=cid %>;
 			break;
 		}


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
Job with tFTPProperties doesn't compile when fileName property is complex (2 or more concatenated strings)

**What is the new behavior?**
Job with tFTPProperties compiles when fileName property is complex (2 or more concatenated strings)

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


