### PR TITLE
fix(TESB-22034): Fix handling of non-required bean deps in routes.

### DIFF
--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/ConfigExternalLib/LibraryField.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/ConfigExternalLib/LibraryField.java
@@ -21,8 +21,11 @@ import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
+import org.eclipse.swt.widgets.TableItem;
 import org.talend.commons.ui.runtime.image.ECoreImage;
 import org.talend.commons.ui.runtime.image.ImageProvider;
 import org.talend.designer.core.model.utils.emf.component.IMPORTType;
@@ -35,6 +38,8 @@ import org.talend.repository.i18n.Messages;
  * 
  */
 public class LibraryField extends TableField {
+
+    private boolean readOnly;
 
     /**
      * DOC tguiu StatusEditor constructor comment.
@@ -49,6 +54,7 @@ public class LibraryField extends TableField {
 
     public LibraryField(String name, Composite parent, boolean isReadOnly) {
         super(name, parent, isReadOnly);
+        this.readOnly = isReadOnly;
     }
 
     @Override
@@ -69,6 +75,23 @@ public class LibraryField extends TableField {
         descriptionColumn.setText(Messages.getString("LibraryField.descriptionColumn")); //$NON-NLS-1$
         descriptionColumn.setWidth(200);
 
+        contextTable.addListener(SWT.MouseUp, new Listener() {
+
+            @Override
+            public void handleEvent(Event event) {
+                if (!readOnly) {
+                    final Table contextTable = (Table) event.widget;
+                    final TableItem item = contextTable.getSelection()[0];
+                    if (item.getBounds(1).contains(event.x, event.y)) {
+                        IMPORTType it = (IMPORTType) getList().get(contextTable.getSelectionIndex());
+                        if ("BeanItem".equals(it.eContainer().eClass().getName())) {
+                            it.setREQUIRED(!it.isREQUIRED());
+                            setInput(getList());
+                        }
+                    }
+                }
+            }
+        });
         return contextTable;
     }
 


### PR DESCRIPTION
The present fix enables selection of the "required" state of bean libraries in the corresponding dialog.

**What is the current behavior?** (You can also link to an open issue here)
Bean dependencies are always handled as required

**What is the new behavior?**
Enable setting of required state

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


