### PR TITLE
TMDM-12258 tMDMOutput get compile issue

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tMDMOutput/tMDMOutput_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMDMOutput/tMDMOutput_main.javajet
@@ -171,7 +171,10 @@ if (metadatas != null && metadatas.size()>0) {
             if (!isStaging && withReport) {%>
                 <% logUtil.debug("\"Put item with report to MDM server.\"");%>
                 
-                org.talend.mdm.webservice.WSPutItemWithReport itemReport_<%=cid %> = new org.talend.mdm.webservice.WSPutItemWithReport(<%=needCheck %>, <%=sourceName %>, item_<%=cid %>);
+                org.talend.mdm.webservice.WSPutItemWithReport itemReport_<%=cid %> = new org.talend.mdm.webservice.WSPutItemWithReport();
+                itemReport_<%=cid %>.setInvokeBeforeSaving(<%=needCheck %>);
+                itemReport_<%=cid %>.setSource(<%=sourceName %>);
+                itemReport_<%=cid %>.setWsPutItem(item_<%=cid %>);
 
                 <%if (isMassInsert) {%>
                     <%if(addTaskID){%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMDMWriteConf/tMDMWriteConf_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMDMWriteConf/tMDMWriteConf_main.javajet
@@ -195,7 +195,10 @@ if (metadatas != null && metadatas.size()>0) {
 
                 <% logUtil.debug("\"Put item to MDM server with full update.\"");%>
 
-                org.talend.mdm.webservice.WSPutItemWithReport itemReport_<%=cid %> = new org.talend.mdm.webservice.WSPutItemWithReport(<%=needCheck %>, <%=sourceName %>, item_<%=cid %>);
+                org.talend.mdm.webservice.WSPutItemWithReport itemReport_<%=cid %> = new org.talend.mdm.webservice.WSPutItemWithReport();
+                itemReport_<%=cid %>.setInvokeBeforeSaving(<%=needCheck %>);
+                itemReport_<%=cid %>.setSource(<%=sourceName %>);
+                itemReport_<%=cid %>.setWsPutItem(item_<%=cid %>);
 
                 <%if (isMassInsert) {%>
                     <%if(addTaskID){%>


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TMDM-12258
After WSPutItemWithReport added 3 attributes, the generated webservice stub changed.
There are 3 parameters for the constructor before, now is 6, so we get the compile error.

**What is the new behavior?**
Use default constructor with no parameters, and set the attributes by setXXX methods.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


