### PR TITLE
fix(TESB-22183): Add support for circular WSDL imports to WSDLLoader.

### DIFF
--- a/main/plugins/org.talend.designer.webservice/src/main/java/org/talend/designer/webservice/ws/wsdlutil/WSDLLocatorImpl.java
+++ b/main/plugins/org.talend.designer.webservice/src/main/java/org/talend/designer/webservice/ws/wsdlutil/WSDLLocatorImpl.java
@@ -42,7 +42,7 @@ public class WSDLLocatorImpl implements WSDLLocator {
     }
 
     public InputSource getBaseInputSource() {
-        GetMethod get = createGedMethod(wsdlUri);
+        GetMethod get = createGetMethod(wsdlUri);
         try {
             httpClient.executeMethod(get);
             InputStream is = get.getResponseBodyAsStream();
@@ -55,11 +55,9 @@ public class WSDLLocatorImpl implements WSDLLocator {
 
     public InputSource getImportInputSource(String parentLocation, String importLocation) {
         try {
-            String contextURI = parentLocation;
-            URL contextURL = (contextURI != null) ? getURL(null, contextURI) : null;
-            URL url = getURL(contextURL, importLocation);
+            URL url = getURL(parentLocation, importLocation);
             latestImportUri = url.toExternalForm();
-            GetMethod get = createGedMethod(latestImportUri);
+            GetMethod get = createGetMethod(latestImportUri);
             httpClient.executeMethod(get);
             InputStream is = get.getResponseBodyAsStream();
             inputStreams.add(is);
@@ -69,6 +67,11 @@ public class WSDLLocatorImpl implements WSDLLocator {
         } catch (IOException ex) {
             throw new RuntimeException(ex);
         }
+    }
+
+    public static URL getURL(String parentLocation, String wsdlLocation) throws MalformedURLException {
+        URL contextURL = (parentLocation != null) ? getURL((String) null, parentLocation) : null;
+        return getURL(contextURL, wsdlLocation);
     }
 
     private static URL getURL(URL contextURL, String spec) throws MalformedURLException {
@@ -105,7 +108,7 @@ public class WSDLLocatorImpl implements WSDLLocator {
         inputStreams.clear();
     }
 
-    private GetMethod createGedMethod(String uri) {
+    private GetMethod createGetMethod(String uri) {
         GetMethod get = new GetMethod(uri);
         if (configuration.getCookie() != null) {
             get.setRequestHeader(HTTP_HEADER_COOKIE, configuration.getCookie());

--- a/test/plugins/org.talend.designer.webservice.test/src/org/talend/designer/webservice/test/ServiceDiscoveryHelperTest.java
+++ b/test/plugins/org.talend.designer.webservice.test/src/org/talend/designer/webservice/test/ServiceDiscoveryHelperTest.java
@@ -1,0 +1,62 @@
+package org.talend.designer.webservice.test;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.wsdl.Definition;
+//============================================================================
+//
+//Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+//
+//This source code is available under agreement available at
+//%InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+//You should have received a copy of the agreement
+//along with this program; if not, write to Talend SA
+//9 rue Pages 92150 Suresnes, France
+//
+//============================================================================
+import javax.wsdl.Import;
+
+import org.junit.Test;
+import org.talend.designer.webservice.ws.wsdlutil.ServiceDiscoveryHelper;
+
+public class ServiceDiscoveryHelperTest {
+
+	private static final String MAIN_DEF_NAMESPACE = "http://www.talend.org/service/";
+	private static final String BINDING_DEF_NAMESPACE = "http://www.talend.org/service/binding/";
+
+	@Test
+	public void testCircularDependencyLoading() throws Exception {
+		String wsdlLocation = getClass().getResource("TestService.wsdl").toExternalForm();
+		ServiceDiscoveryHelper helper = new ServiceDiscoveryHelper(wsdlLocation);
+		List<Definition> definitions = helper.getDefinitions();
+		assertNotNull(definitions);
+		assertEquals(2, definitions.size());
+		Definition mainDef = definitions.get(0);
+		assertEquals(MAIN_DEF_NAMESPACE, mainDef.getTargetNamespace());
+		Map<?, ?> mainDefImports = mainDef.getImports();
+		assertNotNull(mainDefImports);
+		assertEquals(1, mainDefImports.size());
+		List<?> bindingNamespaceImports = (List<?>) mainDefImports.get(BINDING_DEF_NAMESPACE);
+		assertNotNull(bindingNamespaceImports);
+		assertEquals(1, bindingNamespaceImports.size());
+		Import bindingNamespaceImport = (Import) bindingNamespaceImports.get(0);
+		assertEquals(BINDING_DEF_NAMESPACE, bindingNamespaceImport.getNamespaceURI());
+		Definition bindingDef = definitions.get(1);
+		assertEquals(BINDING_DEF_NAMESPACE, bindingDef.getTargetNamespace());
+		Map<?, ?> bindingDefImports = bindingDef.getImports();
+		if (bindingDefImports != null) {
+			int size = bindingDefImports.size();
+			if (size == 1) {
+				List<?> mainNamespaceImports = (List<?>) bindingDefImports.get(MAIN_DEF_NAMESPACE);
+				assertNotNull(mainNamespaceImports);
+				assertEquals(0, mainNamespaceImports.size());
+			} else {
+				assertEquals(0, bindingDefImports.size());
+			}
+		}
+	}
+}

--- a/test/plugins/org.talend.designer.webservice.test/src/org/talend/designer/webservice/test/TestService.wsdl
+++ b/test/plugins/org.talend.designer.webservice.test/src/org/talend/designer/webservice/test/TestService.wsdl
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="TestService"
+		xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+		xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+		xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+		xmlns:tns="http://www.talend.org/service/"
+		targetNamespace="http://www.talend.org/service/">
+
+    <wsdl:import namespace="http://www.talend.org/service/binding/" location="TestServiceBinding.wsdl" />
+
+    <wsdl:types>
+		<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+			targetNamespace="http://www.talend.org/service/">
+			<xsd:element name="TestServiceOperationRequest">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:element name="in" type="xsd:string"></xsd:element>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+			<xsd:element name="TestServiceOperationResponse">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:element name="out" type="xsd:string"></xsd:element>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:schema>
+	</wsdl:types>
+
+	<wsdl:message name="TestServiceOperationRequest">
+		<wsdl:part name="parameters" element="tns:TestServiceOperationRequest"></wsdl:part>
+	</wsdl:message>
+	<wsdl:message name="TestServiceOperationResponse">
+		<wsdl:part name="parameters" element="tns:TestServiceOperationResponse"></wsdl:part>
+	</wsdl:message>
+
+	<wsdl:portType name="TestServicePortType">
+		<wsdl:operation name="TestServiceOperation">
+			<wsdl:input message="tns:TestServiceOperationRequest"></wsdl:input>
+			<wsdl:output message="tns:TestServiceOperationResponse"></wsdl:output>
+		</wsdl:operation>
+	</wsdl:portType>
+
+	<wsdl:service name="TestService">
+		<wsdl:port name="TestServicePort" binding="tns:TestServiceBinding">
+			<soap:address location="http://localhost:8090/services/TestService" />
+		</wsdl:port>
+	</wsdl:service>
+</wsdl:definitions>

--- a/test/plugins/org.talend.designer.webservice.test/src/org/talend/designer/webservice/test/TestServiceBinding.wsdl
+++ b/test/plugins/org.talend.designer.webservice.test/src/org/talend/designer/webservice/test/TestServiceBinding.wsdl
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="TestServiceBinding"
+		xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+		xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+		xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+		xmlns:svc="http://www.talend.org/service/"
+		xmlns:tns="http://www.talend.org/service/binding/"
+		targetNamespace="http://www.talend.org/service/binding/">
+
+    <wsdl:import namespace="http://www.talend.org/service/" location="TestService.wsdl" />
+
+	<wsdl:binding name="TestServiceBinding" type="svc:TestServicePortType">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+		<wsdl:operation name="TestServiceOperation">
+			<soap:operation soapAction="http://www.talend.org/service/TestServiceOperation" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+</wsdl:definitions>


### PR DESCRIPTION
Circular WSDL imports are not prohibited by WS-I basic profile. However, they are currently causing WSDL import to fail in an endless recursion. The present fix corrects this condition and ensures that WSDL documents are not imported more than once.

**What is the current behavior?** (You can also link to an open issue here)
TESB-22183 - Stack overflow when loading WSDL with circular imports.

**What is the new behavior?**
Proper loading of WSDL with circular imports.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


