### PR TITLE
 fix(TESB-22183): Add support for circular WSDL imports to WSDL loading.

### DIFF
--- a/test/plugins/org.talend.designer.webservice.test/src/org/talend/designer/webservice/test/ServiceDiscoveryHelperTest.java
+++ b/test/plugins/org.talend.designer.webservice.test/src/org/talend/designer/webservice/test/ServiceDiscoveryHelperTest.java
@@ -1,0 +1,82 @@
+package org.talend.designer.webservice.test;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.wsdl.Binding;
+import javax.wsdl.Definition;
+//============================================================================
+//
+//Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+//
+//This source code is available under agreement available at
+//%InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+//You should have received a copy of the agreement
+//along with this program; if not, write to Talend SA
+//9 rue Pages 92150 Suresnes, France
+//
+//============================================================================
+import javax.wsdl.Import;
+
+import org.junit.Test;
+import org.talend.designer.webservice.ws.wsdlutil.ServiceDiscoveryHelper;
+
+public class ServiceDiscoveryHelperTest {
+
+	private static final String MAIN_DEF_NAMESPACE = "http://www.talend.org/service/";
+	private static final String BINDING_DEF_NAMESPACE = "http://www.talend.org/service/binding/";
+
+	@Test
+	public void testCircularDependencyLoading() throws Exception {
+		String wsdlLocation = getClass().getResource("TestService.wsdl").toExternalForm();
+		ServiceDiscoveryHelper helper = new ServiceDiscoveryHelper(wsdlLocation);
+		List<Definition> definitions = helper.getDefinitions();
+		assertNotNull(definitions);
+		assertEquals(3, definitions.size());
+		Definition mainDef = definitions.get(0);
+		assertEquals(MAIN_DEF_NAMESPACE, mainDef.getTargetNamespace());
+		Map<?, ?> mainDefImports = mainDef.getImports();
+		assertNotNull(mainDefImports);
+		assertEquals(1, mainDefImports.size());
+		List<?> bindingNamespaceImports = (List<?>) mainDefImports.get(BINDING_DEF_NAMESPACE);
+		assertNotNull(bindingNamespaceImports);
+		assertEquals(2, bindingNamespaceImports.size());
+		Import bindingNamespaceImport = (Import) bindingNamespaceImports.get(0);
+		assertEquals(BINDING_DEF_NAMESPACE, bindingNamespaceImport.getNamespaceURI());
+		assertTrue(bindingNamespaceImport.getLocationURI().indexOf("Jms") < 0);
+		Import bindingNamespaceImportJms = (Import) bindingNamespaceImports.get(1);
+		assertEquals(BINDING_DEF_NAMESPACE, bindingNamespaceImportJms.getNamespaceURI());
+		assertNotEquals(bindingNamespaceImport.getLocationURI(), bindingNamespaceImportJms.getLocationURI());
+		Definition bindingDef = definitions.get(1);
+		assertEquals(BINDING_DEF_NAMESPACE, bindingDef.getTargetNamespace());
+		assertTrue(((Binding) bindingDef.getBindings().values().iterator().next()).getQName().getLocalPart().indexOf("Jms") < 0);
+		Map<?, ?> bindingDefImports = bindingDef.getImports();
+		if (bindingDefImports != null) {
+			int size = bindingDefImports.size();
+			if (size == 1) {
+				List<?> mainNamespaceImports = (List<?>) bindingDefImports.get(MAIN_DEF_NAMESPACE);
+				assertNotNull(mainNamespaceImports);
+				assertEquals(0, mainNamespaceImports.size());
+			} else {
+				assertEquals(0, bindingDefImports.size());
+			}
+		}
+		bindingDef = definitions.get(2);
+		assertEquals(BINDING_DEF_NAMESPACE, bindingDef.getTargetNamespace());
+		assertTrue(((Binding) bindingDef.getBindings().values().iterator().next()).getQName().getLocalPart().indexOf("Jms") > 0);
+		bindingDefImports = bindingDef.getImports();
+		if (bindingDefImports != null) {
+			int size = bindingDefImports.size();
+			if (size == 1) {
+				List<?> mainNamespaceImports = (List<?>) bindingDefImports.get(MAIN_DEF_NAMESPACE);
+				assertNotNull(mainNamespaceImports);
+				assertEquals(0, mainNamespaceImports.size());
+			} else {
+				assertEquals(0, bindingDefImports.size());
+			}
+		}
+	}
+}

--- a/test/plugins/org.talend.designer.webservice.test/src/org/talend/designer/webservice/test/TestService.wsdl
+++ b/test/plugins/org.talend.designer.webservice.test/src/org/talend/designer/webservice/test/TestService.wsdl
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="TestService"
+		xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+		xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+		xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+		xmlns:tns="http://www.talend.org/service/"
+		targetNamespace="http://www.talend.org/service/">
+
+    <wsdl:import namespace="http://www.talend.org/service/binding/" location="TestServiceBinding.wsdl" />
+    <wsdl:import namespace="http://www.talend.org/service/binding/" location="TestServiceJmsBinding.wsdl" />
+
+    <wsdl:types>
+		<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+			targetNamespace="http://www.talend.org/service/">
+			<xsd:element name="TestServiceOperationRequest">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:element name="in" type="xsd:string"></xsd:element>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+			<xsd:element name="TestServiceOperationResponse">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:element name="out" type="xsd:string"></xsd:element>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:schema>
+	</wsdl:types>
+
+	<wsdl:message name="TestServiceOperationRequest">
+		<wsdl:part name="parameters" element="tns:TestServiceOperationRequest"></wsdl:part>
+	</wsdl:message>
+	<wsdl:message name="TestServiceOperationResponse">
+		<wsdl:part name="parameters" element="tns:TestServiceOperationResponse"></wsdl:part>
+	</wsdl:message>
+
+	<wsdl:portType name="TestServicePortType">
+		<wsdl:operation name="TestServiceOperation">
+			<wsdl:input message="tns:TestServiceOperationRequest"></wsdl:input>
+			<wsdl:output message="tns:TestServiceOperationResponse"></wsdl:output>
+		</wsdl:operation>
+	</wsdl:portType>
+
+	<wsdl:service name="TestService">
+		<wsdl:port name="TestServicePort" binding="tns:TestServiceBinding">
+			<soap:address location="http://localhost:8090/services/TestService" />
+		</wsdl:port>
+	</wsdl:service>
+
+    <wsdl:service name="TestServiceJms">
+        <wsdl:port name="TestServiceJmsPort" binding="tns:TestServiceJmsBinding">
+            <soap:address
+                location="jms:jndi:dynamicQueues/testservice.queue?jndiInitialContextFactory=org.apache.activemq.jndi.ActiveMQInitialContextFactory&amp;jndiConnectionFactoryName=ConnectionFactory&amp;jndiURL=tcp://localhost:61616" />
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/test/plugins/org.talend.designer.webservice.test/src/org/talend/designer/webservice/test/TestServiceBinding.wsdl
+++ b/test/plugins/org.talend.designer.webservice.test/src/org/talend/designer/webservice/test/TestServiceBinding.wsdl
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="TestServiceBinding"
+		xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+		xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+		xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+		xmlns:svc="http://www.talend.org/service/"
+		xmlns:tns="http://www.talend.org/service/binding/"
+		targetNamespace="http://www.talend.org/service/binding/">
+
+    <wsdl:import namespace="http://www.talend.org/service/" location="TestService.wsdl" />
+
+	<wsdl:binding name="TestServiceBinding" type="svc:TestServicePortType">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+		<wsdl:operation name="TestServiceOperation">
+			<soap:operation soapAction="http://www.talend.org/service/TestServiceOperation" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+</wsdl:definitions>

--- a/test/plugins/org.talend.designer.webservice.test/src/org/talend/designer/webservice/test/TestServiceJmsBinding.wsdl
+++ b/test/plugins/org.talend.designer.webservice.test/src/org/talend/designer/webservice/test/TestServiceJmsBinding.wsdl
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="TestServiceBinding"
+		xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+		xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+		xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+		xmlns:svc="http://www.talend.org/service/"
+		xmlns:tns="http://www.talend.org/service/binding/"
+		targetNamespace="http://www.talend.org/service/binding/">
+
+    <wsdl:import namespace="http://www.talend.org/service/" location="TestService.wsdl" />
+
+	<wsdl:binding name="TestServiceJmsBinding" type="svc:TestServicePortType">
+		<soap:binding style="document" transport="http://www.w3.org/2010/soapjms/" />
+		<wsdl:operation name="TestServiceOperation">
+			<soap:operation soapAction="http://www.talend.org/service/TestServiceOperation" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+</wsdl:definitions>


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
TESB-22183 Circular WSDL imports cause endless recursion

**What is the new behavior?**
Issue is fixed

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


