### PR TITLE
fix(TUP-19594)Drag DB metadata to job is different between new created

### DIFF
--- a/main/plugins/org.talend.repository/plugin.xml
+++ b/main/plugins/org.talend.repository/plugin.xml
@@ -3068,6 +3068,14 @@
               name="EscapeQuoterForTNormalize"
               version="7.1.0">
         </projecttask>
+        <projecttask
+              beforeLogon="false"
+              breaks="7.1.1"
+              class="org.talend.repository.model.migration.AddTypeNameInConnection"
+              id="org.talend.repository.model.migration.AddTypeNameInConnection"
+              name="AddTypeNameInConnection"
+              version="7.1.1">
+        </projecttask>
    </extension>
 
    <extension

--- a/main/plugins/org.talend.repository/plugin.xml
+++ b/main/plugins/org.talend.repository/plugin.xml
@@ -3070,11 +3070,11 @@
         </projecttask>
         <projecttask
               beforeLogon="false"
-              breaks="7.1.1"
+              breaks="7.0.1"
               class="org.talend.repository.model.migration.AddTypeNameInConnection"
               id="org.talend.repository.model.migration.AddTypeNameInConnection"
               name="AddTypeNameInConnection"
-              version="7.1.1">
+              version="7.0.2">
         </projecttask>
    </extension>
 

--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/model/migration/AddTypeNameInConnection.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/model/migration/AddTypeNameInConnection.java
@@ -1,0 +1,58 @@
+package org.talend.repository.model.migration;
+
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+import org.apache.commons.lang.StringUtils;
+import org.talend.commons.exception.PersistenceException;
+import org.talend.commons.ui.runtime.exception.ExceptionHandler;
+import org.talend.core.model.metadata.builder.connection.impl.DatabaseConnectionImpl;
+import org.talend.core.model.migration.AbstractItemMigrationTask;
+import org.talend.core.model.properties.ConnectionItem;
+import org.talend.core.model.properties.Item;
+import org.talend.core.repository.model.ProxyRepositoryFactory;
+
+/**
+ * 
+ * DOC jding class global comment. Detailled comment
+ */
+public class AddTypeNameInConnection extends AbstractItemMigrationTask {
+
+
+    @Override
+    public ExecutionResult execute(Item item) {
+        try {
+            boolean modified = addTypeName(item);
+            if (modified) {
+                return ExecutionResult.SUCCESS_NO_ALERT;
+            } else {
+                return ExecutionResult.NOTHING_TO_DO;
+            }
+        } catch (Exception e) {
+            ExceptionHandler.process(e);
+            return ExecutionResult.FAILURE;
+        }
+    }
+
+    private boolean addTypeName(Item item) throws PersistenceException {
+        if (item instanceof ConnectionItem) {
+            ConnectionItem conn = (ConnectionItem) item;
+            if (StringUtils.isBlank(conn.getTypeName())) {
+                if (conn.getConnection() instanceof DatabaseConnectionImpl) {
+                    ProxyRepositoryFactory factory = ProxyRepositoryFactory.getInstance();
+                    DatabaseConnectionImpl connection = (DatabaseConnectionImpl) conn.getConnection();
+                    conn.setTypeName(connection.getDatabaseType());
+                    factory.save(item, true);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Date getOrder() {
+        GregorianCalendar gc = new GregorianCalendar(2018, 6, 6, 12, 0, 0);
+        return gc.getTime();
+    }
+}


### PR DESCRIPTION
and import from 641
https://jira.talendforge.org/browse/TUP-19594
Add a migration task to set type name

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


