### PR TITLE
fix(TDQ-15215): No need to run 'include-survivorship-rules' sice the

### DIFF
--- a/main/plugins/org.talend.designer.maven.job/resources/templates/osgi/pom_job_template.xml
+++ b/main/plugins/org.talend.designer.maven.job/resources/templates/osgi/pom_job_template.xml
@@ -245,15 +245,6 @@
                 <microservice.running.configs.dir>${current.resources.dir}/</microservice.running.configs.dir>
             </properties>
         </profile>
-        <profile>
-            <id>include-survivorship-rules</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <survivorship.rules.dir>${current.resources.dir}/metadata/survivorship/</survivorship.rules.dir>
-            </properties>
-        </profile>
 
     </profiles>
 </project>

--- a/main/plugins/org.talend.designer.maven.job/resources/templates/standalone/assembly_job_template.xml
+++ b/main/plugins/org.talend.designer.maven.job/resources/templates/standalone/assembly_job_template.xml
@@ -208,12 +208,6 @@
 				<include>config/**</include>
 			</includes>
 		</fileSet>
-		<fileSet><!-- survivorship rules -->
-			<directory>${survivorship.rules.dir}</directory>
-			<outputDirectory>${talend.job.name}/items/${talend.project.name.lowercase}/metadata/survivorship/</outputDirectory>
-			<includes>
-			</includes>
-		</fileSet>
 	</fileSets>
 	<dependencySets>
 		<dependencySet>

--- a/main/plugins/org.talend.designer.maven.job/resources/templates/standalone/pom_job_template.xml
+++ b/main/plugins/org.talend.designer.maven.job/resources/templates/standalone/pom_job_template.xml
@@ -236,15 +236,6 @@
 				<microservice.running.configs.dir>${current.int-resources.dir}/</microservice.running.configs.dir>
 			</properties>
 		</profile>
-		<profile>
-			<id>include-survivorship-rules</id>
-			<activation>
-				<activeByDefault>true</activeByDefault>
-			</activation>
-			<properties>
-				<survivorship.rules.dir>${current.resources.dir}/metadata/survivorship/</survivorship.rules.dir>
-			</properties>
-		</profile>
 
 	</profiles>
 </project>

--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/handler/AbstractBuildJobHandler.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/handler/AbstractBuildJobHandler.java
@@ -30,8 +30,6 @@ import org.talend.commons.exception.ExceptionHandler;
 import org.talend.commons.exception.PersistenceException;
 import org.talend.commons.utils.workbench.resources.ResourceUtils;
 import org.talend.core.CorePlugin;
-import org.talend.core.GlobalServiceRegister;
-import org.talend.core.ITDQSurvivorshipService;
 import org.talend.core.model.process.ProcessUtils;
 import org.talend.core.model.properties.Item;
 import org.talend.core.model.properties.ProcessItem;
@@ -45,7 +43,6 @@ import org.talend.core.runtime.repository.build.IBuildParametes;
 import org.talend.core.runtime.repository.build.IBuildResourceParametes;
 import org.talend.core.runtime.repository.build.IBuildResourcesProvider;
 import org.talend.core.runtime.util.ParametersUtil;
-import org.talend.designer.core.model.utils.emf.talendfile.NodeType;
 import org.talend.designer.maven.model.TalendMavenConstants;
 import org.talend.designer.runprocess.IRunProcessService;
 import org.talend.designer.runprocess.ProcessorUtilities;
@@ -162,25 +159,6 @@ public abstract class AbstractBuildJobHandler implements IBuildJobHandler, IBuil
         return LastGenerationInfo.getInstance().isUsePigUDFs(processItem.getProperty().getId(), this.version);
     }
 
-    protected boolean needDQSurvivorshipRules() {
-        // when needJobItem or itemDependencies is true, the survivorship rules will be included.so return false here.
-        if (isOptionChoosed(ExportChoice.needJobItem) || itemDependencies) {
-            return false;
-        }
-
-        Collection<NodeType> survivorshipNodes = null;
-        if (GlobalServiceRegister.getDefault().isServiceRegistered(ITDQSurvivorshipService.class)) {
-            ITDQSurvivorshipService tdqSurvShipService = (ITDQSurvivorshipService) GlobalServiceRegister.getDefault().getService(
-                    ITDQSurvivorshipService.class);
-            if (tdqSurvShipService != null) {
-                survivorshipNodes = tdqSurvShipService.getSurvivorshipNodesOfProcess(processItem);
-            }
-        }
-        if (survivorshipNodes != null && !survivorshipNodes.isEmpty()) {
-            return true;
-        }
-        return false;
-    }
 
     protected String getProgramArgs() {
         StringBuffer programArgs = new StringBuffer();
@@ -215,10 +193,6 @@ public abstract class AbstractBuildJobHandler implements IBuildJobHandler, IBuil
         // if not binaries, need add maven resources
         boolean isBinaries = isOptionChoosed(ExportChoice.binaries);
         addArg(profileBuffer, !isBinaries, TalendMavenConstants.PROFILE_INCLUDE_MAVEN_RESOURCES);
-        // DQ survivorship rules when items not exported.
-        if (needDQSurvivorshipRules()) {
-            addArg(profileBuffer, true, TalendMavenConstants.PROFILE_INCLUDE_SURVIVORSHIP_RULES);
-        }
         addArg(profileBuffer, isOptionChoosed(ExportChoice.needJobItem) || itemDependencies,
                 TalendMavenConstants.PROFILE_INCLUDE_ITEMS);
 


### PR DESCRIPTION
rules in src/main/resources. they will be in jar/zip when build the
maven job

**What is the current behavior?** ( https://jira.talendforge.org/browse/TDQ-15215 )


**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- 

- [ ] Bugfix


**Does this PR introduce a breaking change?**

- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


