### PR TITLE
fix(TDI-40674): Add property to avoid windows-separator replacement

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tSCPGet/tSCPGet_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSCPGet/tSCPGet_java.xml
@@ -148,6 +148,16 @@
 
   </PARAMETERS>
 
+  <ADVANCED_PARAMETERS>
+    <PARAMETER
+      NAME="FORCE_UNIX_PATH"
+      FIELD="CHECK"
+      NUM_ROW="1"
+      >
+      <DEFAULT>false</DEFAULT>
+    </PARAMETER>
+  </ADVANCED_PARAMETERS>
+
   <CODEGENERATION>
     <IMPORTS>
     	<IMPORT  NAME="Java_SCP"  MODULE="ganymed-ssh2-261.jar" MVN="mvn:org.talend.libraries/ganymed-ssh2-261/6.0.0"  REQUIRED="true"/>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSCPGet/tSCPGet_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSCPGet/tSCPGet_main.javajet
@@ -15,6 +15,7 @@ imports="
     String replaceOption = ElementParameterParser.getValue(node,"__REPLACEOPTION__");
     List<Map<String, String>> filelist = (List<Map<String,String>>)ElementParameterParser.getObjectValue(node,"__FILELIST__");
     boolean isLog4jEnabled = ("true").equals(ElementParameterParser.getValue(node.getProcess(), "__LOG4J_ACTIVATE__"));
+    boolean enforceUnixPath = ("true").equals(ElementParameterParser.getValue(node,"__FORCE_UNIX_PATH__"));
 %>
 	String[] sourceFileNames_<%=cid%> = new String[]{
 <%
@@ -28,10 +29,17 @@ imports="
 	java.io.File dir_<%=cid %> = null;
 	try{
 <%
-		if(("append").equals(replaceOption)){%>
+		if(("append").equals(replaceOption)){
+%>
 			for (String sourceFile_<%=cid %> : sourceFileNames_<%=cid %>) {
 				if (sourceFile_<%=cid %> != null&& sourceFile_<%=cid %>.length() != 0) {
-					sourceFile_<%=cid %>=sourceFile_<%=cid %>.replaceAll("\\\\","/"); 
+<%
+					if (!enforceUnixPath) {
+%>
+						sourceFile_<%=cid %> = sourceFile_<%=cid %>.replaceAll("\\\\","/");
+<%
+					}
+%>
 					int index_<%=cid %>=sourceFile_<%=cid %>.lastIndexOf("/");
 					if(index_<%=cid %> >0){
 						dir_<%=cid %> = new java.io.File(<%=localdir %>);
@@ -84,10 +92,11 @@ imports="
 			}else{
 				globalMap.put("<%=cid %>_STATUS", "No file transfered.");
 			}
-		<%
+<%
 		}else{
 			boolean isDefaultAction = !("overwrite").equals(replaceOption);
-			if(isDefaultAction) {%>        
+			if(isDefaultAction) {
+%>
 		    	String parentPath_<%=cid%> = new java.io.File(<%=localdir %>).getPath();
 				java.util.List<String> list_<%=cid%> = new java.util.ArrayList<String>();
 				for (int i_<%=cid%> = 0; i_<%=cid%> < sourceFileNames_<%=cid%>.length; i_<%=cid%>++) {
@@ -97,20 +106,26 @@ imports="
 		            }
 		        }
 		        sourceFileNames_<%=cid%> = (String[]) list_<%=cid%>.toArray(new String[0]);
-		<%
+<%
 			}
-		%>
+%>
 			if(sourceFileNames_<%=cid%>!=null && sourceFileNames_<%=cid%>.length!=0){
 				for (String sourceFile_<%=cid %> : sourceFileNames_<%=cid %>) {
 					if (sourceFile_<%=cid %> != null&& sourceFile_<%=cid %>.length() != 0) {
-						sourceFile_<%=cid %>=sourceFile_<%=cid %>.replaceAll("\\\\","/"); 
-					    int index_<%=cid %>=sourceFile_<%=cid %>.lastIndexOf("/");
-					    if(index_<%=cid %> >0){
+<%
+						if (!enforceUnixPath) {
+%>
+							sourceFile_<%=cid %> = sourceFile_<%=cid %>.replaceAll("\\\\","/");
+<%
+						}
+%>
+						int index_<%=cid %>=sourceFile_<%=cid %>.lastIndexOf("/");
+						if(index_<%=cid %> >0){
 							dir_<%=cid %> = new java.io.File(<%=localdir %>);
 							String extension_<%=cid %>=	sourceFile_<%=cid %>.substring(index_<%=cid %>,sourceFile_<%=cid %>.length());
 							java.io.File file_<%=cid %> = new java.io.File(dir_<%=cid %>, extension_<%=cid %>);
 							if(!file_<%=cid %>.exists()){
-						  		file_<%=cid %>.getParentFile().mkdirs();
+								file_<%=cid %>.getParentFile().mkdirs();
 							}
 							java.io.FileOutputStream out_<%=cid %> = null;
 		    				//copy action
@@ -162,9 +177,9 @@ imports="
 					globalMap.put("<%=cid %>_STATUS", "No file transfered.");
 				}
 			}
-		<%
+<%
 		}
-		%>
+%>
 	}catch(java.lang.Exception e_<%=cid%>){
 		globalMap.put("<%=cid %>_STATUS", "File get fail.");
 		throw e_<%=cid%>;

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSCPGet/tSCPGet_messages.properties
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSCPGet/tSCPGet_messages.properties
@@ -29,5 +29,5 @@ TIMEOUT.NAME=Timeout in seconds
 USERNAME.NAME=Username
 USE_EXISTING_CONNECTION.NAME=Use an existing connection
 USE_TIMEOUT.NAME=Use timeout
-
+FORCE_UNIX_PATH.NAME=Enforce unix path notations
 CONNECTION.NAME=Component List


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

https://jira.talendforge.org/browse/TDI-40674
**What is the new behavior?**
With new property it is possible to download files from directory with '\' in name

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


