### PR TITLE
fix(TESB-22695) : use the correct groupId from project.

### DIFF
--- a/main/plugins/org.talend.designer.maven.job/resources/templates/osgi/pom_job_template.xml
+++ b/main/plugins/org.talend.designer.maven.job/resources/templates/osgi/pom_job_template.xml
@@ -78,7 +78,7 @@
 						</goals>
 						<configuration>
 							<file>${basedir}/src/main/resources/feature/feature.xml</file>
-							<groupId>org.example.talend_dev.job</groupId>
+							<groupId>${project.groupId}</groupId>
 							<artifactId>${talend.job.name}-feature</artifactId>
 							<version>${project.version}</version>
 							<classifier>features</classifier>


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
deploying ESB as OSGI to nexus used wrong groupId

**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


