### PR TITLE
fix(TDQ-15455): using getUniqueName().indexOf("tRecordMatching")>-1 i…

### DIFF
--- a/main/plugins/org.talend.designer.codegen/jet_stub/subprocess_header.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/subprocess_header.javajet
@@ -97,7 +97,7 @@
 								}
 
 								// for tRecordMatching
-								if(conn.getTarget().getComponent().getName().equals("tRecordMatching")){
+								if(conn.getTarget().getUniqueName().indexOf("tRecordMatching")>-1){
 									List<Map<String, String>> joinKeys = (List<Map<String,String>>)ElementParameterParser.getObjectValue(conn.getTarget(), "__BLOCKING_DEFINITION__");
 									for(Map<String, String> joinKeyLine : joinKeys){
 										String lookupKey = joinKeyLine.get("LOOKUP_COLUMN");


### PR DESCRIPTION
…nsdead of getComponent().getName().equals("tRecordMatching") to judge the component is tRecordMatching or not

**What is the current behavior?** (You can also link to an open issue here)
using getComponent().getName().equals("tRecordMatching") to judge the component is tRecordMatching or not

**What is the new behavior?**
using getUniqueName().indexOf("tRecordMatching")>-1 to judge the component is tRecordMatching or not

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


