### PR TITLE
tFileInputMail_MIME.javajet : avoid a java.lang.NullPointerException

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileInputMail/tFileInputMail_MIME.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileInputMail/tFileInputMail_MIME.javajet
@@ -166,8 +166,12 @@
 		        	if(("true").equals(mailChecked_<%=cid %>[i_<%=cid%>])){   
 						String[] sa_<%=cid%> = msg_<%=cid %>.getHeader(part_<%=cid%>);
 						String tempStr_<%=cid%>="";
-						for(int i=0;i<sa_<%=cid%>.length;i++){
-							tempStr_<%=cid%>=tempStr_<%=cid%>+sa_<%=cid%>[i] + sep_<%=cid%>;
+						if(sa_<%=cid%>!=null){
+							for(int i=0;i<sa_<%=cid%>.length;i++){
+								tempStr_<%=cid%>=tempStr_<%=cid%>+sa_<%=cid%>[i] + sep_<%=cid%>;
+							}
+						}else{
+							tempStr_<%=cid%>=null;
 						}
 						list_<%=cid%>.add(decode_<%=cid%>.decode(tempStr_<%=cid%>));
 		        	}else{ 


### PR DESCRIPTION
In tFileInputMail, when parsing a mail and requesting for a header field that is not present, the "getHeader" function will return a null value witch is the expected behavior.
In the case the "Multi Value" option is checked for a field, the previous code wasn't checking for null value before trying to loop on the field, witch was causing a java.lang.NullPointerException when trying to get the length of the array.

**What is the current behavior?** (You can also link to an open issue here)
a null pointer exception occurs

**What is the new behavior?**
no more null pointer exception

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


