### PR TITLE
TESB-22594 Error occurred when build a route with ctalendjob to runtime

### DIFF
--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/maven/MavenJavaProcessor.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/maven/MavenJavaProcessor.java
@@ -33,6 +33,7 @@ import org.talend.core.model.process.IProcess;
 import org.talend.core.model.process.JobInfo;
 import org.talend.core.model.process.ProcessUtils;
 import org.talend.core.model.properties.Property;
+import org.talend.core.model.repository.ERepositoryObjectType;
 import org.talend.core.model.utils.JavaResourcesHelper;
 import org.talend.core.repository.utils.ItemResourceUtil;
 import org.talend.core.runtime.process.ITalendProcessJavaProject;
@@ -288,7 +289,7 @@ public class MavenJavaProcessor extends JavaProcessor {
 
         Object exportType = getArguments() == null ? null : getArguments().get(TalendProcessArgumentConstant.ARG_BUILD_TYPE);
 
-        if (exportType == null) {
+        if (exportType == null && !ERepositoryObjectType.getType(itemProperty).equals(ERepositoryObjectType.PROCESS) ) {
             exportType = itemProperty.getAdditionalProperties().get(TalendProcessArgumentConstant.ARG_BUILD_TYPE);
         }
 


### PR DESCRIPTION
Current issue is triggered by this comit https://github.com/Talend/tdi-studio-se/commit/d2f57c48f9731fe1a02e4b138624d6d327a0dd30.

       if (exportType == null) {
            exportType = itemProperty.getAdditionalProperties().get(TalendProcessArgumentConstant.ARG_BUILD_TYPE);
       }

**so, previously export type was null for child jobs but now it has value "ROUTE"
this is why incorrect Job pom creator is selected**

**Current fix excludes assigning of exportType for Jobs**