### PR TITLE
fix(TESB-22825): Avoid to generate standalone pom for service provider

### DIFF
--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/build/StandardJobStandaloneBuildProvider.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/build/StandardJobStandaloneBuildProvider.java
@@ -33,6 +33,7 @@ import org.talend.core.runtime.repository.build.IBuildExportHandler;
 import org.talend.core.runtime.repository.build.IMavenPomCreator;
 import org.talend.core.runtime.repository.build.RepositoryObjectTypeBuildProvider;
 import org.talend.core.service.IESBRouteService;
+import org.talend.designer.core.model.utils.emf.talendfile.NodeType;
 import org.talend.designer.maven.tools.creator.CreateMavenJobPom;
 import org.talend.designer.runprocess.IProcessor;
 import org.talend.designer.runprocess.ProcessorUtilities;
@@ -64,16 +65,18 @@ public class StandardJobStandaloneBuildProvider extends RepositoryObjectTypeBuil
         if (parameters == null || parameters.isEmpty()) {
             return false;
         }
-        
+
         ERepositoryObjectType type = null;
         Property property = null;
+        boolean isRestServiceProvider = false;
 
         Object object = parameters.get(PROCESS);
         if (object != null && object instanceof IProcess2) {
 
             for (INode node : ((IProcess2) object).getGraphicalNodes()) {
                 if ("tRESTRequest".equals(node.getComponent().getName())) {
-                    return false;
+                    isRestServiceProvider = true;
+                    break;
                 }
             }
 
@@ -90,6 +93,16 @@ public class StandardJobStandaloneBuildProvider extends RepositoryObjectTypeBuil
                 if (property != null) {
                     type = ERepositoryObjectType.getType(property);
                 }
+                if (object instanceof ProcessItem) {
+                    ProcessItem processItem = (ProcessItem) object;
+                    for (Object node : processItem.getProcess().getNode()) {
+                        NodeType nodeType = (NodeType) node;
+                        if ("tRESTRequest".equals(nodeType.getComponentName())) {
+                            isRestServiceProvider = true;
+                            break;
+                        }
+                    }
+                }
             }
         }
         if (type == null) {
@@ -101,7 +114,7 @@ public class StandardJobStandaloneBuildProvider extends RepositoryObjectTypeBuil
             }
         }
 
-        if (type != null && type.equals(getObjectType()) && !isServiceOperation(property)) {
+        if (type != null && type.equals(getObjectType()) && !isRestServiceProvider && !isServiceOperation(property)) {
             return true;
         }
 


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
Rest service provider job pom still be generated as standalone type pom file.

**What is the new behavior?**
Avoid to generate standalone pom for service provider

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


