### PR TITLE
fix(TDI-40824):tRedshiftOutputBulkExec compile error since generic components name when use 'encrypt'

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tELTOutput/tELTOutput_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tELTOutput/tELTOutput_main.javajet
@@ -9,6 +9,7 @@ imports="
 		org.talend.core.model.metadata.MappingTypeRetriever
 		org.talend.core.model.metadata.MetadataTalendType
 	 	org.talend.commons.utils.generation.CodeGenerationUtils
+	 	org.talend.core.model.utils.NodeUtil
 		java.util.List
 		java.util.ArrayList
 		java.util.LinkedList
@@ -87,10 +88,11 @@ skeleton="../templates/db_output_bulk.skeleton"
     <%
     if(useExistingConn) {
         String connection = ElementParameterParser.getValue(previousNode, "__CONNECTION__");
+        INode connNode=NodeUtil.getNodeByUniqueName(previousNode.getProcess(),connection);
         String conn = "conn_" + connection;
         String username = "username_" + connection;
         String connectionKey=null;
-        if(connection.indexOf("tJDBCConnection")<0){
+        if(connNode.getComponent().getName().indexOf("tJDBCConnection")<0){
            connectionKey=connection+"_Connection";
         }else{
         	  connectionKey=conn;

--- a/main/plugins/org.talend.designer.components.localprovider/components/tS3Connection/S3Client.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tS3Connection/S3Client.javajet
@@ -79,7 +79,7 @@
 		String public_key = ElementParameterParser.getValue(node,"__PUBLIC_KEY__");
 		String private_key = ElementParameterParser.getValue(node,"__PRIVATE_KEY__");
 		
-		if(encrypt && cid.startsWith("tRedshift")) {
+		if(encrypt && node.getComponent().getName().startsWith("tRedshift")) {
 		%>
 			String masterKey_<%=cid%> = <%=encrypted_key%>; 
 			javax.crypto.spec.SecretKeySpec symmetricKey_<%=cid%> = new javax.crypto.spec.SecretKeySpec(org.apache.commons.codec.binary.Base64.decodeBase64(masterKey_<%=cid%>.getBytes("UTF-8")), "AES");


### PR DESCRIPTION

**What is the current behavior?** (You can also link to an open issue here)

For https://jira.talendforge.org/browse/TDI-40824

**What is the new behavior?**

Fix some bug caused by db unify

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No


