### PR TITLE
fix(TDI-40855): remove duplicated filter for datasource

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tSQLDWHOutput/tSQLDWHOutput_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSQLDWHOutput/tSQLDWHOutput_begin.javajet
@@ -189,10 +189,6 @@ if(("UPDATE").equals(dataAction) || ("INSERT_OR_UPDATE").equals(dataAction) || (
 java.sql.Connection conn_<%=cid%> = null;
 <%
 boolean useExistingConnection = "true".equals(ElementParameterParser.getValue(node,"__USE_EXISTING_CONNECTION__"));
-boolean isEnableDatasource = false;
-if(cid.indexOf("tMSSqlOutput")>-1 || cid.indexOf("tMSSqlSP")>-1 ){
-	isEnableDatasource = true;
-}
 %>
 String dbUser_<%=cid %> = null;
 <%
@@ -208,7 +204,7 @@ if(useExistingConnection) {
 } else {
 	boolean specify_alias = "true".equals(ElementParameterParser.getValue(node, "__SPECIFY_DATASOURCE_ALIAS__"));   
 	String driver = ElementParameterParser.getValue(node, "__DRIVER__");
-	if(isEnableDatasource && specify_alias){
+	if(specify_alias){
 		String alias = ElementParameterParser.getValue(node, "__DATASOURCE_ALIAS__");
 		%>
 		java.util.Map<String, routines.system.TalendDataSource> dataSources_<%=cid%> = (java.util.Map<String, routines.system.TalendDataSource>) globalMap.get(KEY_DB_DATASOURCES);
@@ -279,7 +275,7 @@ if(useExistingConnection) {
     conn_<%=cid%> = java.sql.DriverManager.getConnection(url_<%=cid %>,dbUser_<%=cid%>,dbPwd_<%=cid%>);
     <%dbLog.conn().connDone(dbLog.var("url"));%>
 	<%
-	if(isEnableDatasource && specify_alias){
+	if(specify_alias){
 	%>
 		}
 	<%

--- a/main/plugins/org.talend.designer.components.localprovider/components/templates/tMSSql/_tMSSqlConnection.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/templates/tMSSql/_tMSSqlConnection.javajet
@@ -3,10 +3,6 @@
 java.sql.Connection conn_<%=cid%> = null;
 <%
 boolean useExistingConnection = "true".equals(ElementParameterParser.getValue(node,"__USE_EXISTING_CONNECTION__"));
-boolean isEnableDatasource = false;
-if(cid.indexOf("tMSSqlOutput")>-1 || cid.indexOf("tMSSqlSP")>-1 ){
-	isEnableDatasource = true;
-}
 %>
 String dbUser_<%=cid %> = null;
 <%
@@ -22,7 +18,7 @@ if(useExistingConnection) {
 } else {
 	boolean specify_alias = "true".equals(ElementParameterParser.getValue(node, "__SPECIFY_DATASOURCE_ALIAS__"));   
 	String driver = ElementParameterParser.getValue(node, "__DRIVER__");
-	if(isEnableDatasource && specify_alias){
+	if(specify_alias){
 		String alias = ElementParameterParser.getValue(node, "__DATASOURCE_ALIAS__");
 		%>
 		java.util.Map<String, routines.system.TalendDataSource> dataSources_<%=cid%> = (java.util.Map<String, routines.system.TalendDataSource>) globalMap.get(KEY_DB_DATASOURCES);
@@ -93,7 +89,7 @@ if(useExistingConnection) {
     conn_<%=cid%> = java.sql.DriverManager.getConnection(url_<%=cid %>,dbUser_<%=cid%>,dbPwd_<%=cid%>);
     <%dbLog.conn().connDone(dbLog.var("url"));%>
 	<%
-	if(isEnableDatasource && specify_alias){
+	if(specify_alias){
 	%>
 		}
 	<%


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-40855

**What is the new behavior?**
isEnableDatasource was useless filter. It was deleted

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


