### PR TITLE
Metadata migration fix and default values and diplayName for test connection

### DIFF
--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/metadata/migration/TaCoKitMigrationManager.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/metadata/migration/TaCoKitMigrationManager.java
@@ -267,25 +267,18 @@ public class TaCoKitMigrationManager {
                 ISchedulingRule refreshRule = ruleFactory
                         .refreshRule(projectManager.getResourceProject(projectManager.getCurrentProject().getEmfProject()));
                 try {
-                    workspace.run(new IWorkspaceRunnable() {
+                    workspace.run(workspaceMonitor -> ProxyRepositoryFactory.getInstance()
+                            .executeRepositoryWorkUnit(new RepositoryWorkUnit(title) {
 
-                        @Override
-                        public void run(final IProgressMonitor workspaceMonitor) throws CoreException {
-                            ProxyRepositoryFactory.getInstance()
-                                    .executeRepositoryWorkUnit(new RepositoryWorkUnit(title) {
-
-                                        @Override
-                                        protected void run() throws LoginException, PersistenceException {
-                                            try {
-                                                checkMigration(workspaceMonitor);
-                                            } catch (Exception e) {
-                                                ExceptionHandler.process(e);
-                                            }
-                                        }
-                                    });
-
-                        }
-                    }, refreshRule, IWorkspace.AVOID_UPDATE, jobMonitor);
+                                @Override
+                                protected void run() {
+                                    try {
+                                        checkMigration(workspaceMonitor);
+                                    } catch (Exception e) {
+                                        ExceptionHandler.process(e);
+                                    }
+                                }
+                            }), refreshRule, IWorkspace.AVOID_UPDATE, jobMonitor);
                 } catch (CoreException e) {
                     ExceptionHandler.process(e);
                 }
@@ -297,8 +290,7 @@ public class TaCoKitMigrationManager {
         migrationJob.join();
     }
 
-    public void updatedRelatedItems(final ConnectionItem item, final String version, final IProgressMonitor progressMonitor)
-            throws Exception {
+    public void updatedRelatedItems(final ConnectionItem item, final String version, final IProgressMonitor progressMonitor) {
         IProgressMonitor monitor = progressMonitor;
         if (monitor == null) {
             monitor = new NullProgressMonitor();

--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/metadata/model/TaCoKitConfigurationModel.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/metadata/model/TaCoKitConfigurationModel.java
@@ -21,7 +21,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -38,23 +37,23 @@ import org.talend.sdk.component.studio.util.TaCoKitUtil;
 
 /**
  * DOC cmeng class global comment. Detailled comment
- * 
+ *
  * Provides convenient API for updating {@link Connection} properties
  */
 public class TaCoKitConfigurationModel {
 
     private final Connection connection;
-    
+
     private final ConfigTypeNode configType;
 
     private TaCoKitConfigurationModel parentConfigurationModel;
 
     private String parentConfigurationModelItemId;
-    
+
     public TaCoKitConfigurationModel(final Connection connection) {
         this(connection, Lookups.taCoKitCache().getConfigTypeNode(getConfigId(connection)));
     }
-    
+
     public TaCoKitConfigurationModel(final Connection connection, final ConfigTypeNode configType) {
         this.connection = connection;
         this.configType = configType;
@@ -74,30 +73,30 @@ public class TaCoKitConfigurationModel {
     private void setParentConfigurationId(final String parentId) {
         getAllProperties().put(TACOKIT_CONFIG_PARENT_ID, parentId);
     }
-    
+
     @SuppressWarnings("deprecation")
     private static String getConfigId(final Connection connection) {
         return (String) connection.getProperties().get(TACOKIT_CONFIG_ID);
     }
-    
+
     public static boolean isTacokit(final Connection connection) {
         return !StringUtils.isEmpty(getConfigId(connection));
     }
-    
+
     private boolean isVersionSet() {
         return getAllProperties().containsKey(TACOKIT_CONFIG_VERSION);
     }
-    
+
     public int getVersion() {
         final String version = (String) getAllProperties().get(TACOKIT_CONFIG_VERSION);
         return Integer.parseInt(version);
     }
-    
+
     @SuppressWarnings("unchecked")
     private void setVersion(final int version) {
         getAllProperties().put(TACOKIT_CONFIG_VERSION, Integer.toString(version));
     }
-    
+
     public int getConfigurationVersion() {
         return configType.getVersion();
     }
@@ -137,26 +136,12 @@ public class TaCoKitConfigurationModel {
         }
         return null;
     }
-    
+
     private String getValueType(final ConfigTypeNode typeNode, final String key) throws Exception {
         return typeNode.getProperties().stream()
                 .filter(propertyDefinition -> TaCoKitUtil.equals(key, propertyDefinition.getPath()))
                 .map(SimplePropertyDefinition::getType).findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("wrong key: " + key));
-    }
-
-    public ConfigTypeNode getFirstConfigTypeNodeContains(final String key) throws Exception {
-        ConfigTypeNode configTypeNode = null;
-        TaCoKitConfigurationModel parentModel = getParentConfigurationModel();
-        if (parentModel != null) {
-            configTypeNode = parentModel.getFirstConfigTypeNodeContains(key);
-        }
-        if (configTypeNode == null) {
-            if (contains(key)) {
-                configTypeNode = getConfigTypeNode();
-            }
-        }
-        return configTypeNode;
     }
 
     private boolean contains(final String key) {
@@ -208,13 +193,12 @@ public class TaCoKitConfigurationModel {
     private Map getAllProperties() {
         return connection.getProperties();
     }
-    
+
     @SuppressWarnings({ "rawtypes", "unchecked" })
     private Map getBuiltInProperties() {
         final Map builtIn = new HashMap();
-        final Iterator it = getAllProperties().entrySet().iterator();
-        while (it.hasNext()) {
-            final Map.Entry entry = (Entry) it.next();
+        for (final Object o : getAllProperties().entrySet()) {
+            final Entry entry = (Entry) o;
             final String key = (String) entry.getKey();
             if (BuiltInKeys.isBuiltIn(key)) {
                 builtIn.put(key, entry.getValue());
@@ -222,18 +206,17 @@ public class TaCoKitConfigurationModel {
         }
         return builtIn;
     }
-    
+
     /**
      * Returns properties view, which doesn't include built-in (service) properties
-     * 
+     *
      * @return properties view
      */
     @SuppressWarnings("rawtypes")
     public Map<String, String> getProperties() {
         Map<String, String> properties = new HashMap<>();
-        final Iterator it = getAllProperties().entrySet().iterator();
-        while (it.hasNext()) {
-            final Map.Entry entry = (Entry) it.next();
+        for (final Object o : getAllProperties().entrySet()) {
+            final Entry entry = (Entry) o;
             final String key = (String) entry.getKey();
             if (!BuiltInKeys.isBuiltIn(key)) {
                 properties.put(key, (String) entry.getValue());
@@ -241,7 +224,7 @@ public class TaCoKitConfigurationModel {
         }
         return Collections.unmodifiableMap(properties);
     }
-    
+
     @SuppressWarnings({ "rawtypes", "unchecked" })
     private void clear() {
         final Map builtIn = getBuiltInProperties();
@@ -252,20 +235,20 @@ public class TaCoKitConfigurationModel {
     public Connection getConnection() {
         return connection;
     }
-    
+
     @SuppressWarnings("unchecked")
     public void migrate(final Map<String, String> migratedProperties) {
         clear();
         getAllProperties().putAll(migratedProperties);
         setVersion(getConfigurationVersion());
     }
-    
+
     /**
      * Checks whether Configuration requires migration. Configuration requires
      * migration in case current Configuration version is greater than persisted
      * version. In case versions are equal migration is not required. If persisted
      * version is greater than current version, then IllegalStateException is thrown
-     * 
+     *
      * @return true, if migration is required
      */
     public boolean needsMigration() {
@@ -279,13 +262,13 @@ public class TaCoKitConfigurationModel {
     }
 
     public static class ValueModel {
-        
+
         private final TaCoKitConfigurationModel configurationModel;
 
         private final String value;
-        
+
         private final String type;
-        
+
         public ValueModel(final TaCoKitConfigurationModel configurationModel, final String value, final String type) {
             this.configurationModel = configurationModel;
             this.value = value;
@@ -299,7 +282,7 @@ public class TaCoKitConfigurationModel {
         public String getValue() {
             return this.value;
         }
-        
+
         public String getType() {
             return type;
         }
@@ -311,7 +294,7 @@ public class TaCoKitConfigurationModel {
         }
 
     }
-        
+
     public static class BuiltInKeys {
 
         static final String TACOKIT_CONFIG_ID = "__TACOKIT_CONFIG_ID"; //$NON-NLS-1$

--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/metadata/model/TaCoKitConfigurationModel.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/metadata/model/TaCoKitConfigurationModel.java
@@ -14,7 +14,6 @@ package org.talend.sdk.component.studio.metadata.model;
 
 import static org.talend.sdk.component.studio.metadata.model.TaCoKitConfigurationModel.BuiltInKeys.TACOKIT_CONFIG_ID;
 import static org.talend.sdk.component.studio.metadata.model.TaCoKitConfigurationModel.BuiltInKeys.TACOKIT_CONFIG_PARENT_ID;
-import static org.talend.sdk.component.studio.metadata.model.TaCoKitConfigurationModel.BuiltInKeys.TACOKIT_CONFIG_VERSION;
 import static org.talend.sdk.component.studio.metadata.model.TaCoKitConfigurationModel.BuiltInKeys.TACOKIT_PARENT_ITEM_ID;
 
 import java.util.Arrays;
@@ -25,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
@@ -59,9 +59,6 @@ public class TaCoKitConfigurationModel {
         this.configType = configType;
         setConfigurationId(configType.getId());
         setParentConfigurationId(configType.getParentId());
-        if (!isVersionSet()) {
-            setVersion(getConfigurationVersion());
-        }
     }
 
     @SuppressWarnings("unchecked")
@@ -83,18 +80,12 @@ public class TaCoKitConfigurationModel {
         return !StringUtils.isEmpty(getConfigId(connection));
     }
 
-    private boolean isVersionSet() {
-        return getAllProperties().containsKey(TACOKIT_CONFIG_VERSION);
-    }
-
     public int getVersion() {
-        final String version = (String) getAllProperties().get(TACOKIT_CONFIG_VERSION);
+        final String version = Optional.ofNullable(getProperties().get(configType.getProperties().stream()
+                .filter(p -> p.getName().equals(p.getPath()))
+                .findFirst().map(SimplePropertyDefinition::getPath).orElse("configuration") + ".__version"))
+                .orElse("-1");
         return Integer.parseInt(version);
-    }
-
-    @SuppressWarnings("unchecked")
-    private void setVersion(final int version) {
-        getAllProperties().put(TACOKIT_CONFIG_VERSION, Integer.toString(version));
     }
 
     public int getConfigurationVersion() {
@@ -240,7 +231,6 @@ public class TaCoKitConfigurationModel {
     public void migrate(final Map<String, String> migratedProperties) {
         clear();
         getAllProperties().putAll(migratedProperties);
-        setVersion(getConfigurationVersion());
     }
 
     /**
@@ -299,13 +289,11 @@ public class TaCoKitConfigurationModel {
 
         static final String TACOKIT_CONFIG_ID = "__TACOKIT_CONFIG_ID"; //$NON-NLS-1$
 
-        static final String TACOKIT_CONFIG_VERSION = "__TACOKIT_CONFIG_VERSION"; //$NON-NLS-1$
-
         static final String TACOKIT_CONFIG_PARENT_ID = "__TACOKIT_CONFIG_PARENT_ID"; //$NON-NLS-1$
 
         static final String TACOKIT_PARENT_ITEM_ID = "__TACOKIT_PARENT_ITEM_ID"; //$NON-NLS-1$
 
-        private static final Set<String> keys = new HashSet<>(Arrays.asList(TACOKIT_CONFIG_ID, TACOKIT_CONFIG_VERSION,
+        private static final Set<String> keys = new HashSet<>(Arrays.asList(TACOKIT_CONFIG_ID,
                 TACOKIT_CONFIG_PARENT_ID, TACOKIT_PARENT_ITEM_ID));
 
         static boolean isBuiltIn(final String key) {

--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/ElementParameterCreator.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/ElementParameterCreator.java
@@ -117,7 +117,7 @@ public class ElementParameterCreator {
         checkSchemaProperties(new SettingVisitor(node, updateComponentsParameter, detail).withCategory(BASIC));
     }
 
-    private int getConfigTypeVersion(final PropertyDefinitionDecorator p, final ConfigTypeNodes configTypeNodes, final String familyId) {
+    public static int getConfigTypeVersion(final PropertyDefinitionDecorator p, final ConfigTypeNodes configTypeNodes, final String familyId) {
         final String type = p.getMetadata().get("configurationtype::type");
         final String name = p.getMetadata().get("configurationtype::name");
         return configTypeNodes.getNodes().values().stream()
@@ -127,7 +127,7 @@ public class ElementParameterCreator {
                 .findFirst().map(ConfigTypeNode::getVersion).orElse(-1);
     }
 
-    private String getPropertyFamilyId(final ConfigTypeNode it, final ConfigTypeNodes nodes) {
+    private static String getPropertyFamilyId(final ConfigTypeNode it, final ConfigTypeNodes nodes) {
         if (it.getParentId() == null) {
             return null;
         }

--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/SettingVisitor.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/SettingVisitor.java
@@ -343,7 +343,7 @@ public class SettingVisitor implements PropertyVisitor {
         if (isEnum && (validation == null || validation.getEnumValues() == null)) {
             throw new IllegalArgumentException("No values for enum " + node.getProperty().getPath());
         }
-        final int valuesCount;
+
         if (validation == null || validation.getEnumValues() == null || validation.getEnumValues().isEmpty()) {
             final ActionReference dynamicValuesAction =
                     ofNullable(node.getProperty().getMetadata().get("action::dynamic_values"))
@@ -365,7 +365,6 @@ public class SettingVisitor implements PropertyVisitor {
                 throw new IllegalStateException("No proposals for " + node.getProperty().getPath());
             }
             final Collection<Map<String, String>> items = Collection.class.cast(rawItems);
-            valuesCount = items.size();
             final String[] ids = items.stream().map(m -> m.get("id")).toArray(String[]::new);
             final String[] labels =
                     items.stream().map(m -> m.getOrDefault("label", m.get("id"))).toArray(String[]::new);
@@ -374,7 +373,7 @@ public class SettingVisitor implements PropertyVisitor {
             parameter.setListItemsDisplayCodeName(labels);
         } else {
             final List<String> possibleValues = new ArrayList<>(validation.getEnumValues());
-            valuesCount = possibleValues.size();
+            final int valuesCount = possibleValues.size();
 
             final String[] valuesArray = possibleValues.toArray(new String[valuesCount]);
             parameter.setListItemsValue(valuesArray);
@@ -385,17 +384,13 @@ public class SettingVisitor implements PropertyVisitor {
             parameter.setListItemsDisplayCodeName(valuesArray);
         }
 
-        parameter.setListItemsReadOnlyIf(new String[valuesCount]);
-        parameter.setListItemsNotReadOnlyIf(new String[valuesCount]);
-        parameter.setListItemsShowIf(new String[valuesCount]);
-        parameter.setListItemsNotShowIf(new String[valuesCount]);
-
         String defaultValue = node.getProperty().getDefaultValue();
         if (defaultValue == null && node.getProperty().getMetadata() != null) {
             defaultValue = node.getProperty().getMetadata().get("ui::defaultvalue::value");
         }
         parameter.setDefaultClosedListValue(defaultValue);
         parameter.setDefaultValue(defaultValue);
+        parameter.setValue(defaultValue);
         return parameter;
     }
 

--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/TextElementParameter.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/TextElementParameter.java
@@ -30,7 +30,7 @@ public class TextElementParameter extends DebouncedParameter implements IAdvance
 
     @Override
     public void setValue(final Object newValue) {
-        super.setValue(String.valueOf(newValue));
+        super.setValue(newValue == null ? null : String.valueOf(newValue));
     }
 
     @Override

--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/VersionParameter.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/VersionParameter.java
@@ -5,7 +5,7 @@ import org.talend.core.model.process.EParameterFieldType;
 import org.talend.core.model.process.IElement;
 import org.talend.designer.core.model.components.ElementParameter;
 
-public class VersionParameter extends ElementParameter {
+public class VersionParameter extends TaCoKitElementParameter {
 
     public static final String VERSION_SUFFIX = ".__version";
 
@@ -13,7 +13,7 @@ public class VersionParameter extends ElementParameter {
         super(element);
         setTaggedValue("org.talend.sdk.component.source", "tacokit");
         setName(path + VERSION_SUFFIX);
-        setValue(version);
+        updateValueOnly(version);
         setDisplayName(path + VERSION_SUFFIX);
         setFieldType(EParameterFieldType.TECHNICAL);
         setCategory(EComponentCategory.BASIC);

--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/resolver/HealthCheckResolver.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/resolver/HealthCheckResolver.java
@@ -68,8 +68,8 @@ public class HealthCheckResolver {
     public void resolveParameters(final Map<String, IElementParameter> settings) {
         final ButtonParameter button = new ButtonParameter(element);
         button.setCategory(category);
-        button.setDisplayName(ofNullable(node.getProperty().getDisplayName())
-                .filter(it -> !node.getProperty().getName().equals(it))
+        button.setDisplayName(ofNullable(action.getDisplayName())
+                .filter(it -> !action.getName().equals(it))
                 .orElseGet(() -> Messages.getString("healthCheck.button")));
         button.setName(node.getProperty().getPath() + ".testConnection");
         button.setNumRow(rowNumber);

--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/ui/composite/TaCoKitWizardComposite.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/ui/composite/TaCoKitWizardComposite.java
@@ -34,11 +34,14 @@ public class TaCoKitWizardComposite extends TaCoKitComposite {
 
     private final IValueChangedListener configurationUpdater;
 
+    private final boolean isNew;
+
     public TaCoKitWizardComposite(final Composite parentComposite, final int styles, final EComponentCategory section,
             final Element element, final TaCoKitConfigurationModel model, final boolean isCompactView,
-            final Color backgroundColor) {
+            final Color backgroundColor, final boolean isNew) {
         super(parentComposite, styles, section, element, isCompactView, backgroundColor);
         this.configurationModel = model;
+        this.isNew = isNew;
         configurationUpdater = new ConfigurationModelUpdater();
         init();
     }
@@ -72,6 +75,10 @@ public class TaCoKitWizardComposite extends TaCoKitComposite {
                 .filter(TaCoKitElementParameter::isPersisted)
                 .forEach(parameter -> {
                     parameter.addValueChangeListener(configurationUpdater);
+                    if (isNew) {
+                        parameter.setValue(parameter.getValue());
+                        return;
+                    }
                     try {
                         ValueModel valueModel = configurationModel.getValue(parameter.getName());
                         if (valueModel != null) {

--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/ui/wizard/TaCoKitConfigurationWizard.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/ui/wizard/TaCoKitConfigurationWizard.java
@@ -51,6 +51,8 @@ public abstract class TaCoKitConfigurationWizard extends CheckLastVersionReposit
 
     private TaCoKitConfigurationWizardPage advancedPage;
 
+    protected abstract boolean isNew();
+
     public TaCoKitConfigurationWizard(final IWorkbench workbench, final TaCoKitConfigurationRuntimeData runtimeData) {
         super(workbench, runtimeData.isCreation(), runtimeData.isReadonly());
         this.runtimeData = runtimeData;
@@ -139,11 +141,11 @@ public abstract class TaCoKitConfigurationWizard extends CheckLastVersionReposit
         addPage(wizardPropertiesPage);
         final PropertyNode root = new PropertyTreeCreator(new WizardTypeMapper()).createPropertyTree(configTypeNode);
         if (root.hasLeaves(Metadatas.MAIN_FORM)) {
-            mainPage = new TaCoKitConfigurationWizardPage(runtimeData, Metadatas.MAIN_FORM);
+            mainPage = new TaCoKitConfigurationWizardPage(runtimeData, Metadatas.MAIN_FORM, isNew());
             addPage(mainPage);
         }
         if (root.hasLeaves(Metadatas.ADVANCED_FORM)) {
-            advancedPage = new TaCoKitConfigurationWizardPage(runtimeData, Metadatas.ADVANCED_FORM);
+            advancedPage = new TaCoKitConfigurationWizardPage(runtimeData, Metadatas.ADVANCED_FORM, isNew());
             addPage(advancedPage);
         }
     }

--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/ui/wizard/TaCoKitCreateWizard.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/ui/wizard/TaCoKitCreateWizard.java
@@ -41,6 +41,10 @@ public class TaCoKitCreateWizard extends TaCoKitConfigurationWizard {
         super(workbench, runtimeData);
     }
 
+    @Override protected boolean isNew() {
+        return true;
+    }
+
     /**
      * Part of constructor
      * Sets window title depending on whether it is {@code creation} wizard or editing
@@ -60,15 +64,11 @@ public class TaCoKitCreateWizard extends TaCoKitConfigurationWizard {
      */
     @Override
     protected IWorkspaceRunnable createFinishOperation() {
-        return new IWorkspaceRunnable() {
-
-            @Override
-            public void run(final IProgressMonitor monitor) throws CoreException {
-                try {
-                    createConfigurationItem();
-                } catch (Exception e) {
-                    throw new CoreException(new Status(IStatus.ERROR, GAV.INSTANCE.getArtifactId(), e.getMessage(), e));
-                }
+        return monitor -> {
+            try {
+                createConfigurationItem();
+            } catch (Exception e) {
+                throw new CoreException(new Status(IStatus.ERROR, GAV.INSTANCE.getArtifactId(), e.getMessage(), e));
             }
         };
     }

--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/ui/wizard/TaCoKitEditWizard.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/ui/wizard/TaCoKitEditWizard.java
@@ -31,6 +31,10 @@ import org.talend.sdk.component.studio.i18n.Messages;
  */
 public class TaCoKitEditWizard extends TaCoKitConfigurationWizard {
 
+    @Override protected boolean isNew() {
+        return false;
+    }
+
     public TaCoKitEditWizard(final IWorkbench workbench, final TaCoKitConfigurationRuntimeData runtimeData) {
         super(workbench, runtimeData);
     }
@@ -55,15 +59,11 @@ public class TaCoKitEditWizard extends TaCoKitConfigurationWizard {
      */
     @Override
     protected IWorkspaceRunnable createFinishOperation() {
-        return new IWorkspaceRunnable() {
-
-            @Override
-            public void run(final IProgressMonitor monitor) throws CoreException {
-                try {
-                    updateConfigurationItem();
-                } catch (Exception e) {
-                    throw new CoreException(new Status(IStatus.ERROR, GAV.INSTANCE.getArtifactId(), e.getMessage(), e));
-                }
+        return monitor -> {
+            try {
+                updateConfigurationItem();
+            } catch (Exception e) {
+                throw new CoreException(new Status(IStatus.ERROR, GAV.INSTANCE.getArtifactId(), e.getMessage(), e));
             }
         };
     }

--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/ui/wizard/page/TaCoKitConfigurationWizardPage.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/ui/wizard/page/TaCoKitConfigurationWizardPage.java
@@ -53,6 +53,8 @@ import org.talend.sdk.component.studio.ui.wizard.TaCoKitConfigurationRuntimeData
  */
 public class TaCoKitConfigurationWizardPage extends AbsTaCoKitWizardPage {
 
+    private final boolean isNew;
+
     private Element element;
 
     private TaCoKitWizardComposite tacokitComposite;
@@ -65,8 +67,10 @@ public class TaCoKitConfigurationWizardPage extends AbsTaCoKitWizardPage {
 
     private final EComponentCategory category;
 
-    public TaCoKitConfigurationWizardPage(final TaCoKitConfigurationRuntimeData runtimeData, final String form) {
+    public TaCoKitConfigurationWizardPage(final TaCoKitConfigurationRuntimeData runtimeData, final String form,
+            final boolean isNew) {
         super(Messages.getString("WizardPage.TaCoKitConfiguration"), runtimeData); //$NON-NLS-1$
+        this.isNew = isNew;
         final ConfigTypeNode configTypeNode = runtimeData.getConfigTypeNode();
         setTitle(Messages.getString("TaCoKitConfiguration.wizard.title", configTypeNode.getConfigurationType(), // $NON-NLS-1$
                 configTypeNode.getDisplayName()));
@@ -127,7 +131,7 @@ public class TaCoKitConfigurationWizardPage extends AbsTaCoKitWizardPage {
                     .forEach(p -> configurationModel.setValue(p));
             element.setElementParameters(parameters);
             tacokitComposite = new TaCoKitWizardComposite(container, SWT.H_SCROLL | SWT.V_SCROLL | SWT.NO_FOCUS, category,
-                    element, configurationModel, true, container.getBackground());
+                    element, configurationModel, true, container.getBackground(), isNew);
             tacokitComposite.setLayoutData(createMainFormData(runtimeData.isAddContextFields()));
 
         } catch (Exception e) {

--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/ui/wizard/page/TaCoKitConfigurationWizardPage.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/ui/wizard/page/TaCoKitConfigurationWizardPage.java
@@ -15,6 +15,7 @@ package org.talend.sdk.component.studio.ui.wizard.page;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.swt.SWT;
@@ -34,8 +35,8 @@ import org.talend.designer.core.model.components.EParameterName;
 import org.talend.designer.core.model.components.ElementParameter;
 import org.talend.designer.core.model.process.DataNode;
 import org.talend.sdk.component.server.front.model.ConfigTypeNode;
+import org.talend.sdk.component.studio.Lookups;
 import org.talend.sdk.component.studio.i18n.Messages;
-import org.talend.sdk.component.studio.metadata.model.TaCoKitConfigurationItemModel;
 import org.talend.sdk.component.studio.metadata.model.TaCoKitConfigurationModel;
 import org.talend.sdk.component.studio.model.parameter.Layout;
 import org.talend.sdk.component.studio.model.parameter.LayoutParameter;
@@ -43,6 +44,7 @@ import org.talend.sdk.component.studio.model.parameter.Metadatas;
 import org.talend.sdk.component.studio.model.parameter.PropertyNode;
 import org.talend.sdk.component.studio.model.parameter.PropertyTreeCreator;
 import org.talend.sdk.component.studio.model.parameter.SettingVisitor;
+import org.talend.sdk.component.studio.model.parameter.VersionParameter;
 import org.talend.sdk.component.studio.ui.composite.TaCoKitWizardComposite;
 import org.talend.sdk.component.studio.ui.wizard.TaCoKitConfigurationRuntimeData;
 
@@ -94,8 +96,6 @@ public class TaCoKitConfigurationWizardPage extends AbsTaCoKitWizardPage {
 
             final TaCoKitConfigurationRuntimeData runtimeData = getTaCoKitConfigurationRuntimeData();
             configurationModel = getConfigurationItemModel();
-            final boolean addContextFields = runtimeData.isAddContextFields();
-
             final ConfigTypeNode configTypeNode = runtimeData.getConfigTypeNode();
             final DummyComponent component = new DummyComponent(configTypeNode.getDisplayName());
             final DataNode node = new DataNode(component, component.getName());
@@ -112,21 +112,24 @@ public class TaCoKitConfigurationWizardPage extends AbsTaCoKitWizardPage {
             parameters.addAll(settingsCreator.getSettings());
             final ElementParameter layoutParameter = createLayoutParameter(root, form, category, element);
             parameters.add(layoutParameter);
+            //add version params
+            Map<String, ConfigTypeNode> nodes = Lookups.taCoKitCache().getConfigTypeNodeMap();
+            configTypeNode.getProperties()
+                    .stream()
+                    .filter(p -> p.getMetadata().containsKey("configurationtype::type") && p.getMetadata().containsKey("configurationtype::name"))
+                    .map(p -> new VersionParameter(node, p.getPath(),
+                            nodes.values().stream()
+                                    .filter(n -> n.getConfigurationType() != null)
+                                    .filter(n -> p.getMetadata().get("configurationtype::type").equals(n.getConfigurationType()))
+                                    .filter(n -> n.getName().equals(p.getMetadata().get("configurationtype::name")))
+                                    .findFirst()
+                                    .map(n -> String.valueOf(n.getVersion())).orElse("-1")))
+                    .forEach(p -> configurationModel.setValue(p));
             element.setElementParameters(parameters);
+            tacokitComposite = new TaCoKitWizardComposite(container, SWT.H_SCROLL | SWT.V_SCROLL | SWT.NO_FOCUS, category,
+                    element, configurationModel, true, container.getBackground());
+            tacokitComposite.setLayoutData(createMainFormData(runtimeData.isAddContextFields()));
 
-            tacokitComposite =
-                    new TaCoKitWizardComposite(container, SWT.H_SCROLL | SWT.V_SCROLL | SWT.NO_FOCUS, category,
-                            element, configurationModel, true, container.getBackground());
-            tacokitComposite.setLayoutData(createMainFormData(addContextFields));
-
-            if (addContextFields) {
-                // Composite contextParentComp = new Composite(container, SWT.NONE);
-                // contextParentComp.setLayoutData(createFooterFormData(tacokitComposite));
-                // contextParentComp.setLayout(new GridLayout());
-                // ContextComposite contextComp = addContextFields(contextParentComp);
-                // contextComp.addPropertyChangeListener(tacokitComposite);
-                // contextComp.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-            }
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }
@@ -185,7 +188,9 @@ public class TaCoKitConfigurationWizardPage extends AbsTaCoKitWizardPage {
 
     @Override
     protected IStatus[] getStatuses() {
-        return Arrays.asList(super.getStatuses(), tacokitConfigStatus).toArray(new IStatus[0]);
+        List<IStatus> status = Arrays.asList(super.getStatuses());
+        status.add(tacokitConfigStatus);
+        return status.toArray(new IStatus[0]);
     }
 
 }

--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/util/TaCoKitUtil.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/util/TaCoKitUtil.java
@@ -89,8 +89,7 @@ public class TaCoKitUtil {
             if (parentTypeNode == null) {
                 throw new NullPointerException("Can't find parent node: " + parentId);
             }
-            IPath parentPath = getTaCoKitBaseFolder(parentTypeNode);
-            baseFolderPath = parentPath;
+            baseFolderPath = getTaCoKitBaseFolder(parentTypeNode);
         }
         // better to use lowercase, since different OS support different path name
         String configName = getTaCoKitFolderName(configNode);


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TCOMP-996

**What is the new behavior?**
I have added the configuration version to the serialized properties.

**What is missing :** 
* path adaptation of the configuration. root configuration need to be passed to migration without the configuration prefix to respect the migration handler expectation. only component migration handler expect the configuration prefix as defined in component constructor.

* ElementParameter value need to be updated after the migration and synchronized with the connection properties which hold the node data



