### PR TITLE
fix(TDI-32740): Change default command separator

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tSCPFileList/tSCPFileList_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSCPFileList/tSCPFileList_java.xml
@@ -124,7 +124,7 @@
       FIELD="TEXT"
       NUM_ROW="90"
     >
-      <DEFAULT>":"</DEFAULT>
+      <DEFAULT>";"</DEFAULT>
     </PARAMETER>
 
     <PARAMETER


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
Default command separator is ":"

**What is the new behavior?**
Default command separator is ";"

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

https://jira.talendforge.org/browse/TDI-32740
