### PR TITLE
feat(TDI-40875): give to writer all incoming columns

### DIFF
--- a/main/plugins/org.talend.designer.codegen/jet_stub/generic/component_main.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/generic/component_main.javajet
@@ -79,14 +79,6 @@ if(hasInput){
     if (hasValidInput && haveValidNodeMetadata) {
         List<IMetadataColumn> input_columnList = inputConn.getMetadataTable().getListColumns();
         
-        Set<String> currentComponentColumnLabels = new HashSet<String>();
-        List<IMetadataColumn> columnList = metadata.getListColumns();
-        if(columnList!=null) {
-            for(IMetadataColumn componentColumn : columnList) {
-            	currentComponentColumnLabels.add(componentColumn.getLabel());
-            }
-        }
-        
         if (input_columnList!=null && !input_columnList.isEmpty()) {
             // If there are dynamic columns in the schema, they need to be
             // initialized into the runtime schema of the actual IndexedRecord
@@ -124,10 +116,6 @@ if(hasInput){
             for (int i = 0; i < input_columnList.size(); i++) { // column
                 IMetadataColumn column = input_columnList.get(i);
                 if (dynamicPos != i) {
-                	//skip the put action if the input column doesn't appear in component metadata
-                	if(!currentComponentColumnLabels.contains(column.getLabel())) {
-                		continue;
-                	}
                     %>
                     incomingEnforcer_<%=cid%>.put("<%=column.getLabel()%>", <%=inputConn.getName()%>.<%=column.getLabel()%>);
                     <%

--- a/main/plugins/org.talend.designer.codegen/jet_stub/generic/component_main.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/generic/component_main.javajet
@@ -80,6 +80,27 @@ if(hasInput){
         List<IMetadataColumn> input_columnList = inputConn.getMetadataTable().getListColumns();
         
         if (input_columnList!=null && !input_columnList.isEmpty()) {
+            // add incoming (not present) columns to enforcer for this comps
+            if (cid.contains("tDataStewardship") || cid.contains("tMarkLogic")){
+                %>
+                boolean shouldCreateRuntimeSchemaForIncomingNode = false;
+                <%
+                for (int i = 0; i < input_columnList.size(); i++) {
+                    if(!input_columnList.get(i).getTalendType().equals("id_Dynamic")) {
+                    %>
+                        if (incomingEnforcer_<%=cid%>.getDesignSchema().getField("<%=input_columnList.get(i)%>") == null){
+                            incomingEnforcer_<%=cid%>.addIncomingNodeField("<%=input_columnList.get(i)%>", <%=inputConn.getName()%>.<%=input_columnList.get(i)%>.getClass().getCanonicalName());
+                            shouldCreateRuntimeSchemaForIncomingNode = true;
+                        }
+                    <%
+                    }
+                }
+                %>
+                if (shouldCreateRuntimeSchemaForIncomingNode){
+                    incomingEnforcer_<%=cid%>.createRuntimeSchema();
+                }
+                <%
+            }
             // If there are dynamic columns in the schema, they need to be
             // initialized into the runtime schema of the actual IndexedRecord
             // provided to the component.
@@ -117,7 +138,10 @@ if(hasInput){
                 IMetadataColumn column = input_columnList.get(i);
                 if (dynamicPos != i) {
                     %>
-                    incomingEnforcer_<%=cid%>.put("<%=column.getLabel()%>", <%=inputConn.getName()%>.<%=column.getLabel()%>);
+                    //skip the put action if the input column doesn't appear in component runtime schema
+                    if (incomingEnforcer_<%=cid%>.getRuntimeSchema().getField("<%=input_columnList.get(i)%>") != null){
+                        incomingEnforcer_<%=cid%>.put("<%=column.getLabel()%>", <%=inputConn.getName()%>.<%=column.getLabel()%>);
+                    }
                     <%
                 } else {
                     %>


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

https://jira.talendforge.org/browse/TDI-40875

Currently, the incomingEnforcer only contains the columns defined in the outgoing schema.
So, if a component needs the incoming values there're not passed to writer until they are defined in the outgoing schema. 

**What is the new behavior?**

Now, we give to the writer all incoming columns even if there're not in the component's schema.
This allows to use incoming values for anything like querying and not polluting the outgoing schema.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


