### PR TITLE
fix(TDI-40927): Set default Authenticator for ftp socks proxy

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPConnection/tFTPConnection_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPConnection/tFTPConnection_begin.javajet
@@ -52,6 +52,11 @@ if (ElementParameterParser.canEncrypt(node, passwordFieldName)) {
 <%}%>
 
   props_<%=cid%>.put("java.net.socks.password", decryptedProxyPassword_<%=cid%>);
+  java.net.Authenticator.setDefault(new java.net.Authenticator() {
+        public java.net.PasswordAuthentication getPasswordAuthentication() {
+            return new java.net.PasswordAuthentication(<%=proxyUser %>, decryptedProxyPassword_<%=cid%>.toCharArray());
+        }
+  });
 <%
 }
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPDelete/tFTPDelete_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPDelete/tFTPDelete_begin.javajet
@@ -77,7 +77,12 @@ if (ElementParameterParser.canEncrypt(node, passwordFieldName)) {
   String decryptedProxyPassword_<%=cid%> = <%= ElementParameterParser.getValue(node, passwordFieldName)%>; 
 <%}%>
 
-  props_<%=cid%>.put("java.net.socks.password", decryptedProxyPassword_<%=cid%>);        
+  props_<%=cid%>.put("java.net.socks.password", decryptedProxyPassword_<%=cid%>);
+  java.net.Authenticator.setDefault(new java.net.Authenticator() {
+        public java.net.PasswordAuthentication getPasswordAuthentication() {
+            return new java.net.PasswordAuthentication(<%=proxyUser %>, decryptedProxyPassword_<%=cid%>.toCharArray());
+        }
+  });
 <%}%>
 int nb_file_<%=cid%> = 0;
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPFileExist/tFTPFileExist_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPFileExist/tFTPFileExist_begin.javajet
@@ -78,7 +78,12 @@ if (ElementParameterParser.canEncrypt(node, passwordFieldName)) {
   String decryptedProxyPassword_<%=cid%> = <%= ElementParameterParser.getValue(node, passwordFieldName)%>; 
 <%}%>
 
-  props_<%=cid%>.put("java.net.socks.password", decryptedProxyPassword_<%=cid%>);        
+  props_<%=cid%>.put("java.net.socks.password", decryptedProxyPassword_<%=cid%>);
+  java.net.Authenticator.setDefault(new java.net.Authenticator() {
+        public java.net.PasswordAuthentication getPasswordAuthentication() {
+            return new java.net.PasswordAuthentication(<%=proxyUser %>, decryptedProxyPassword_<%=cid%>.toCharArray());
+        }
+  });
 <%
 }
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPFileList/tFTPFileList_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPFileList/tFTPFileList_begin.javajet
@@ -94,7 +94,12 @@ if (ElementParameterParser.canEncrypt(node, passwordFieldName)) {
  	String decryptedProxyPassword_<%=cid%> = <%= ElementParameterParser.getValue(node, passwordFieldName)%>; 
 <%}%>
 
-	props_<%=cid%>.put("java.net.socks.password", decryptedProxyPassword_<%=cid%>);		
+	props_<%=cid%>.put("java.net.socks.password", decryptedProxyPassword_<%=cid%>);
+	java.net.Authenticator.setDefault(new java.net.Authenticator() {
+		public java.net.PasswordAuthentication getPasswordAuthentication() {
+			return new java.net.PasswordAuthentication(<%=proxyUser %>, decryptedProxyPassword_<%=cid%>.toCharArray());
+		}
+	});
 <%
 }
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPFileProperties/tFTPFileProperties_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPFileProperties/tFTPFileProperties_begin.javajet
@@ -82,7 +82,12 @@ if (ElementParameterParser.canEncrypt(node, passwordFieldName)) {
   String decryptedProxyPassword_<%=cid%> = <%= ElementParameterParser.getValue(node, passwordFieldName)%>; 
 <%}%>
 
-  props_<%=cid%>.put("java.net.socks.password", decryptedProxyPassword_<%=cid%>);    
+  props_<%=cid%>.put("java.net.socks.password", decryptedProxyPassword_<%=cid%>);
+  java.net.Authenticator.setDefault(new java.net.Authenticator() {
+        public java.net.PasswordAuthentication getPasswordAuthentication() {
+            return new java.net.PasswordAuthentication(<%=proxyUser %>, decryptedProxyPassword_<%=cid%>.toCharArray());
+        }
+  });
 <%
 }
 String outputConnName = null;

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPGet/tFTPGet_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPGet/tFTPGet_begin.javajet
@@ -88,7 +88,12 @@ if (ElementParameterParser.canEncrypt(node, passwordFieldName)) {
   String decryptedProxyPassword_<%=cid%> = <%= ElementParameterParser.getValue(node, passwordFieldName)%>; 
 <%}%>
 
-  props_<%=cid%>.put("java.net.socks.password", decryptedProxyPassword_<%=cid%>);        
+  props_<%=cid%>.put("java.net.socks.password", decryptedProxyPassword_<%=cid%>);
+  java.net.Authenticator.setDefault(new java.net.Authenticator() {
+        public java.net.PasswordAuthentication getPasswordAuthentication() {
+            return new java.net.PasswordAuthentication(<%=proxyUser %>, decryptedProxyPassword_<%=cid%>.toCharArray());
+        }
+  });
 <%
 } 
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPPut/tFTPPut_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPPut/tFTPPut_begin.javajet
@@ -82,7 +82,12 @@ if (ElementParameterParser.canEncrypt(node, passwordFieldName)) {
   String decryptedProxyPassword_<%=cid%> = <%= ElementParameterParser.getValue(node, passwordFieldName)%>; 
 <%}%>
 
-  props_<%=cid%>.put("java.net.socks.password",decryptedProxyPassword_<%=cid%>);        
+  props_<%=cid%>.put("java.net.socks.password",decryptedProxyPassword_<%=cid%>);
+  java.net.Authenticator.setDefault(new java.net.Authenticator() {
+        public java.net.PasswordAuthentication getPasswordAuthentication() {
+            return new java.net.PasswordAuthentication(<%=proxyUser %>, decryptedProxyPassword_<%=cid%>.toCharArray());
+        }
+  });
 <%}%>
 int nb_file_<%=cid%> = 0;
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPRename/tFTPRename_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPRename/tFTPRename_begin.javajet
@@ -79,7 +79,12 @@ if (ElementParameterParser.canEncrypt(node, passwordFieldName)) {
   	String decryptedProxyPassword_<%=cid%> = <%= ElementParameterParser.getValue(node, passwordFieldName)%>; 
 <%}%>
 
-	props_<%=cid%>.put("java.net.socks.password", decryptedProxyPassword_<%=cid%>);        
+	props_<%=cid%>.put("java.net.socks.password", decryptedProxyPassword_<%=cid%>);
+	java.net.Authenticator.setDefault(new java.net.Authenticator() {
+		public java.net.PasswordAuthentication getPasswordAuthentication() {
+			return new java.net.PasswordAuthentication(<%=proxyUser %>, decryptedProxyPassword_<%=cid%>.toCharArray());
+		}
+	});
 <%}%>
 	int nb_file_<%=cid%> = 0;
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFTPTruncate/tFTPTruncate_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFTPTruncate/tFTPTruncate_begin.javajet
@@ -77,7 +77,12 @@ if (ElementParameterParser.canEncrypt(node, passwordFieldName)) {
   String decryptedProxyPassword_<%=cid%> = <%= ElementParameterParser.getValue(node, passwordFieldName)%>; 
 <%}%>
 	
-	props_<%=cid%>.put("java.net.socks.password", decryptedProxyPassword_<%=cid%>);        
+	props_<%=cid%>.put("java.net.socks.password", decryptedProxyPassword_<%=cid%>);
+	java.net.Authenticator.setDefault(new java.net.Authenticator() {
+		public java.net.PasswordAuthentication getPasswordAuthentication() {
+			return new java.net.PasswordAuthentication(<%=proxyUser %>, decryptedProxyPassword_<%=cid%>.toCharArray());
+		}
+	});
 <%}%>
 	int nb_file_<%=cid%> = 0;
 


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
SOCKS Proxy with auth doesn't work for ftp components

**What is the new behavior?**
SOCKS Proxy with auth works

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


