### PR TITLE
fix(TCOMP-1056): fix refresh problem on advanced component tab

### DIFF
--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/views/properties/ComponentSettingsView.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/views/properties/ComponentSettingsView.java
@@ -260,14 +260,15 @@ public class ComponentSettingsView extends ViewPart implements IComponentSetting
             } else if (category == EComponentCategory.SQL_PATTERN) {
                 dc = new SQLPatternComposite(parent, SWT.H_SCROLL | SWT.V_SCROLL | SWT.NO_FOCUS, element);
             } else if (category == EComponentCategory.ADVANCED) {
-                dc = new MissingSettingsMultiThreadDynamicComposite(parent, SWT.H_SCROLL | SWT.V_SCROLL | SWT.NO_FOCUS, category,
-                        element, true);
                 // Generic
                 if (generic && wizardService != null) {
                     Composite composite = wizardService.creatDynamicComposite(parent, element, EComponentCategory.ADVANCED, true);
                     if (composite instanceof MultipleThreadDynamicComposite) {
                         dc = (MultipleThreadDynamicComposite) composite;
                     }
+                } else {
+                    dc = new MissingSettingsMultiThreadDynamicComposite(parent, SWT.H_SCROLL | SWT.V_SCROLL | SWT.NO_FOCUS, category,
+                            element, true);
                 }
             } else {
                 dc = new MultipleThreadDynamicComposite(parent, SWT.H_SCROLL | SWT.V_SCROLL | SWT.NO_FOCUS, category, element,


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

Current implementation has an issue. MissingSettingsMultiThreadDynamicComposite() contstructor is called in any case. It creates the whole composite using javajet-specific algorithms. 
Then Tacokit-specific composite is created too. It constructs one more composite.
However, javajet composite already exists and attached to parent composite. Also this composite is shown to user.

**What is the new behavior?**

Now, only one composite is created.

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
https://jira.talendforge.org/browse/TCOMP-1056

