### PR TITLE
Dsylaiev/tdi 37336 add error message when context value set to null

### DIFF
--- a/main/plugins/org.talend.designer.codegen/jet_stub/footer.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/footer.javajet
@@ -526,7 +526,9 @@
 
 				}
             }
-            <% for (IContextParameter ctxParam :params)
+            <%
+            String warningMessageFormat = "Null value will be used for context parameter %s: %s";
+            for (IContextParameter ctxParam :params)
             {
 				%>
 				    context.setContextType("<%=ctxParam.getName()%>", "<%=ctxParam.getType()%>");
@@ -578,13 +580,11 @@
 <%
                 if (isLog4jEnabled) {
 %>
-                    log.warn("Can't parse context value to Date: " + e.getMessage());
-                    log.warn("Null value will be used for context parameter <%=ctxParam.getName() %>\n");
+                    log.warn(String.format("<%=warningMessageFormat %>", "<%=ctxParam.getName() %>", e.getMessage()));
 <%
                 } else {
 %>
-                    System.err.println("Can't parse context value to Date: " + e.getMessage());
-                    System.err.println("Null value will be used for context parameter <%=ctxParam.getName() %>\n");
+                    System.err.println(String.format("<%=warningMessageFormat %>", "<%=ctxParam.getName() %>", e.getMessage()));
 <%
                 }
 %>
@@ -609,13 +609,11 @@
 <%
                 if (isLog4jEnabled) {
 %>
-                    log.warn("Can't parse context value to <%=typeToGenerate %>: " + e.getMessage());
-                    log.warn("Null value will be used for context parameter <%=ctxParam.getName() %>\n");
+                    log.warn(String.format("<%=warningMessageFormat %>", "<%=ctxParam.getName() %>", e.getMessage()));
 <%
                 } else {
 %>
-                    System.err.println("Can't parse context value to <%=typeToGenerate %>: " + e.getMessage());
-                    System.err.println("Null value will be used for context parameter <%=ctxParam.getName() %>\n");
+                    System.err.println(String.format("<%=warningMessageFormat %>", "<%=ctxParam.getName() %>", e.getMessage()));
 <%
                 }
 %>

--- a/main/plugins/org.talend.designer.codegen/jet_stub/footer.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/footer.javajet
@@ -593,6 +593,8 @@
              try{
                  context.<%=ctxParam.getName()%>=routines.system.ParserUtils.parseTo_<%=typeToGenerate%> (context.getProperty("<%=ctxParam.getName()%>"));
              }catch(NumberFormatException e){
+                 System.err.println("Can't parse context value to <%=typeToGenerate %>: " + e.getMessage());
+                 System.err.println("Null value will be used for context parameter <%=ctxParam.getName() %>");
                  context.<%=ctxParam.getName()%>=null;
               }
              <%

--- a/main/plugins/org.talend.designer.codegen/jet_stub/footer.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/footer.javajet
@@ -575,8 +575,19 @@
 
             }catch(ParseException e)
             {
-                System.err.println("Can't parse context value to Date: " + e.getMessage());
-                System.err.println("Null value will be used for context parameter <%=ctxParam.getName() %>");
+<%
+                if (isLog4jEnabled) {
+%>
+                    log.warn("Can't parse context value to Date: " + e.getMessage());
+                    log.warn("Null value will be used for context parameter <%=ctxParam.getName() %>\n");
+<%
+                } else {
+%>
+                    System.err.println("Can't parse context value to Date: " + e.getMessage());
+                    System.err.println("Null value will be used for context parameter <%=ctxParam.getName() %>\n");
+<%
+                }
+%>
                 context.<%=ctxParam.getName()%>=null;
             }
               <%
@@ -595,8 +606,19 @@
              try{
                  context.<%=ctxParam.getName()%>=routines.system.ParserUtils.parseTo_<%=typeToGenerate%> (context.getProperty("<%=ctxParam.getName()%>"));
              }catch(NumberFormatException e){
-                 System.err.println("Can't parse context value to <%=typeToGenerate %>: " + e.getMessage());
-                 System.err.println("Null value will be used for context parameter <%=ctxParam.getName() %>");
+<%
+                if (isLog4jEnabled) {
+%>
+                    log.warn("Can't parse context value to <%=typeToGenerate %>: " + e.getMessage());
+                    log.warn("Null value will be used for context parameter <%=ctxParam.getName() %>\n");
+<%
+                } else {
+%>
+                    System.err.println("Can't parse context value to <%=typeToGenerate %>: " + e.getMessage());
+                    System.err.println("Null value will be used for context parameter <%=ctxParam.getName() %>\n");
+<%
+                }
+%>
                  context.<%=ctxParam.getName()%>=null;
               }
              <%

--- a/main/plugins/org.talend.designer.codegen/jet_stub/footer.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/footer.javajet
@@ -575,6 +575,8 @@
 
             }catch(ParseException e)
             {
+                System.err.println("Can't parse context value to Date: " + e.getMessage());
+                System.err.println("Null value will be used for context parameter <%=ctxParam.getName() %>");
                 context.<%=ctxParam.getName()%>=null;
             }
               <%


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

When parsing expection occurs, context value is to null without any notifying the user
**What is the new behavior?**

When parsing expection occurs, user notification appear
**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


