### PR TITLE
fix(TCOMP-1078): fix guess schema button visibility

### DIFF
--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/ui/composite/TaCoKitWizardComposite.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/ui/composite/TaCoKitWizardComposite.java
@@ -103,12 +103,11 @@ public class TaCoKitWizardComposite extends TaCoKitComposite {
     /**
      * Overrides parent method as Property Type widget should not be shown in wizard pages
      *
-     * @param parent parent Composite
      * @return last Composite added
      */
     @Override
-    protected Composite addCommonWidgets(final Composite parent) {
-        return addSchemas(parent, null);
+    protected Composite addCommonWidgets() {
+        return addSchemas(composite, null);
     }
 
     private class ConfigurationModelUpdater implements IValueChangedListener {


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

Guess schema button is created only for schema which is not present on layout (basic or advanced). However, it is not created for if schema is present on layout.

**What is the new behavior?**

Guess schema button is created regardless it is present or not on layout

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
https://jira.talendforge.org/browse/TCOMP-1078


