### PR TITLE
fix(TCOMP-925): columns order in tcompv1 tables

### DIFF
--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/ListPropertyNode.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/ListPropertyNode.java
@@ -18,6 +18,8 @@ package org.talend.sdk.component.studio.model.parameter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.talend.core.model.process.EParameterFieldType;
 
@@ -51,7 +53,12 @@ public class ListPropertyNode extends PropertyNode {
         column.setParent(this);
     }
 
-    public List<PropertyNode> getColumns() {
-        return Collections.unmodifiableList(nestedProperties);
+    public List<PropertyNode> getColumns(String form) {
+        final Set<String> childrenNames = getChildrenNames(form);
+        return Collections.unmodifiableList(
+                sortChildren(nestedProperties
+                        .stream()
+                        .filter(node -> childrenNames.contains(node.getProperty().getName()))
+                        .collect(Collectors.toList()), form));
     }
 }

--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/PropertyNode.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/PropertyNode.java
@@ -28,10 +28,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.talend.core.model.process.EParameterFieldType;
-
 import javax.json.bind.annotation.JsonbCreator;
 import javax.json.bind.annotation.JsonbProperty;
+
+import org.talend.core.model.process.EParameterFieldType;
 
 public class PropertyNode {
 
@@ -185,7 +185,7 @@ public class PropertyNode {
      * @param form Name or form
      * @return sorted list
      */
-    private List<PropertyNode> sortChildren(final List<PropertyNode> children, final String form) {
+    protected List<PropertyNode> sortChildren(final List<PropertyNode> children, final String form) {
         final HashMap<String, Integer> order = property.getChildrenOrder(form);
         if (order != null) {
             children.sort((node1, node2) -> {
@@ -207,7 +207,7 @@ public class PropertyNode {
      * @param form Name of form
      * @return children names of specified <code>form</code>
      */
-    private Set<String> getChildrenNames(final String form) {
+    protected Set<String> getChildrenNames(final String form) {
         if (MAIN_FORM.equals(form)) {
             return getMainChildrenNames();
         } else {

--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/SettingVisitor.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/SettingVisitor.java
@@ -585,7 +585,7 @@ public class SettingVisitor implements PropertyVisitor {
      * @return list of table parameters
      */
     private List<IElementParameter> createTableParameters(final ListPropertyNode tableNode) {
-        final List<PropertyNode> columns = tableNode.getColumns();
+        final List<PropertyNode> columns = tableNode.getColumns(form);
         if (columns.size() == 1 && columns.get(0).getProperty().getDisplayName().endsWith("[${index}]")) {
             columns.iterator().next().getProperty().setDisplayName("Value");
         }


### PR DESCRIPTION
* Add support for OptionsOrder/GridLayout for SomeClass used as List<SomeClass> option in Studio

**What is the current behavior?** (You can also link to an open issue here)
studio integration plugin ignores OptionsOrder/GridLayout for tables and columns are sorted in alphabetical order

**What is the new behavior?**
Columns are ordered as set in OptionsOrder/GridLayout

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
https://jira.talendforge.org/browse/TCOMP-925

