### PR TITLE
TESB-23238 API definitions parameters import in tRESTRequest

### DIFF
--- a/main/plugins/org.talend.designer.oas/src/org/talend/designer/oas/external/APIParam.java
+++ b/main/plugins/org.talend.designer.oas/src/org/talend/designer/oas/external/APIParam.java
@@ -1,0 +1,107 @@
+package org.talend.designer.oas.external;
+
+public class APIParam {
+
+    private String name;
+
+    private EParamType type;
+
+    private String pattern;
+
+    private EParamKind kind;
+
+    private boolean required = false;
+
+    private Integer length;
+
+    private String defaultValue;
+
+    public APIParam(String name, EParamType type, EParamKind paramKind) {
+        super();
+        this.name = name;
+        this.type = type;
+        this.kind = paramKind;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public EParamType getType() {
+        return type;
+    }
+
+    public void setType(EParamType type) {
+        this.type = type;
+    }
+
+    public String getPattern() {
+        return pattern;
+    }
+
+    public void setPattern(String pattern) {
+        this.pattern = pattern;
+    }
+
+    public EParamKind getParamKind() {
+        return kind;
+    }
+
+    public void setParamKind(EParamKind source) {
+        this.kind = source;
+    }
+
+    public Integer getLength() {
+        return length;
+    }
+
+    public void setLength(Integer length) {
+        this.length = length;
+    }
+
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+
+    public boolean isRequired() {
+        return required;
+    }
+
+    public void setRequired(boolean required) {
+        this.required = required;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        APIParam other = (APIParam) obj;
+        if (name == null) {
+            if (other.name != null)
+                return false;
+        } else if (!name.equals(other.name))
+            return false;
+        return true;
+    }
+
+}

--- a/main/plugins/org.talend.designer.oas/src/org/talend/designer/oas/external/EParamKind.java
+++ b/main/plugins/org.talend.designer.oas/src/org/talend/designer/oas/external/EParamKind.java
@@ -1,0 +1,45 @@
+package org.talend.designer.oas.external;
+/**
+ * MediaTypes *\/* application/xml text/xml application/json
+ */
+public enum EParamKind {
+
+    PATH("path"),
+    QUERY("query"),
+    FORM("form"),
+    HEADER("header"),
+    MATRIX("matrix"),
+    MULTIPART("multipart")
+    
+    ;
+
+    private String label;
+
+    /**
+     * DOC dsergent MediaTypes constructor comment.
+     * 
+     * @param label
+     */
+    private EParamKind(String label) {
+        this.label = label;
+    }
+
+    /**
+     * Getter for label.
+     * 
+     * @return the label
+     */
+    public String getLabel() {
+        return this.label;
+    }
+
+    public static EParamKind fromString(String text) {
+        for (EParamKind mt : EParamKind.values()) {
+            if (mt.label.equalsIgnoreCase(text)) {
+                return mt;
+            }
+        }
+        return null;
+    }
+
+}

--- a/main/plugins/org.talend.designer.oas/src/org/talend/designer/oas/external/EParamType.java
+++ b/main/plugins/org.talend.designer.oas/src/org/talend/designer/oas/external/EParamType.java
@@ -1,0 +1,63 @@
+package org.talend.designer.oas.external;
+
+/**
+ * MediaTypes *\/* application/xml text/xml application/json
+ */
+public enum EParamType {
+
+    BOOLEAN("boolean | Boolean", Boolean.class),
+    BYTE("byte | Byte", Byte.class),
+    // BYTE_ARRAY("byte[]"),
+    CHARACTER("char | Character", Character.class),
+    DATE("Date", java.util.Date.class),
+    DOUBLE("double | Double", Double.class),
+    FLOAT("float | Float", Float.class),
+    BIG_DECIMAL("BigDecimal", java.math.BigDecimal.class),
+    INTEGER("int | Integer", Integer.class),
+    LONG("long | Long", Long.class),
+    OBJECT("Object", Object.class),
+    SHORT("short | Short", Short.class),
+    STRING("String", String.class),
+    // LIST("List"),
+    // DYNAMIC("Dynamic"),
+    // DOCUMENT("Document")
+    ;
+
+    private String label;
+
+    private String talendTypeId;
+
+    /**
+     * DOC dsergent MediaTypes constructor comment.
+     * 
+     * @param label
+     */
+    private EParamType(String label, Class<?> nullableClass) {
+        this.label = label;
+        this.talendTypeId = "id_" + nullableClass.getSimpleName();
+
+    }
+
+    /**
+     * Getter for label.
+     * 
+     * @return the label
+     */
+    public String getLabel() {
+        return this.label;
+    }
+
+    public String getTalendTypeId() {
+        return talendTypeId;
+    }
+
+    public static EParamType fromString(String text) {
+        for (EParamType mt : EParamType.values()) {
+            if (mt.label.equalsIgnoreCase(text)) {
+                return mt;
+            }
+        }
+        return null;
+    }
+
+}

--- a/main/plugins/org.talend.designer.oas/src/org/talend/designer/oas/external/RestAPIMapping.java
+++ b/main/plugins/org.talend.designer.oas/src/org/talend/designer/oas/external/RestAPIMapping.java
@@ -1,4 +1,8 @@
 package org.talend.designer.oas.external;
+
+import java.util.LinkedList;
+import java.util.List;
+
 // ============================================================================
 //
 // Copyright (C) 2006-2018 Talend Inc. - www.talend.com
@@ -28,6 +32,8 @@ public class RestAPIMapping {
     private EESBMediaType consumes;
 
     private EESBMediaType produces;
+
+    private List<APIParam> params = new LinkedList<APIParam>();
 
     /**
      * DOC dsergent RestAPIMapping constructor comment.
@@ -134,6 +140,10 @@ public class RestAPIMapping {
      */
     public void setProduces(EESBMediaType produces) {
         this.produces = produces;
+    }
+
+    public List<APIParam> getParams() {
+        return params;
     }
 
     /*


### PR DESCRIPTION
**What is the new behavior?**

When using an API definition from metadata for tRESTRequest component,
operation parameters (path, query & header parameters) are now
automatically created.

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No
