### PR TITLE
TESB-23870 Camel dependencies are not included to manifest of route's child jobs

### DIFF
--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/maven/MavenJavaProcessor.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/maven/MavenJavaProcessor.java
@@ -349,6 +349,15 @@ public class MavenJavaProcessor extends JavaProcessor {
         if (!isMainJob && isGoalInstall) {
             if (!buildCacheManager.isJobBuild(getProperty())) {
                 deleteExistedJobJarFile(talendJavaProject);
+                if ("ROUTE".equalsIgnoreCase(getBuildType(getProperty())) && project != null) {
+                    // TESB-23870
+                    // child routes job project must be compiled explicitly for 
+                    // correct child job manifest generation during OSGi packaging
+                    if (!MavenProjectUtils.hasMavenNature(project)) {
+                        MavenProjectUtils.enableMavenNature(monitor, project);
+                    }
+                    talendJavaProject.buildWholeCodeProject();
+                }
                 buildCacheManager.putJobCache(getProperty());
             } else {
                 // for already installed sub jobs, can restore pom here directly
@@ -436,5 +445,12 @@ public class MavenJavaProcessor extends JavaProcessor {
         }
         // Else, a simple compilation is needed.
         return TalendMavenConstants.GOAL_COMPILE;
+    }
+    
+    private String getBuildType(Property property) {
+        if (property != null && property.getAdditionalProperties() != null) {
+            return (String) property.getAdditionalProperties().get(TalendProcessArgumentConstant.ARG_BUILD_TYPE);
+        }
+        return null;
     }
 }

--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/maven/MavenJavaProcessor.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/maven/MavenJavaProcessor.java
@@ -349,7 +349,8 @@ public class MavenJavaProcessor extends JavaProcessor {
         if (!isMainJob && isGoalInstall) {
             if (!buildCacheManager.isJobBuild(getProperty())) {
                 deleteExistedJobJarFile(talendJavaProject);
-                if ("ROUTE".equalsIgnoreCase(getBuildType(getProperty())) && project != null) {
+                if ("ROUTE".equalsIgnoreCase(getBuildType(getProperty())) && project != null &&
+                		ERepositoryObjectType.PROCESS.equals(ERepositoryObjectType.getType(getProperty()))) {
                     // TESB-23870
                     // child routes job project must be compiled explicitly for 
                     // correct child job manifest generation during OSGi packaging


### PR DESCRIPTION
**What is the current behavior?** 

At this moment we have issue with incorrect manifest generation for child Jobs TESB-23870 which was provoked by https://github.com/Talend/tdi-studio-se/commit/34d92b92c9e45cf32bfb5a7f645fed16713c708f

The problem is - manifest from child Jobs does not have required dependencies because of manifest creator can not find required dependencies due to missing generated classes. So, it is necessary to compile child subjobs before manifest is calculated. Besides, it is not possible to avoid creation of maven nature for child job project (otherwise project with child Job can not be compiled) 

**What is the new behavior?** 

Current change suppose creation of maven nature and compillation of  child Jobs during creation of OSGi Routes with child Jobs (referenced by cTalendJob).