### PR TITLE
fix(TUP-20913)Remote project:job run use old data if not run the child

### DIFF
--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/dependencies/service/ResourcesDependenciesService.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/dependencies/service/ResourcesDependenciesService.java
@@ -12,6 +12,8 @@
 // ============================================================================
 package org.talend.designer.core.ui.editor.dependencies.service;
 
+import java.util.List;
+
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.gef.commands.Command;
@@ -31,6 +33,7 @@ import org.talend.core.model.process.IProcess;
 import org.talend.core.model.process.IProcess2;
 import org.talend.core.model.properties.Item;
 import org.talend.core.model.properties.Property;
+import org.talend.core.model.relationship.Relation;
 import org.talend.core.model.relationship.RelationshipItemBuilder;
 import org.talend.core.model.repository.ERepositoryObjectType;
 import org.talend.core.model.repository.IRepositoryViewObject;
@@ -41,6 +44,7 @@ import org.talend.designer.core.ui.AbstractMultiPageTalendEditor;
 import org.talend.designer.core.ui.editor.dependencies.dialog.DependenciesResourceSelectionDialog;
 import org.talend.designer.core.ui.editor.dependencies.model.JobResourceDependencyModel;
 import org.talend.designer.core.ui.editor.dependencies.util.ResourceDependenciesUtil;
+import org.talend.designer.maven.tools.BuildCacheManager;
 import org.talend.repository.ProjectManager;
 
 public class ResourcesDependenciesService implements IResourcesDependenciesService {
@@ -189,5 +193,29 @@ public class ResourcesDependenciesService implements IResourcesDependenciesServi
 
         }
     }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.talend.core.service.IResourcesDependenciesService#removeBuildJobCacheForResource(java.lang.String)
+     */
+    @Override
+    public void removeBuildJobCacheForResource(String resourceId) {
+        ProxyRepositoryFactory factory = ProxyRepositoryFactory.getInstance();
+        BuildCacheManager buildCacheManager = BuildCacheManager.getInstance();
+        List<Relation> relations = RelationshipItemBuilder.getInstance().getAllVersionItemsRelatedTo(resourceId,
+                RelationshipItemBuilder.RESOURCE_RELATION, true);
+        try {
+            for (Relation relation : relations) {
+                IRepositoryViewObject object = factory.getSpecificVersion(relation.getId(), relation.getVersion(), false);
+                if (object != null) {
+                    buildCacheManager.preRemoveJobCache(object.getProperty());
+                }
+            }
+        } catch (PersistenceException e) {
+            ExceptionHandler.process(e);
+        }
+    }
+
 
 }


### PR DESCRIPTION
job first after change the resources item
https://jira.talendforge.org/browse/TUP-20913

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


