### PR TITLE
fix(TUP-21039): "Apply context to children jobs" does not work for "grand son" job if Studio not restarted (#2848)

### DIFF
--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/handler/BuildJobHandler.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/handler/BuildJobHandler.java
@@ -93,6 +93,7 @@ public class BuildJobHandler extends AbstractBuildJobHandler {
     public IProcessor generateJobFiles(IProgressMonitor monitor) throws Exception {
         LastGenerationInfo.getInstance().getUseDynamicMap().clear();
         LastGenerationInfo.getInstance().getUseRulesMap().clear();
+        BuildCacheManager.getInstance().clearAllCaches();
 
         final Map<String, Object> argumentsMap = new HashMap<String, Object>(getArguments());
 
@@ -384,9 +385,12 @@ public class BuildJobHandler extends AbstractBuildJobHandler {
         final Map<String, Object> argumentsMap = new HashMap<String, Object>();
         argumentsMap.put(TalendProcessArgumentConstant.ARG_GOAL, TalendMavenConstants.GOAL_PACKAGE);
         argumentsMap.put(TalendProcessArgumentConstant.ARG_PROGRAM_ARGUMENTS, getProgramArgs());
+        try {
+            talendProcessJavaProject.buildModules(monitor, null, argumentsMap);
+            BuildCacheManager.getInstance().performBuildSuccess();
+        } finally {
+            BuildCacheManager.getInstance().clearAllCaches();
+        }
 
-        talendProcessJavaProject.buildModules(monitor, null, argumentsMap);
-
-        BuildCacheManager.getInstance().performBuildSuccess();
     }
 }


### PR DESCRIPTION
* fix(TUP-21039): "Apply context to children jobs" does not work for
"grand son" job if Studio not restarted
https://jira.talendforge.org/browse/TUP-21039

* fix(TUP-21039): "Apply context to children jobs" does not work for
"grand son" job if Studio not restarted
https://jira.talendforge.org/browse/TUP-21039

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


