### PR TITLE
fix(TUP-20913)Remote project:job run use old data if not run the child

### DIFF
--- a/main/plugins/org.talend.repository.resource/src/org/talend/repository/resource/ui/wizards/OpenAnotherVersionResrouceWizard.java
+++ b/main/plugins/org.talend.repository.resource/src/org/talend/repository/resource/ui/wizards/OpenAnotherVersionResrouceWizard.java
@@ -29,12 +29,14 @@ import org.talend.commons.exception.PersistenceException;
 import org.talend.commons.runtime.model.repository.ERepositoryStatus;
 import org.talend.commons.ui.runtime.exception.MessageBoxExceptionHandler;
 import org.talend.core.CorePlugin;
+import org.talend.core.GlobalServiceRegister;
 import org.talend.core.model.properties.Item;
 import org.talend.core.model.properties.Property;
 import org.talend.core.model.repository.IRepositoryViewObject;
 import org.talend.core.model.repository.RepositoryManager;
 import org.talend.core.model.resources.ResourceItem;
 import org.talend.core.repository.model.ProxyRepositoryFactory;
+import org.talend.core.service.IResourcesDependenciesService;
 import org.talend.expressionbuilder.ExpressionPersistance;
 import org.talend.repository.ProjectManager;
 import org.talend.repository.model.IProxyRepositoryFactory;
@@ -152,6 +154,15 @@ public class OpenAnotherVersionResrouceWizard extends Wizard {
 			} catch (CoreException e) {
 				MessageBoxExceptionHandler.process(e);
 			}
+            // if create a new version Resource, need clean the latest childjob build cache
+            if (GlobalServiceRegister.getDefault().isServiceRegistered(IResourcesDependenciesService.class)) {
+                IResourcesDependenciesService service = (IResourcesDependenciesService) GlobalServiceRegister.getDefault()
+                        .getService(IResourcesDependenciesService.class);
+                if (service != null) {
+                    service.removeBuildJobCacheForResource(repoObject.getProperty().getId());
+                }
+            }
+
 		} else {
 			StructuredSelection selection = (StructuredSelection) mainPage
 					.getSelection();


### PR DESCRIPTION
job first after change the resources item
https://jira.talendforge.org/browse/TUP-20913

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


