### PR TITLE
fix(TDI-41330): Use sql TIME in setNull for SIQ (#2927)

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tMSSqlOutput/tMSSqlOutput_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMSSqlOutput/tMSSqlOutput_end.javajet
@@ -275,7 +275,10 @@ skeleton="../templates/db_output_bulk.skeleton"
 				%>
 		            }
 		        }else{
-		            <%=prefix+cid%>.setNull(count<%=cid%>,java.sql.Types.DATE);
+<%
+                    String typeToSetNull = "TIME".equals(dbType) ? "java.sql.Types.TIME" : "java.sql.Types.DATE";
+%>
+                    <%=prefix+cid%>.setNull(count<%=cid%>,<%=typeToSetNull%>);
 		        }
 		<%
 		    }else{

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMSSqlOutput/tMSSqlOutput_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMSSqlOutput/tMSSqlOutput_main.javajet
@@ -273,8 +273,10 @@ skeleton="../templates/db_output_bulk.skeleton"
 				%>
                     }
                 }else{
-
-                    <%=prefix+cid%>.setNull(counter<%=cid%>,java.sql.Types.DATE);
+<%
+                    String typeToSetNull = "TIME".equals(dbType) ? "java.sql.Types.TIME" : "java.sql.Types.DATE";
+%>
+                    <%=prefix+cid%>.setNull(counter<%=cid%>,<%=typeToSetNull %>);
 
                 }
                 <%


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**
Backport of https://github.com/Talend/tdi-studio-se/pull/2927

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


