### PR TITLE
fix(TDI-31328): Add default datePattern to SVNLogInput locked schema

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tSVNLogInput/tSVNLogInput_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSVNLogInput/tSVNLogInput_java.xml
@@ -106,7 +106,7 @@
       <TABLE  READONLY="true">
         <COLUMN NAME="revision" TYPE="id_Integer"/>
         <COLUMN NAME="author" TYPE="id_String" LENGTH="50"/>
-        <COLUMN NAME="date" TYPE="id_Date"/>
+        <COLUMN NAME="date" TYPE="id_Date" PATTERN='"yyyy-MM-dd HH:mm:ss"'/>
         <COLUMN NAME="message" TYPE="id_String" LENGTH="10000"/>
         <COLUMN NAME="nb_file_added" TYPE="id_Integer"/>
         <COLUMN NAME="nb_file_modified" TYPE="id_Integer"/>


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
No date pattern in default component schema -> warning appeared

**What is the new behavior?**
Set default date pattern for new tSVNLogInput components added to jobs

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


