### PR TITLE
bugfix(TUP-21041):ELT Maps generate incorrect SQL when sql contains schema.table.column1 + schema.table.column2

### DIFF
--- a/main/plugins/org.talend.designer.dbmap/src/main/java/org/talend/designer/dbmap/language/generation/DbGenerationManager.java
+++ b/main/plugins/org.talend.designer.dbmap/src/main/java/org/talend/designer/dbmap/language/generation/DbGenerationManager.java
@@ -27,8 +27,12 @@ import java.util.regex.PatternSyntaxException;
 import org.talend.commons.ui.runtime.exception.ExceptionHandler;
 import org.talend.commons.utils.StringUtils;
 import org.talend.commons.utils.data.text.StringHelper;
+import org.talend.core.database.EDatabaseTypeName;
+import org.talend.core.model.metadata.Dbms;
 import org.talend.core.model.metadata.IMetadataColumn;
 import org.talend.core.model.metadata.IMetadataTable;
+import org.talend.core.model.metadata.MappingTypeRetriever;
+import org.talend.core.model.metadata.MetadataTalendType;
 import org.talend.core.model.metadata.MetadataToolHelper;
 import org.talend.core.model.process.EConnectionType;
 import org.talend.core.model.process.IConnection;
@@ -40,6 +44,7 @@ import org.talend.core.model.process.INode;
 import org.talend.core.model.process.IProcess;
 import org.talend.core.model.utils.ContextParameterUtils;
 import org.talend.core.model.utils.TalendTextUtils;
+import org.talend.core.utils.TalendQuoteUtils;
 import org.talend.designer.core.model.components.EParameterName;
 import org.talend.designer.dbmap.DbMapComponent;
 import org.talend.designer.dbmap.external.data.ExternalDbMapData;
@@ -1016,6 +1021,7 @@ public abstract class DbGenerationManager {
     }
 
     protected String initExpression(DbMapComponent component, ExternalDbMapEntry dbMapEntry) {
+    	String quote = getQuote(component);
         String expression = dbMapEntry.getExpression();
         if (expression != null) {
             List<Map<String, String>> itemNameList = null;
@@ -1040,7 +1046,7 @@ public abstract class DbGenerationManager {
                 itemNameList = mapParser2.parseInTableEntryLocations(expression);
             }
 
-            String quoParser = "[\\\\]?\\\""; //$NON-NLS-1$
+            String quoParser = "[\\\\]?\\" + quote; //$NON-NLS-1$
             for (Map<String, String> itemNamemap : itemNameList) {
                 Set<Entry<String, String>> set = itemNamemap.entrySet();
                 Iterator<Entry<String, String>> ite = set.iterator();
@@ -1105,13 +1111,17 @@ public abstract class DbGenerationManager {
                                             continue;
                                         }
                                         if (expression.trim().equals(tableValue + "." + oriName)) {
-                                            expression = tableValue + "." + getColumnName(iconn, oriName);
-                                            expression = expression.replaceAll(quoParser,"\\\\\""); //$NON-NLS-1$
+                                            expression = tableValue + "." + getColumnName(iconn, oriName, quote);
+                                            if(TalendQuoteUtils.QUOTATION_MARK.equals(quote)){
+                                            	expression = expression.replaceAll(quoParser,"\\\\" +quote); //$NON-NLS-1$
+                                            }
                                             continue;
                                         }
                                         if (expression.trim().equals(originaltableName + "." + oriName)) {
-                                            expression = originaltableName + "." + getColumnName(iconn, oriName);
-                                            expression = expression.replaceAll(quoParser,"\\\\\""); //$NON-NLS-1$
+                                            expression = originaltableName + "." + getColumnName(iconn, oriName, quote);
+                                            if(TalendQuoteUtils.QUOTATION_MARK.equals(quote)){
+                                            	expression = expression.replaceAll(quoParser,"\\\\" +quote); //$NON-NLS-1$
+                                            }
                                             continue;
                                         }
                                         // if it is temp delived table, use label to generate sql
@@ -1119,13 +1129,15 @@ public abstract class DbGenerationManager {
                                             continue;
                                         }
                                         if (!isRefTableConnection(iconn) && isUseDelimitedIdentifiers()) {
-                                            oriName = getColumnName(iconn, oriName);
+                                            oriName = getColumnName(iconn, oriName, quote);
                                         } else {
                                             oriName = oriName.replaceAll("\\$", "\\\\\\$"); //$NON-NLS-1$ //$NON-NLS-2$
                                         }
                                         expression = expression.replaceFirst(tableValue + "\\." + co.getLabel(), //$NON-NLS-1$
                                         		tableValue + "\\." + oriName); //$NON-NLS-1$
-                                        expression = expression.replaceAll(quoParser,"\\\\\""); //$NON-NLS-1$
+                                        if(TalendQuoteUtils.QUOTATION_MARK.equals(quote)){
+                                        	expression = expression.replaceAll(quoParser,"\\\\" +quote); //$NON-NLS-1$
+                                        }
                                     }
                                 }
 
@@ -1138,6 +1150,26 @@ public abstract class DbGenerationManager {
         }
 
         return expression;
+    }
+    
+    private String getQuote(DbMapComponent component){
+    	String quote = TalendQuoteUtils.QUOTATION_MARK;
+    	IElementParameter mappingPara = component.getElementParameter(EParameterName.MAPPING.getName());
+    	if(mappingPara == null){
+    		return quote;
+    	}
+    	String mapping = (String) mappingPara.getValue();
+    	if(mapping == null){
+    		return quote;
+    	}
+		MappingTypeRetriever mappingTypeRetriever = MetadataTalendType.getMappingTypeRetriever(mapping);
+		if (mappingTypeRetriever == null) {
+			return quote;
+		}
+		Dbms dbms = mappingTypeRetriever.getDbms();
+		String product = dbms.getProduct();
+		EDatabaseTypeName type = EDatabaseTypeName.getTypeFromProductName(product);
+		return TalendQuoteUtils.getQuoteByDBType(type);
     }
 
     private String getOriginalColumnName(String entryName, DbMapComponent component, ExternalDbMapTable table) {
@@ -1247,6 +1279,14 @@ public abstract class DbGenerationManager {
             return name;
         }
     }
+    
+    protected String getColumnName(IConnection conn, String name, String quote) {
+        if (!isRefTableConnection(conn) && isUseDelimitedIdentifiers()) {
+            return getNameWithDelimitedIdentifier(name, quote);
+        } else {
+            return name;
+        }
+    }
 
     protected boolean isRefTableConnection(IConnection conn) {
         return conn != null && conn.getLineStyle() == EConnectionType.TABLE_REF;
@@ -1257,6 +1297,13 @@ public abstract class DbGenerationManager {
         String newName = name;
         newName = newName.replaceAll("\"", "\"\"");
         newName = delimitedIdentifier + newName + delimitedIdentifier;
+        return newName;
+    }
+    
+    protected String getNameWithDelimitedIdentifier(String name, String quote) {
+        String newName = name;
+        newName = newName.replaceAll("\"", "\"\"");
+        newName = quote + newName + quote;
         return newName;
     }
 

--- a/test/plugins/org.talend.designer.dbmap.test/src/org/talend/designer/dbmap/language/generation/DbGenerationManagerTest.java
+++ b/test/plugins/org.talend.designer.dbmap.test/src/org/talend/designer/dbmap/language/generation/DbGenerationManagerTest.java
@@ -29,6 +29,7 @@ import org.talend.core.model.properties.PropertiesFactory;
 import org.talend.core.model.properties.Property;
 import org.talend.core.model.utils.TalendTextUtils;
 import org.talend.core.ui.component.ComponentsFactoryProvider;
+import org.talend.designer.core.model.components.EParameterName;
 import org.talend.designer.core.model.components.ElementParameter;
 import org.talend.designer.core.model.components.NodeConnector;
 import org.talend.designer.core.ui.editor.connections.Connection;
@@ -134,11 +135,42 @@ public class DbGenerationManagerTest extends DbGenerationManagerTestHelper {
 
     @Test
     public void testInitExpression() {
-        checkValue("t1.\\\"id\\\"", extMapEntry);
+    	checkValue("t1.\\\"id\\\"", extMapEntry);
         
         ExternalDbMapEntry extMapEntry2 = new ExternalDbMapEntry("multiple", "t1.id + t1.name");
         tableEntries.add(extMapEntry2);
         checkValue("t1.\\\"id\\\" + t1.\\\"name\\\"", extMapEntry2);
+        
+        testWithQuote();
+    }
+    
+    private void testWithQuote(){
+    	dbManager.setUseDelimitedIdentifiers(true);
+    	List<IConnection> incomingConnections = new ArrayList<IConnection>();
+        String[] columns = new String[] { "id",  "name"};
+        String[] labels = new String[] { "id",  "name"};
+        incomingConnections.add(createConnection("t1", "t1", labels, columns));
+        dbMapComponent.setIncomingConnections(incomingConnections);
+        
+        ElementParameter param = new ElementParameter(dbMapComponent);
+    	param.setName(EParameterName.MAPPING.getName());
+    	param.setValue("mysql_id");
+    	List<ElementParameter> list = new ArrayList<>();
+    	list.add(param);
+    	dbMapComponent.setElementParameters(list);
+    	checkValue("t1.`id`", extMapEntry);
+    	
+    	ExternalDbMapEntry extMapEntry2 = new ExternalDbMapEntry("multiple", "t1.id + t1.name");
+        tableEntries.add(extMapEntry2);
+        checkValue("t1.`id` + t1.`name`", extMapEntry2);
+    	
+    	param.setValue("oracle_id");
+    	checkValue("t1.\\\"id\\\"", extMapEntry);
+    	checkValue("t1.\\\"id\\\" + t1.\\\"name\\\"", extMapEntry2);
+    	
+    	param.setValue("mssql_id");
+    	checkValue("t1.\\\"id\\\"", extMapEntry);
+    	checkValue("t1.\\\"id\\\" + t1.\\\"name\\\"", extMapEntry2);
     }
 
     public void checkValue(String expression, ExternalDbMapEntry entry) {


### PR DESCRIPTION
Map components and is not separated with string concat from SQL code

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [* ] The commit message follows Talend standard
- [ *] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [* ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [* ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


