### PR TITLE
Jzhang/bugfix/tup 20880 repository share show warn dialog choice shou…

### DIFF
--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/preference/ArtifactRepositoryShareSettingPageTester.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/preference/ArtifactRepositoryShareSettingPageTester.java
@@ -14,31 +14,13 @@ package org.talend.repository.preference;
 
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.jface.preference.IPreferenceNode;
-import org.talend.commons.exception.ExceptionHandler;
-import org.talend.commons.exception.PersistenceException;
-import org.talend.core.context.Context;
-import org.talend.core.context.RepositoryContext;
-import org.talend.core.repository.model.ProxyRepositoryFactory;
-import org.talend.core.runtime.CoreRuntimePlugin;
 import org.talend.core.runtime.preference.IProjectSettingPageTester;
 
 public class ArtifactRepositoryShareSettingPageTester implements IProjectSettingPageTester {
 
     @Override
     public boolean valid(IConfigurationElement element, IPreferenceNode node) {
-        try {
-            boolean isLocalProject = ProxyRepositoryFactory.getInstance().isLocalConnectionProvider();
-            boolean isOffline = false;
-            if (!isLocalProject) {
-                RepositoryContext repositoryContext = (RepositoryContext) CoreRuntimePlugin.getInstance().getContext()
-                        .getProperty(Context.REPOSITORY_CONTEXT_KEY);
-                isOffline = repositoryContext.isOffline();
-            }
-            return !isLocalProject && !isOffline;
-        } catch (PersistenceException e) {
-            ExceptionHandler.process(e);
-        }
-        return false;
+        return true;
     }
 
 }


### PR DESCRIPTION
…ld also exists for local project (#2999)

* fix(TUP-20880)Repository share: show warn dialog choice should also
exists for local project

* fix(TUP-20880)Repository share: show warn dialog choice should also
exists for local project

* fix(TUP-20880)repository share show warn dialog choice should also
exists for local project

* fix(TUP-20880)repository share show warn dialog choice should also
exists for local project

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


