### PR TITLE
fix(TBD-8089): Hive requiring user when not needed

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/templates/DB/Input/HelpClass.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/templates/DB/Input/HelpClass.javajet
@@ -90,7 +90,7 @@ imports="
 				<%this.setURL(node);%>
 				<%
 				log4jCodeGenerateUtil.debugConnectionParams(node);
-				if ("SSO".equals(ElementParameterParser.getValue(node, "__JDBC_URL__"))){
+				if ("SSO".equals(ElementParameterParser.getValue(node, "__JDBC_URL__")) || !needUserAndPassword){
 					log4jCodeGenerateUtil.connect_begin_noUser();
 				} else {
 					log4jCodeGenerateUtil.connect_begin();


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

Codegen trying to find Hive username variable which does not exist

**What is the new behavior?**

Preventing codegen to seek this variable when not needed

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


