### PR TITLE
fix(TUP-21356):talend-bigdata-launcher-1.2.0-20170410.jar not found when spark job launched from standard job by jobserver.

### DIFF
--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/java/JavaProcessor.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/java/JavaProcessor.java
@@ -1355,8 +1355,12 @@ public class JavaProcessor extends AbstractJavaProcessor implements IJavaBreakpo
         final String classPathSeparator = extractClassPathSeparator();
         final String libPrefixPath = getRootWorkingDir(true);
 
-        Set<ModuleNeeded> neededModules = getNeededModules(
-                TalendProcessOptionConstants.MODULES_WITH_CHILDREN | TalendProcessOptionConstants.MODULES_EXCLUDE_SHADED);
+        int option = TalendProcessOptionConstants.MODULES_WITH_CHILDREN;
+
+        if (isExportConfig() || isSkipClasspathJar()) {
+            option = option | TalendProcessOptionConstants.MODULES_EXCLUDE_SHADED;
+        }
+        Set<ModuleNeeded> neededModules = getNeededModules(option);
         JavaProcessorUtilities.checkJavaProjectLib(neededModules);
 
         // Ignore hadoop confs jars in lib path.


### PR DESCRIPTION
What is the current behavior? (You can also link to an open issue here)
https://jira.talendforge.org/browse/TUP-21356

What is the new behavior?
https://jira.talendforge.org/browse/TUP-21356


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


