### PR TITLE
fix(TDI-41556): Redshift driver name was changed

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tCreateTable/tCreateTable_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tCreateTable/tCreateTable_main.javajet
@@ -1857,7 +1857,7 @@ class RedshiftManager extends Manager {
         this.connection = connection;
     }
     protected String getDriver() {
-        return "com.amazon.redshift.jdbc41.Driver";
+        return "com.amazon.redshift.jdbc42.Driver";
     }
     public String getConnectionURL() {
         return "\"jdbc:redshift://\" + " + host + " + \":\" + " + port + " + \"/\" + " + dbName;

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPostgresqlConnection/tPostgresqlConnection_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPostgresqlConnection/tPostgresqlConnection_begin.javajet
@@ -22,16 +22,17 @@ imports="
 		
 		public void adjustDriverRegisterOrderForConflcit() {
 %>
-		java.util.Enumeration<java.sql.Driver> drivers_<%=cid%> =  java.sql.DriverManager.getDrivers();
+        java.util.Enumeration<java.sql.Driver> drivers_<%=cid%> =  java.sql.DriverManager.getDrivers();
+        java.util.Set<String> redShiftDriverNames_<%=cid%> = new java.util.HashSet<String>(java.util.Arrays
+                .asList("com.amazon.redshift.jdbc.Driver","com.amazon.redshift.jdbc41.Driver","com.amazon.redshift.jdbc42.Driver"));
     while (drivers_<%=cid%>.hasMoreElements()) {
         java.sql.Driver d_<%=cid%> = drivers_<%=cid%>.nextElement();
-        java.util.List<String> driverList_<%=cid%> = java.util.Arrays.<String>asList("com.amazon.redshift.jdbc.Driver","com.amazon.redshift.jdbc41.Driver","com.amazon.redshift.jdbc42.Driver");
-        if (driverList_<%=cid%>.contains(d_<%=cid%>.getClass().getName())) {
+        if (redShiftDriverNames_<%=cid%>.contains(d_<%=cid%>.getClass().getName())) {
             try {
                 java.sql.DriverManager.deregisterDriver(d_<%=cid%>);
                 java.sql.DriverManager.registerDriver(d_<%=cid%>);
             } catch (java.lang.Exception e_<%=cid%>) {
-            		//do nothing
+                    //do nothing
             }
         }
     }

--- a/main/plugins/org.talend.designer.components.localprovider/components/tPostgresqlConnection/tPostgresqlConnection_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tPostgresqlConnection/tPostgresqlConnection_begin.javajet
@@ -25,7 +25,7 @@ imports="
 		java.util.Enumeration<java.sql.Driver> drivers_<%=cid%> =  java.sql.DriverManager.getDrivers();
     while (drivers_<%=cid%>.hasMoreElements()) {
         java.sql.Driver d_<%=cid%> = drivers_<%=cid%>.nextElement();
-        java.util.List<String> driverList_<%=cid%> = java.util.Arrays.<String>asList("com.amazon.redshift.jdbc.Driver","com.amazon.redshift.jdbc41.Driver");
+        java.util.List<String> driverList_<%=cid%> = java.util.Arrays.<String>asList("com.amazon.redshift.jdbc.Driver","com.amazon.redshift.jdbc41.Driver","com.amazon.redshift.jdbc42.Driver");
         if (driverList_<%=cid%>.contains(d_<%=cid%>.getClass().getName())) {
             try {
                 java.sql.DriverManager.deregisterDriver(d_<%=cid%>);


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-41556

**What is the new behavior?**
driver name for Redshift driver was changed. It used outdated name.
Also for tPostgreSQLConnection was updated list with Redshift driver names to avoid conflict when both DBs in one job.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


