### PR TITLE
fix(TUP-9814):SCD component add a warning message if the source key is empty.

### DIFF
--- a/main/plugins/org.talend.designer.core/src/main/java/messages.properties
+++ b/main/plugins/org.talend.designer.core/src/main/java/messages.properties
@@ -526,6 +526,7 @@ Node.hasMoreThenOneColumn=Table ({0}) have more then one column.
 Node.notExistedContextName=The context name {0} of line {1} is not existed in column {2}
 Node.inputMustNotBeAMappingField=The input field ({0}) is used in the mapping. You should keep the field as blank.
 Node.inputMustNotBeAMappingField=The input field ({0}) is used in the mapping. You should keep the field as blank.
+Node.hasMoreThenOneSourceKey=This component has no source key defined.
 NodeBreakpointAction.addBreakPoint=Add breakpoint
 NodeBreakpointAction.removeBreakpoint=Remove breakpoint
 NodePart_componentNotLoaded=Component is not loaded

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/nodes/Node.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/nodes/Node.java
@@ -2771,6 +2771,13 @@ public class Node extends Element implements IGraphicalNode {
                             param.getDisplayName());
                     Problems.add(ProblemStatus.WARNING, this, warnMessage);
                 }
+                // add a warning message on the component if the source key is empty
+                if (param.getName().equals("SOURCE_KEYS")) { //$NON-NLS-1$
+                    if (tableValues == null || tableValues.isEmpty()) {
+                        String warnMessage = Messages.getString("Node.hasMoreThenOneSourceKey"); //$NON-NLS-1$
+                        Problems.add(ProblemStatus.WARNING, this, warnMessage);
+                    }
+                }
             }
 
             if (param.getName().equals(EParameterName.COMMENT.getName())) {


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TUP-9814

**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


