### PR TITLE
fix(TDI-41581): change MySQL db name recognition

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tCreateTable/tCreateTable_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tCreateTable/tCreateTable_main.javajet
@@ -2431,7 +2431,7 @@ if(columnList != null && columnList.size() > 0) {
                 String dbnameMySQL = "";
                 if (useExistMySQLConn) {
                     List< ? extends INode> nodes =  node.getProcess().getNodesOfType("tMysqlConnection");
-                    String connectionMySQL = ElementParameterParser.getValue(node,"__CONNECTION__");
+                    String connectionMySQL = ElementParameterParser.getValue(node,"__CONNECTION_MYSQL__");
                     for (INode ne : nodes) {
                         if (connectionMySQL.equals(ne.getUniqueName())) {
                             dbnameMySQL = ElementParameterParser.getValue(ne, "__DBNAME__");


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-41581

**What is the new behavior?**
tCreateTable for MySQL when use exist connection now define database name rightly.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


