### PR TITLE
TESB-22085:Dynamic schema column type is always String in Runtime

### DIFF
--- a/main/plugins/org.talend.designer.maven.job/resources/templates/osgi/assembly_job_template.xml
+++ b/main/plugins/org.talend.designer.maven.job/resources/templates/osgi/assembly_job_template.xml
@@ -38,6 +38,13 @@
                 <include>**</include>
             </includes>
         </fileSet>
+        <fileSet> <!-- add xmlMappings -->
+            <directory>${current.bundle.resources.dir}/xmlMappings</directory>
+            <outputDirectory>xmlMappings</outputDirectory>
+            <includes>
+                <include>**</include>
+            </includes>
+        </fileSet>	
         
         <fileSet> <!-- add metadata -->
             <directory>${basedir}/src/main/resources</directory>

--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/handler/BuildOSGiBundleHandler.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/handler/BuildOSGiBundleHandler.java
@@ -127,6 +127,8 @@ public class BuildOSGiBundleHandler extends BuildJobHandler {
             folder = talendProcessJavaProject.getSrcSubFolder(monitor, sub);
         } else if (path.startsWith("META-INF")) {
             folder = talendProcessJavaProject.createSubFolder(monitor, talendProcessJavaProject.getBundleResourcesFolder(), path);
+        } else if (path.startsWith("xmlMappings")) {
+            folder = talendProcessJavaProject.createSubFolder(monitor, talendProcessJavaProject.getBundleResourcesFolder(), path);
         }
         return folder == null ? null : folder.getFile(fileName);
     }

--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/esb/JobJavaScriptOSGIForESBManager.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/esb/JobJavaScriptOSGIForESBManager.java
@@ -35,6 +35,7 @@ import java.util.jar.Manifest;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.map.MultiKeyMap;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -186,7 +187,18 @@ public class JobJavaScriptOSGIForESBManager extends JobJavaScriptsManager {
                 getJobScriptsUncompressed(jobScriptResource, processItem);
 
                 // dynamic DB XML mapping
-                addXmlMapping(process, isOptionChoosed(ExportChoice.needSourceCode));
+                addXmlMapping(process, true);// isOptionChoosed(ExportChoice.needSourceCode)
+
+                if (CollectionUtils.isNotEmpty(process.getAllResources())) {
+                    ExportFileResource xm = new ExportFileResource(null, JavaUtils.JAVA_XML_MAPPING);
+                    Set<URL> urls = process
+                            .getResourcesByRelativePath(JOB_SOURCE_FOLDER_NAME + PATH_SEPARATOR + JavaUtils.JAVA_XML_MAPPING);
+
+                    if (CollectionUtils.isNotEmpty(urls)) {
+                        xm.addResources(new ArrayList<URL>(urls));
+                        list.add(xm);
+                    }
+                }
 
                 generateConfig(osgiResource, processItem, iProcess);
 


### PR DESCRIPTION
**What is the current behavior?**

At this moment xmlMapping is not propagated to Jobs OSGi Bundle.
Unfortunatelly we can not just backport existing bugfix for 6.4 https://github.com/Talend/tdi-studio-se/pull/2360/files because of artifacts propagation in 7.1/7.2 has some differences (it is necessary also to extend corresponding template to make propagation of xmlMappings complete).

**What is the new behavior?**

xmlMapping become propagated to Jobs OSGi Bundle

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

See corresponding PR for 6.4
https://github.com/Talend/tdi-studio-se/pull/2360/files
