### PR TITLE
feat(TDI-41773): set exit value right after script has executed

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tSystem/tSystem_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSystem/tSystem_begin.javajet
@@ -253,6 +253,7 @@ if(ps_<%=cid %>.getOutputStream()!=null){
 ps_<%=cid %>.waitFor();
 normal_<%=cid %>.join(10000);
 error_<%=cid %>.join(10000);
+globalMap.put("<%=cid %>_EXIT_VALUE", ps_<%=cid %>.exitValue());
 
 <%
 if(("NORMAL_OUTPUT").equals(outputAction)||("NORMAL_OUTPUT").equals(errorOuput)){

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSystem/tSystem_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSystem/tSystem_end.javajet
@@ -36,4 +36,3 @@
 		}
 	}
 %>
-globalMap.put("<%=cid %>_EXIT_VALUE", ps_<%=cid %>.exitValue());


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
exit value is set in the 'end' part of component

**What is the new behavior?**
exit value is set in the 'begin' part of component right after execution


**Please check if the PR fulfills these requirements**

- [x ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


