### PR TITLE
TESB-24851, fix the Connection leak in case of Failover mode and OSGi deployment

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tMomConnection/tMomConnection_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMomConnection/tMomConnection_begin.javajet
@@ -119,7 +119,7 @@ class="MomConnection"
 			<%
 			}
 			%>
-		
+		    globalMap.put("connection_<%=cid%>", connection_<%=cid %>);
 		    connection_<%=cid %>.start();
 		    <%
 			if(isLog4jEnabled){
@@ -135,7 +135,6 @@ class="MomConnection"
 		}
 		%>
 		
-	    globalMap.put("connection_<%=cid%>", connection_<%=cid %>);
 	    javax.jms.Session session_<%=cid %> = connection_<%=cid %>.createSession(<%=transacted%>, javax.jms.Session.<%=acknowledgmentMode%>);
 	    globalMap.put("session_<%=cid %>", session_<%=cid %>);
 		<%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMomConnection/tMomConnection_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMomConnection/tMomConnection_begin.javajet
@@ -95,6 +95,7 @@ class="MomConnection"
 		if(isUseSharedConnection){
 		%>
 			javax.jms.Connection connection_<%=cid %> = org.talend.mq.SharedActiveMQConnection.getMQConnection(url_<%=cid %>,<%=dbuser%>,decryptedPassword_<%=cid%>,<%=sharedConnectionName%>);
+			globalMap.put("connection_<%=cid%>", connection_<%=cid %>);
 		<%
 		}else{
 		%>


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
(See TESB-24851) in case of Failover mode on tMomConnection component, deploy the job into Runtime OSGi container, and the AMQ 61616 is not available, the Connection has no chance to be closed and keep running to re-connect for ever even the job got undeployed from container.

**What is the new behavior?**
The fix is putting the connection_tMomConnection_1 earlier into the Map before it is starting, so that it is able to be closed in the destroy() method when uninstalled.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


