### PR TITLE
fix(TDI-31429): Avoid compile error for byte array

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tExtractJSONFields/read_by_jsonpath_process.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tExtractJSONFields/read_by_jsonpath_process.javajet
@@ -152,8 +152,12 @@ for (int i=0;i<mapping.size();i++) {
         		} else if(javaType == JavaTypesManager.LIST && splitList){
         		%>
         		    <%=firstConnName%>.<%=column.getLabel() %> = ParserUtils.parseTo_List(value_<%=cid%>.toString(),",");
-        		<%
-        		} else {
+<%
+                } else if (javaType == JavaTypesManager.BYTE_ARRAY) {
+%>
+                    <%=firstConnName%>.<%=column.getLabel() %> = value_<%=cid%>.toString().getBytes();
+<%
+                } else {
 %>
 					<%=firstConnName%>.<%=column.getLabel() %> = ParserUtils.parseTo_<%=typeToGenerate %>(value_<%=cid%>.toString());
 <%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tExtractJSONFields/read_by_xpath_process.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tExtractJSONFields/read_by_xpath_process.javajet
@@ -287,9 +287,13 @@ if(outConns!=null){
 									if (javaType == JavaTypesManager.DATE) {
 									%>
 										<%=firstConnName%>.<%=column.getLabel() %> = ParserUtils.parseTo_Date(str_<%= cid %>, <%= patternValue %>);
-									<%
+<%
+									} else if (javaType == JavaTypesManager.BYTE_ARRAY){
+%>
+										<%=firstConnName%>.<%=column.getLabel() %> = str_<%= cid %>.toString().getBytes();
+<%
 									} else {
-									%>
+%>
 										<%=firstConnName%>.<%=column.getLabel() %> = ParserUtils.parseTo_<%= typeToGenerate %>(str_<%= cid %>);
 									<%
 									}


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

Compile error on tExtractJSONField when byte[] field is extracting
**What is the new behavior?**
No compile error, same behavior for tExtractJSONField as for tFileInputJSON

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


