### PR TITLE
TESB-25472 Avoid InvalidThreadAccess to get the real error

### DIFF
--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/handler/BuildJobHandler.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/handler/BuildJobHandler.java
@@ -411,7 +411,13 @@ public class BuildJobHandler extends AbstractBuildJobHandler {
                     buildDelegate(monitor);
                 } catch (Exception e) {
                     if (!CommonUIPlugin.isFullyHeadless() && isOptionChoosed(ExportChoice.buildImage)) {
-                        MessageBoxExceptionHandler.process(e, Display.getDefault().getActiveShell());
+                        Display.getDefault().syncExec(new Runnable() {
+                            
+                            @Override
+                            public void run() {
+                                MessageBoxExceptionHandler.process(e, Display.getDefault().getActiveShell());
+                            }
+                        });
                     } else {
                         ExceptionHandler.process(e);
                     }


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
Studio tries to display an error message dialog from inside a Job. This causes an InvalidThreadAccess.

**What is the new behavior?**
Code now synchronize with UI thread to display the error message and user can get the real error message.

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

