### PR TITLE
basic date support (coming Talend Component Kit 1.1.10)

### DIFF
--- a/main/plugins/org.talend.sdk.component.studio-integration/pom.xml
+++ b/main/plugins/org.talend.sdk.component.studio-integration/pom.xml
@@ -14,7 +14,7 @@
   <description>Studio integration of the Talend Component Kit framework.</description>
 
   <properties>
-    <component-runtime.version>1.1.9</component-runtime.version>
+    <component-runtime.version>1.1.10-SNAPSHOT</component-runtime.version>
     <commons-lang3.version>3.6</commons-lang3.version>
     <mockito.version>2.23.0</mockito.version>
     <oro.version>2.0.8</oro.version>

--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/WidgetTypeMapper.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/WidgetTypeMapper.java
@@ -18,6 +18,7 @@ package org.talend.sdk.component.studio.model.parameter;
 import static java.util.Locale.ROOT;
 import static org.talend.core.model.process.EParameterFieldType.CHECK;
 import static org.talend.core.model.process.EParameterFieldType.CLOSED_LIST;
+import static org.talend.core.model.process.EParameterFieldType.DATE;
 import static org.talend.core.model.process.EParameterFieldType.MEMO;
 import static org.talend.core.model.process.EParameterFieldType.MEMO_JAVA;
 import static org.talend.core.model.process.EParameterFieldType.MEMO_PERL;
@@ -88,6 +89,16 @@ public class WidgetTypeMapper {
             return getSuggestableTableType();
         } else if (isTable(property)) {
             return getTableType();
+        } else if (isDate(property)) {
+            final String type = property.getMetadata().getOrDefault("ui::datetime", "datetime");
+            switch (type) {
+                case "time": // HH:MM:ss
+                case "date": // YYYY-MM-dd
+                case "datetime": // YYYY-MM-dd HH:MM:ss
+                case "zoneddatetime": // YYYY-MM-dd HH:MM:ss+offset[zone]
+                default: // FIXME: today we don't completely map all the widgets
+                    return getDateType();
+            }
         }
         final String codeStyle = property.getMetadata().get(UI_CODE);
         if (codeStyle != null) {
@@ -241,8 +252,16 @@ public class WidgetTypeMapper {
         return ARRAY.equals(property.getType());
     }
 
+    private boolean isDate(final SimplePropertyDefinition property) {
+        return property.getMetadata().containsKey("ui::datetime");
+    }
+
     protected EParameterFieldType getTableType() {
         return TABLE;
+    }
+
+    protected EParameterFieldType getDateType() {
+        return DATE;
     }
 
     private boolean isValueSelection(final PropertyDefinitionDecorator property) {

--- a/main/plugins/org.talend.sdk.component.studio-integration/src/test/java/org/talend/sdk/component/studio/ComponentModelTest.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/test/java/org/talend/sdk/component/studio/ComponentModelTest.java
@@ -144,7 +144,7 @@ class ComponentModelTest {
         final ComponentIndex idx =
                 new ComponentIndex(id, "XML Input", null, null, null, 1, Arrays.asList("Local", "File"), null);
         final ComponentDetail detail = new ComponentDetail(id, "XML Input", null, "Processor", 1, emptyList(), null,
-                emptyList(), emptyList(), null);
+                emptyList(), emptyList(), emptyList(), null);
         final ComponentModel componentModel = new ComponentModel(idx, detail) {
 
             @Override
@@ -177,7 +177,7 @@ class ComponentModelTest {
         ComponentIndex idx =
                 new ComponentIndex(id, "XML Input", null, null, null, 1, Arrays.asList("Local", "File"), null);
         ComponentDetail detail = new ComponentDetail(id, "XML Input", null, "Processor", 1, emptyList(), null,
-                emptyList(), emptyList(), null);
+                emptyList(), emptyList(), emptyList(), null);
         ComponentModel componentModel = new ComponentModel(idx, detail);
 
         assertEquals(expectedFamilyName, componentModel.getOriginalFamilyName());
@@ -191,7 +191,7 @@ class ComponentModelTest {
         ComponentIndex idx =
                 new ComponentIndex(id, "XML Input", null, null, null, 1, Arrays.asList("Local", "File"), null);
         ComponentDetail detail = new ComponentDetail(id, "XML Input", null, "Processor", 1, emptyList(), null,
-                emptyList(), emptyList(), null);
+                emptyList(), emptyList(), emptyList(), null);
         ComponentModel componentModel = new ComponentModel(idx, detail);
 
         assertEquals(expectedName, componentModel.getLongName());
@@ -205,7 +205,7 @@ class ComponentModelTest {
         ComponentIndex idx =
                 new ComponentIndex(id, "XML Input", null, null, null, 1, Arrays.asList("Local", "File"), null);
         ComponentDetail detail = new ComponentDetail(id, "XML Input", null, "Processor", 1, emptyList(), null,
-                emptyList(), emptyList(), null);
+                emptyList(), emptyList(), emptyList(), null);
         ComponentModel componentModel = new ComponentModel(idx, detail);
 
         List<? extends INodeConnector> connectors = componentModel.createConnectors(null);
@@ -219,7 +219,7 @@ class ComponentModelTest {
         ComponentIndex idx =
                 new ComponentIndex(id, "XML Input", null, null, null, 1, Arrays.asList("Local", "File"), null);
         ComponentDetail detail = new ComponentDetail(id, "XML Input", null, "Processor", 1, emptyList(), null,
-                emptyList(), emptyList(), null);
+                emptyList(), emptyList(), emptyList(), null);
         ComponentModel componentModel = new ComponentModel(idx, detail);
 
         List<? extends INodeReturn> returnVariables = componentModel.createReturns(null);
@@ -241,7 +241,7 @@ class ComponentModelTest {
         ComponentIndex idx =
                 new ComponentIndex(id, "XML Input", null, null, null, 1, Arrays.asList("Local", "File"), null);
         ComponentDetail detail = new ComponentDetail(id, "XML Input", null, "Processor", 1, emptyList(), null,
-                emptyList(), emptyList(), null);
+                emptyList(), emptyList(), emptyList(), null);
         ComponentModel componentModel = new ComponentModel(idx, detail);
 
         List<ECodePart> codeParts = componentModel.getAvailableCodeParts();
@@ -258,7 +258,7 @@ class ComponentModelTest {
         ComponentIndex idx =
                 new ComponentIndex(id, "XML Input", null, null, null, 1, Arrays.asList("Local", "File"), null);
         ComponentDetail detail = new ComponentDetail(id, "XML Input", null, "Input", 1, emptyList(), null, emptyList(),
-                emptyList(), null);
+                emptyList(), emptyList(), null);
         ComponentModel componentModel = new ComponentModel(idx, detail);
 
         List<ECodePart> codeParts = componentModel.getAvailableCodeParts();


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

date/time inputs have no dedicated widget

**What is the new behavior?**

components can use "time"/"date"/"datetime"/"zoneddatetime" widgets in their declaration.
this PR maps them all to DATE widget - i'll open a ticket to refine them.

IMPORTANT: this PR upgraded the plugin to Talend Component Kit 1.1.10-SNAPSHOT, this is mainly because a change in the model but is not required, feel free to revert that version in the plugin pom or do the upgrade in tcommon se/ee to ensure it works properly

Edit: relative PR to complete this work: https://jira.talendforge.org/browse/TUP-23326

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


