### PR TITLE
bugfix(TUP-23400):Collaborative work in SVN: one user delete a job,

### DIFF
--- a/main/plugins/org.talend.designer.codegen/src/main/java/org/talend/designer/codegen/JavaRoutineSynchronizer.java
+++ b/main/plugins/org.talend.designer.codegen/src/main/java/org/talend/designer/codegen/JavaRoutineSynchronizer.java
@@ -15,6 +15,7 @@ package org.talend.designer.codegen;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.Collection;
 import java.util.List;
@@ -32,6 +33,7 @@ import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.runtime.CoreException;
 import org.talend.commons.exception.ExceptionHandler;
 import org.talend.commons.exception.SystemException;
+import org.talend.commons.runtime.utils.io.IOUtils;
 import org.talend.commons.utils.generation.JavaUtils;
 import org.talend.commons.utils.io.FilesUtils;
 import org.talend.core.CorePlugin;
@@ -179,7 +181,11 @@ public class JavaRoutineSynchronizer extends AbstractRoutineSynchronizer {
     private static void copyFile(File in, IFile out) throws CoreException, IOException {
         final FileInputStream fis = new FileInputStream(in);
         if (out.exists()) {
-            out.setContents(fis, true, false, null);
+            InputStream outIs = out.getContents(true);
+            if (!IOUtils.contentEquals(fis, outIs)) {                
+                out.setContents(fis, true, false, null);
+            }
+            outIs.close();
         } else {
             out.create(fis, true, null);
         }


### PR DESCRIPTION
another user will hang on in "User operation is waiting" page after
click refresh.

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [ *] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [* ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [* ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


