### PR TITLE
fix(TDI-42536): tFileFetch NTLM PROXY issues

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileFetch/tFileFetch_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileFetch/tFileFetch_main.javajet
@@ -253,6 +253,10 @@ if ("http".equals(protocol) || "https".equals(protocol)) {
 			client_<%=cid %>.getState().setProxyCredentials(
 			new org.apache.commons.httpclient.auth.AuthScope(<%=proxyHost %>, Integer.parseInt(<%=proxyPort%>), null),
 			new org.apache.commons.httpclient.UsernamePasswordCredentials(<%=proxyUser %>, decryptedPassword_<%=cid%>));
+			
+			java.util.ArrayList<String> authPrefs_<%=cid %> = new java.util.ArrayList<>();
+			authPrefs_<%=cid %>.add(org.apache.commons.httpclient.auth.AuthPolicy.BASIC);
+			client_<%=cid %>.getParams().setParameter(org.apache.commons.httpclient.auth.AuthPolicy.AUTH_SCHEME_PRIORITY, authPrefs_<%=cid %>);
 		<%}
 	}
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileFetch/tFileFetch_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileFetch/tFileFetch_main.javajet
@@ -254,8 +254,7 @@ if ("http".equals(protocol) || "https".equals(protocol)) {
 			new org.apache.commons.httpclient.auth.AuthScope(<%=proxyHost %>, Integer.parseInt(<%=proxyPort%>), null),
 			new org.apache.commons.httpclient.UsernamePasswordCredentials(<%=proxyUser %>, decryptedPassword_<%=cid%>));
 			
-			java.util.ArrayList<String> authPrefs_<%=cid %> = new java.util.ArrayList<>();
-			authPrefs_<%=cid %>.add(org.apache.commons.httpclient.auth.AuthPolicy.BASIC);
+			java.util.List<String> authPrefs_<%=cid %> = java.util.Collections.singletonList(org.apache.commons.httpclient.auth.AuthPolicy.BASIC);
 			client_<%=cid %>.getParams().setParameter(org.apache.commons.httpclient.auth.AuthPolicy.AUTH_SCHEME_PRIORITY, authPrefs_<%=cid %>);
 		<%}
 	}


### PR DESCRIPTION
* Fix basic auth when server allows different auth mechanisms

**What is the current behavior?** (You can also link to an open issue here)
When proxy server has several authentication mechanisms and ntlm has the highest priority, tFileFetch component tries using ntlm mechanism, even if the checkbox "Enable NTLM Credentials" is not checked.

**What is the new behavior?**
If the checkbox "Enable NTLM Credentials" is not checked, tFileFetch would try using BASIC authentication mechanism.

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


