### PR TITLE
chore(monitoring/TUP-23824): Ensure monitoring feature can rely on system properties to configure the audit logger and does not hardcode a local file name+location+maxsize

### DIFF
--- a/main/plugins/org.talend.designer.codegen/jet_stub/footer.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/footer.javajet
@@ -493,7 +493,11 @@
 				properties_<%=jobCatcherNode.getUniqueName()%>.setProperty("appender.file.maxsize", "52428800");
 				properties_<%=jobCatcherNode.getUniqueName()%>.setProperty("appender.file.maxbackup", "20");
 				properties_<%=jobCatcherNode.getUniqueName()%>.setProperty("host", "false");
-				
+
+				System.getProperties().stringPropertyNames().stream()
+					.filter(it -> it.startsWith("monitoring.audit.logger.properties."))
+					.forEach(key -> properties_<%=jobCatcherNode.getUniqueName()%>.setProperty(key.substring("monitoring.audit.logger.properties.".length()), System.getProperty(key)));
+
 				auditLogger_<%=jobCatcherNode.getUniqueName()%> = org.talend.job.audit.JobEventAuditLoggerFactory.createJobAuditLogger(properties_<%=jobCatcherNode.getUniqueName()%>);
 			}
 		<%
@@ -1509,13 +1513,13 @@ if (execStat) {
             }
         } else if (arg.startsWith("--log4jLevel=")) {
             log4jLevel = arg.substring(13);
-		} else if (arg.startsWith("--monitoring=")) {//for trunjob call
-			enableLogStash = "true".equalsIgnoreCase(arg.substring(13));
+		} else if (arg.startsWith("--monitoring") && arg.contains("=")) {//for trunjob call
+		    final int equal = arg.indexOf('=');
+			final String key = arg.substring("--".length(), equal);
+			System.setProperty(key, arg.substring(equal + 1));
 		}
 		
-		if(!enableLogStash) {
-			enableLogStash = "true".equalsIgnoreCase(System.getProperty("monitoring"));
-		}
+		enableLogStash = "true".equalsIgnoreCase(System.getProperty("monitoring"));
     }
     
     private static final String NULL_VALUE_EXPRESSION_IN_COMMAND_STRING_FOR_CHILD_JOB_ONLY = "<TALEND_NULL>";

--- a/main/plugins/org.talend.designer.codegen/jet_stub/footer.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/footer.javajet
@@ -445,6 +445,7 @@
                 lastStr = "";
             }
         }
+        enableLogStash = "true".equalsIgnoreCase(System.getProperty("monitoring"));
 
         <%if(isLog4jEnabled){%>
 	        if(!"".equals(log4jLevel)){
@@ -1518,8 +1519,6 @@ if (execStat) {
 			final String key = arg.substring("--".length(), equal);
 			System.setProperty(key, arg.substring(equal + 1));
 		}
-		
-		enableLogStash = "true".equalsIgnoreCase(System.getProperty("monitoring"));
     }
     
     private static final String NULL_VALUE_EXPRESSION_IN_COMMAND_STRING_FOR_CHILD_JOB_ONLY = "<TALEND_NULL>";


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

When activating the monitoring, the audit logger is hardcoded to be a file, with a max size, in a particular location - which is relative so can be unexpected - and hardcodes the service, application names etc.

**What is the new behavior?**

System properties enable to customize this configuration.

Example:

    -Dmonitoring=true
    -Dmonitoring.audit.logger.properties.log.appender=console


**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


