### PR TITLE
fix(TDI-42436): copy Redshift components to cloud folder

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tAmazonRedshiftManage/tAmazonRedshiftManage_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tAmazonRedshiftManage/tAmazonRedshiftManage_java.xml
@@ -7,6 +7,7 @@
 
   <FAMILIES>
 		<FAMILY>Databases/DB Specifics/Amazon/Redshift</FAMILY>
+        <FAMILY>Cloud/Amazon/Redshift</FAMILY>
   </FAMILIES>
 
 	<DOCUMENTATION>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tAmazonRedshiftManage/tAmazonRedshiftManage_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tAmazonRedshiftManage/tAmazonRedshiftManage_java.xml
@@ -7,7 +7,7 @@
 
   <FAMILIES>
 		<FAMILY>Databases/DB Specifics/Amazon/Redshift</FAMILY>
-        <FAMILY>Cloud/Amazon/Redshift</FAMILY>
+		<FAMILY>Cloud/Amazon/Redshift</FAMILY>
   </FAMILIES>
 
 	<DOCUMENTATION>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tRedshiftUnload/tRedshiftUnload_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tRedshiftUnload/tRedshiftUnload_java.xml
@@ -7,6 +7,7 @@
 
   <FAMILIES>
 		<FAMILY>Databases/DB Specifics/Amazon/Redshift</FAMILY>
+        <FAMILY>Cloud/Amazon/Redshift</FAMILY>
   </FAMILIES>
 
 	<DOCUMENTATION>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tRedshiftUnload/tRedshiftUnload_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tRedshiftUnload/tRedshiftUnload_java.xml
@@ -7,7 +7,7 @@
 
   <FAMILIES>
 		<FAMILY>Databases/DB Specifics/Amazon/Redshift</FAMILY>
-        <FAMILY>Cloud/Amazon/Redshift</FAMILY>
+		<FAMILY>Cloud/Amazon/Redshift</FAMILY>
   </FAMILIES>
 
 	<DOCUMENTATION>


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-42436

**What is the new behavior?**
 tAmazonRedshiftManage and tRedshiftUnload was added to Cloud/Amazon/Redshift family folder

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


