### PR TITLE
TESB-26086 Adding missing context files to published artifacts

### DIFF
--- a/main/plugins/org.talend.designer.publish.core/src/org/talend/designer/publish/core/actions/AbstractPublishJobAction.java
+++ b/main/plugins/org.talend.designer.publish.core/src/org/talend/designer/publish/core/actions/AbstractPublishJobAction.java
@@ -112,6 +112,9 @@ public abstract class AbstractPublishJobAction implements IRunnableWithProgress 
             // TDI-32861, because for publish job, so means, must be binaries
             exportChoiceMap.put(ExportChoice.binaries, true);
             exportChoiceMap.put(ExportChoice.includeLibs, true);
+            
+            // TESB-26145/TESB-26086 adding context to published job
+            exportChoiceMap.put(ExportChoice.needContext, true);
 
             ProcessItem processItem = (ProcessItem) node.getObject().getProperty().getItem();
             exportItemForDQComponent(processItem);


### PR DESCRIPTION
**What is the current behavior?**
Published data service artifacts are missing context files: when a dataservice job is published for the first time and was never build from Studio before, published artifact is missing the context files.

**What is the new behavior?**
Context files are included even when job was not built before.

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

