### PR TITLE
bugfix(TDI-42581): tSOAP doesn't support SOAPActions for Soap 1.2

### DIFF
--- a/main/plugins/org.talend.designer.components.libs/libs_src/soap/src/main/java/org/talend/soap/SOAPUtil.java
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/soap/src/main/java/org/talend/soap/SOAPUtil.java
@@ -297,8 +297,10 @@ public class SOAPUtil {
     /* https://jira.talendforge.org/browse/TDI-42581 skip add SOAPAction directly to header v1.2 */
     private void setSoapAction(String version, String soapAction, MimeHeaders mimeHeaders) {
         if (SOAP12.equals(version)) {
-            // https://jira.talendforge.org/browse/TDI-42581 skip add SOAPAction directly to header
-            mimeHeaders.setHeader("Content-Type", "application/soap+xml; charset=utf-8; action=\"" + soapAction + "\"");
+            // in soap version 1.2 param 'action' optional and should not be empty
+            if( soapAction != null && !soapAction.trim().isEmpty()) {
+                mimeHeaders.setHeader("Content-Type", "application/soap+xml; charset=utf-8; action=\"" + soapAction + "\"");
+            }
         } else {
             mimeHeaders.setHeader("SOAPAction", soapAction);
         }


### PR DESCRIPTION
param 'action' optional and  should not be empty

it will be added in case when not empty. 




**Does this PR introduce a breaking change?**

- [ ] Yes
- [ X] No

**Other information**:


