### PR TITLE
fix(TDI-42689) : prefer BigDecimal for float&double

### DIFF
--- a/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/pom.xml
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/pom.xml
@@ -7,7 +7,7 @@
    <groupId>net.sf.json-lib</groupId>
    <artifactId>json-lib</artifactId>
    <packaging>jar</packaging>
-   <version>2.4.1-talend</version>
+   <version>2.4.2-talend</version>
    <name>json-lib</name>
 
 	<properties>

--- a/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/main/java/net/sf/json/util/JSONTokener.java
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/main/java/net/sf/json/util/JSONTokener.java
@@ -446,7 +446,11 @@ public class JSONTokener {
       boolean isDecimal = s.indexOf('.') != -1;
 
       if(isDecimal){
-         return new BigDecimal(s);
+         Double d = Double.valueOf(s);
+         if(Double.POSITIVE_INFINITY == Math.abs(d)){
+            return new BigDecimal(s);
+         }
+         return d;
       }
 
       return NumberUtils.createNumber(s);

--- a/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/main/java/net/sf/json/util/JSONTokener.java
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/main/java/net/sf/json/util/JSONTokener.java
@@ -15,6 +15,7 @@
  */
 package net.sf.json.util;
 
+import java.math.BigDecimal;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONException;
 import net.sf.json.JSONNull;
@@ -414,7 +415,7 @@ public class JSONTokener {
          }
 
          try{
-            return NumberUtils.createNumber(s);
+            return  createNumber(s);
          }catch( Exception e ){
             return s;
          }
@@ -433,6 +434,22 @@ public class JSONTokener {
       }
 
       return s;
+   }
+
+   /**
+    * This method has been added to fix https://jira.talendforge.org/browse/TDI-42689
+    *
+    * @param s The String representation of the number
+    * @return The Number instance
+    */
+   private Number createNumber(String s){
+      boolean isDecimal = s.indexOf('.') != -1;
+
+      if(isDecimal){
+         return new BigDecimal(s);
+      }
+
+      return NumberUtils.createNumber(s);
    }
 
    /**

--- a/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/main/java/net/sf/json/util/JSONUtils.java
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/main/java/net/sf/json/util/JSONUtils.java
@@ -184,14 +184,10 @@ public final class JSONUtils {
             return Integer.class;
          }else if( isLong( n ) ){
             return Long.class;
-         }else if( isFloat( n ) ){
-            return Float.class;
          }else if( isBigInteger( n ) ){
             return BigInteger.class;
          }else if( isBigDecimal( n ) ){
             return BigDecimal.class;
-         }else if( isDouble( n ) ){
-            return Double.class;
          }else{
             throw new JSONException( "Unsupported type" );
          }

--- a/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/main/java/net/sf/json/util/JSONUtils.java
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/main/java/net/sf/json/util/JSONUtils.java
@@ -186,6 +186,8 @@ public final class JSONUtils {
             return Long.class;
          }else if( isBigInteger( n ) ){
             return BigInteger.class;
+         }else if( isDouble( n ) ){
+            return Double.class;
          }else if( isBigDecimal( n ) ){
             return BigDecimal.class;
          }else{

--- a/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/test/java/net/sf/json/TestJSONObject.java
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/test/java/net/sf/json/TestJSONObject.java
@@ -1044,14 +1044,14 @@ public class TestJSONObject extends TestCase {
    }
 
    public void testToBean_BeanD() {
-      String json = "{bool:true,integer:1,string:\"json\",bdarray:[4.2424245783E7, 123456789.2424245783E7, 6.0]}";
+      String json = "{bool:true,integer:1,string:\"json\",doublearray:[4.2424245783E7, 123456789.2424245783E7, 6.0]}";
       JSONObject jsonObject = JSONObject.fromObject( json );
       BeanD bean = (BeanD) JSONObject.toBean( jsonObject, BeanD.class );
       assertEquals( jsonObject.get( "bool" ), Boolean.valueOf( bean.isBool() ) );
       assertEquals( jsonObject.get( "integer" ), new Integer( bean.getInteger() ) );
       assertEquals( jsonObject.get( "string" ), bean.getString() );
-      Assertions.assertEquals( bean.getBdarray(),
-              JSONArray.toArray( jsonObject.getJSONArray( "bdarray" ) ) );
+      Assertions.assertEquals( bean.getDoublearray(),
+              JSONArray.toArray( jsonObject.getJSONArray( "doublearray" ) ) );
    }
 
    public void testToBean_ClassBean() {
@@ -1062,9 +1062,29 @@ public class TestJSONObject extends TestCase {
       assertEquals( Object.class, bean.getKlass() );
    }
 
-   public void testToBean_DynaBean__BigInteger_BigDecimal() {
+   public void testToBean_DynaBean__BigInteger_Double() {
       BigInteger l = new BigDecimal( "1.7976931348623157E308" ).toBigInteger();
       BigDecimal m = new BigDecimal( "1.7976931348623157E307" ).add( new BigDecimal( "0.0001" ) );
+      JSONObject json = new JSONObject().element( "i", BigInteger.ZERO )
+              .element( "d", MorphUtils.BIGDECIMAL_ONE )
+              .element( "bi", l )
+              .element( "bd", m );
+      Object bean = JSONObject.toBean( json );
+      Object i = ((MorphDynaBean) bean).get( "i" );
+      Object d = ((MorphDynaBean) bean).get( "d" );
+      assertTrue( i instanceof Integer );
+      assertTrue( d instanceof Integer );
+
+      Object bi = ((MorphDynaBean) bean).get( "bi" );
+      Object bd = ((MorphDynaBean) bean).get( "bd" );
+      assertTrue( bi instanceof BigInteger );
+      assertTrue( bd instanceof Double );
+   }
+
+
+   public void testToBean_DynaBean__BigInteger_BigDecimal() {
+      BigInteger l = new BigDecimal( "1.7976931348623157E308" ).toBigInteger();
+      BigDecimal m = new BigDecimal( "-1.7976931348623157E309" ).add( new BigDecimal( "0.0001" ) );
       JSONObject json = new JSONObject().element( "i", BigInteger.ZERO )
             .element( "d", MorphUtils.BIGDECIMAL_ONE )
             .element( "bi", l )

--- a/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/test/java/net/sf/json/TestJSONObject.java
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/test/java/net/sf/json/TestJSONObject.java
@@ -27,6 +27,7 @@ import net.sf.json.processors.PropertyNameProcessor;
 import net.sf.json.sample.BeanA;
 import net.sf.json.sample.BeanB;
 import net.sf.json.sample.BeanC;
+import net.sf.json.sample.BeanD;
 import net.sf.json.sample.BeanFoo;
 import net.sf.json.sample.BeanWithFunc;
 import net.sf.json.sample.ChildBean;
@@ -1040,6 +1041,17 @@ public class TestJSONObject extends TestCase {
       assertEquals( jsonObject.get( "string" ), bean.getString() );
       Assertions.assertEquals( bean.getIntarray(),
             JSONArray.toArray( jsonObject.getJSONArray( "intarray" ) ) );
+   }
+
+   public void testToBean_BeanD() {
+      String json = "{bool:true,integer:1,string:\"json\",bdarray:[4.2424245783E7, 123456789.2424245783E7, 6.0]}";
+      JSONObject jsonObject = JSONObject.fromObject( json );
+      BeanD bean = (BeanD) JSONObject.toBean( jsonObject, BeanD.class );
+      assertEquals( jsonObject.get( "bool" ), Boolean.valueOf( bean.isBool() ) );
+      assertEquals( jsonObject.get( "integer" ), new Integer( bean.getInteger() ) );
+      assertEquals( jsonObject.get( "string" ), bean.getString() );
+      Assertions.assertEquals( bean.getBdarray(),
+              JSONArray.toArray( jsonObject.getJSONArray( "bdarray" ) ) );
    }
 
    public void testToBean_ClassBean() {

--- a/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/test/java/net/sf/json/sample/BeanD.java
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/test/java/net/sf/json/sample/BeanD.java
@@ -25,14 +25,14 @@ import java.math.BigDecimal;
  * @author Andres Almiray <aalmiray@users.sourceforge.net>
  */
 public class BeanD extends BeanA {
-   private BigDecimal[] bdarray = new BigDecimal[3];
+   private Double[] doublearray = new Double[3];
 
-   public BigDecimal[] getBdarray() {
-      return bdarray;
+   public Double[] getDoublearray() {
+      return doublearray;
    }
 
-   public void setBdarray( BigDecimal[] bdarray ) {
-      this.bdarray = bdarray;
+   public void setDoublearray(Double[] doublearray) {
+      this.doublearray = doublearray;
    }
 
    public String toString() {

--- a/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/test/java/net/sf/json/sample/BeanD.java
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/test/java/net/sf/json/sample/BeanD.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2002-2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.sf.json.sample;
+
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang.builder.ToStringStyle;
+
+import java.math.BigDecimal;
+
+/**
+ * @author Andres Almiray <aalmiray@users.sourceforge.net>
+ */
+public class BeanD extends BeanA {
+   private BigDecimal[] bdarray = new BigDecimal[3];
+
+   public BigDecimal[] getBdarray() {
+      return bdarray;
+   }
+
+   public void setBdarray( BigDecimal[] bdarray ) {
+      this.bdarray = bdarray;
+   }
+
+   public String toString() {
+      return ToStringBuilder.reflectionToString( this, ToStringStyle.MULTI_LINE_STYLE );
+   }
+}

--- a/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/test/java/net/sf/json/util/TestJSONBuilder.java
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/test/java/net/sf/json/util/TestJSONBuilder.java
@@ -94,7 +94,7 @@ public class TestJSONBuilder extends TestCase {
             .endObject();
       JSONObject jsonObj = JSONObject.fromObject( w.toString() );
       assertEquals( Boolean.TRUE, jsonObj.get( "bool" ) );
-      assertEquals( new BigDecimal( "1.1" ), jsonObj.get( "numDouble" ) );
+      assertEquals( Double.valueOf( "1.1" ), jsonObj.get( "numDouble" ) );
       assertEquals( new Long( 2 ).longValue(), ((Number) jsonObj.get( "numInt" )).longValue() );
       assertEquals( "text", jsonObj.get( "text" ) );
       assertTrue( JSONUtils.isFunction( jsonObj.get( "func" ) ) );

--- a/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/test/java/net/sf/json/util/TestJSONBuilder.java
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/test/java/net/sf/json/util/TestJSONBuilder.java
@@ -17,6 +17,7 @@
 package net.sf.json.util;
 
 import java.io.StringWriter;
+import java.math.BigDecimal;
 
 import junit.framework.TestCase;
 import net.sf.json.JSONFunction;
@@ -93,7 +94,7 @@ public class TestJSONBuilder extends TestCase {
             .endObject();
       JSONObject jsonObj = JSONObject.fromObject( w.toString() );
       assertEquals( Boolean.TRUE, jsonObj.get( "bool" ) );
-      assertEquals( new Double( 1.1d ), jsonObj.get( "numDouble" ) );
+      assertEquals( new BigDecimal( "1.1" ), jsonObj.get( "numDouble" ) );
       assertEquals( new Long( 2 ).longValue(), ((Number) jsonObj.get( "numInt" )).longValue() );
       assertEquals( "text", jsonObj.get( "text" ) );
       assertTrue( JSONUtils.isFunction( jsonObj.get( "func" ) ) );

--- a/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/test/java/net/sf/json/util/TestJSONStringer.java
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/test/java/net/sf/json/util/TestJSONStringer.java
@@ -87,7 +87,7 @@ public class TestJSONStringer extends TestCase {
             .endObject();
       JSONObject jsonObj = JSONObject.fromObject( b.toString() );
       assertEquals( Boolean.TRUE, jsonObj.get( "bool" ) );
-      assertEquals( new BigDecimal( "1.1" ), jsonObj.get( "numDouble" ) );
+      assertEquals( Double.valueOf( "1.1" ), jsonObj.get( "numDouble" ) );
       assertEquals( new Long( 2 ).longValue(), ((Number) jsonObj.get( "numInt" )).longValue() );
       assertEquals( "text", jsonObj.get( "text" ) );
       assertTrue( JSONUtils.isFunction( jsonObj.get( "func" ) ) );

--- a/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/test/java/net/sf/json/util/TestJSONStringer.java
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/test/java/net/sf/json/util/TestJSONStringer.java
@@ -20,6 +20,8 @@ import junit.framework.TestCase;
 import net.sf.json.JSONFunction;
 import net.sf.json.JSONObject;
 
+import java.math.BigDecimal;
+
 /**
  * @author Andres Almiray <aalmiray@users.sourceforge.net>
  */
@@ -85,7 +87,7 @@ public class TestJSONStringer extends TestCase {
             .endObject();
       JSONObject jsonObj = JSONObject.fromObject( b.toString() );
       assertEquals( Boolean.TRUE, jsonObj.get( "bool" ) );
-      assertEquals( new Double( 1.1d ), jsonObj.get( "numDouble" ) );
+      assertEquals( new BigDecimal( "1.1" ), jsonObj.get( "numDouble" ) );
       assertEquals( new Long( 2 ).longValue(), ((Number) jsonObj.get( "numInt" )).longValue() );
       assertEquals( "text", jsonObj.get( "text" ) );
       assertTrue( JSONUtils.isFunction( jsonObj.get( "func" ) ) );

--- a/main/plugins/org.talend.designer.components.localprovider/components/tExtractJSONFields/tExtractJSONFields_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tExtractJSONFields/tExtractJSONFields_java.xml
@@ -178,7 +178,7 @@
     <IMPORTS>
     		<IMPORT NAME="Java_DOM4J1.6" MODULE="dom4j-1.6.1.jar" MVN="mvn:dom4j/dom4j/1.6.1"  UrlPath="platform:/plugin/org.talend.libraries.dom4j-jaxen/lib/dom4j-1.6.1.jar" REQUIRED_IF="READ_BY == 'XPATH'" BundleID="" />
             <IMPORT NAME="Java_JAXEN1.1" MODULE="jaxen-1.1.1.jar" MVN="mvn:org.talend.libraries/jaxen-1.1.1/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.dom4j-jaxen/lib/jaxen-1.1.1.jar" REQUIRED_IF="READ_BY == 'XPATH'" BundleID="" />
-            <IMPORT NAME="json-lib" MODULE="json-lib-2.4.1-talend.jar" MVN="mvn:net.sf.json-lib/json-lib/2.4.1-talend" REQUIRED_IF="READ_BY == 'XPATH'" />
+            <IMPORT NAME="json-lib" MODULE="json-lib-2.4.2-talend.jar" MVN="mvn:net.sf.json-lib/json-lib/2.4.2-talend" REQUIRED_IF="READ_BY == 'XPATH'" />
             <IMPORT NAME="commons_lang" MODULE="commons-lang-2.6.jar" MVN="mvn:commons-lang/commons-lang/2.6"  UrlPath="platform:/plugin/org.talend.libraries.apache.common/lib/commons-lang-2.6.jar" REQUIRED_IF="READ_BY == 'XPATH'" />
             <IMPORT NAME="commons_logging" MODULE="commons-logging-1.1.1.jar" MVN="mvn:org.talend.libraries/commons-logging-1.1.1/6.0.0"  UrlPath="platform:/base/plugins/org.apache.commons.logging_1.1.1.v201101211721.jar" REQUIRED_IF="READ_BY == 'XPATH'" />
             <IMPORT NAME="ezmorph" MODULE="ezmorph-1.0.6.jar" MVN="mvn:org.talend.libraries/ezmorph-1.0.6/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.jackson/lib/ezmorph-1.0.6.jar" REQUIRED_IF="READ_BY == 'XPATH'" />

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileInputJSON/tFileInputJSON_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileInputJSON/tFileInputJSON_java.xml
@@ -165,7 +165,7 @@
 				REQUIRED_IF="(READ_BY == 'XPATH')" BundleID="" />
 			<IMPORT NAME="Java_JAXEN1.1" MODULE="jaxen-1.1.1.jar" MVN="mvn:org.talend.libraries/jaxen-1.1.1/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.dom4j-jaxen/lib/jaxen-1.1.1.jar"
 				REQUIRED_IF="(READ_BY == 'XPATH')" BundleID="" />
-			<IMPORT NAME="json-lib" MODULE="json-lib-2.4.1-talend.jar" MVN="mvn:net.sf.json-lib/json-lib/2.4.1-talend" REQUIRED_IF="(READ_BY == 'XPATH')" />
+			<IMPORT NAME="json-lib" MODULE="json-lib-2.4.2-talend.jar" MVN="mvn:net.sf.json-lib/json-lib/2.4.2-talend" REQUIRED_IF="(READ_BY == 'XPATH')" />
 			<IMPORT NAME="commons_lang" MODULE="commons-lang-2.6.jar" MVN="mvn:commons-lang/commons-lang/2.6"  UrlPath="platform:/plugin/org.talend.libraries.apache.common/lib/commons-lang-2.6.jar"
 				REQUIRED_IF="(READ_BY == 'XPATH')" />
 			<IMPORT NAME="commons_logging" MODULE="commons-logging-1.1.1.jar" MVN="mvn:org.talend.libraries/commons-logging-1.1.1/6.0.0"  UrlPath="platform:/base/plugins/org.apache.commons.logging_1.1.1.v201101211721.jar"

--- a/main/plugins/org.talend.designer.components.localprovider/components/tWriteJSONFieldIn/tWriteJSONFieldIn_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tWriteJSONFieldIn/tWriteJSONFieldIn_java.xml
@@ -68,7 +68,7 @@
 			<IMPORT NAME="commons_lang" MODULE="commons-lang-2.6.jar" MVN="mvn:commons-lang/commons-lang/2.6"  UrlPath="platform:/plugin/org.talend.libraries.apache.common/lib/commons-lang-2.6.jar" REQUIRED="true" />
 			<IMPORT NAME="commons_logging" MODULE="commons-logging-1.1.1.jar" MVN="mvn:org.talend.libraries/commons-logging-1.1.1/6.0.0"  UrlPath="platform:/base/plugins/org.apache.commons.logging_1.1.1.v201101211721.jar" REQUIRED="true" />
 			<IMPORT NAME="ezmorph" MODULE="ezmorph-1.0.6.jar" MVN="mvn:org.talend.libraries/ezmorph-1.0.6/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.jackson/lib/ezmorph-1.0.6.jar" REQUIRED="true" />
-			<IMPORT NAME="json-lib" MODULE="json-lib-2.4.1-talend.jar" MVN="mvn:net.sf.json-lib/json-lib/2.4.1-talend" REQUIRED="true" />
+			<IMPORT NAME="json-lib" MODULE="json-lib-2.4.2-talend.jar" MVN="mvn:net.sf.json-lib/json-lib/2.4.2-talend" REQUIRED="true" />
 		</IMPORTS>
 	</CODEGENERATION>
 


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-42689

**What is the new behavior?**
BigDecimal is used instead of float & double to avoid lose of decimal precision.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


