### PR TITLE
fix(TUP-20950):When Configuration/Datastore class is empty it is displayed in Studio as a Text field.

### DIFF
--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/SettingVisitor.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/SettingVisitor.java
@@ -201,7 +201,7 @@ public class SettingVisitor implements PropertyVisitor {
      */
     @Override
     public void visit(final PropertyNode node) {
-        if (node.isLeaf()) {
+        if (node.isLeaf() && !PropertyTypes.OBJECT.equalsIgnoreCase(node.getProperty().getType())) {
             switch (node.getFieldType()) {
             case CHECK:
                 final CheckElementParameter check = visitCheck(node);

--- a/test/plugins/org.talend.sdk.component.studio-integration.test/src/main/java/org/talend/sdk/component/studio/model/parameter/SettingVisitorTest.java
+++ b/test/plugins/org.talend.sdk.component.studio-integration.test/src/main/java/org/talend/sdk/component/studio/model/parameter/SettingVisitorTest.java
@@ -1,0 +1,97 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.sdk.component.studio.model.parameter;
+
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.talend.core.model.metadata.IMetadataColumn;
+import org.talend.core.model.metadata.IMetadataTable;
+import org.talend.core.model.metadata.MetadataColumn;
+import org.talend.core.model.metadata.MetadataTable;
+import org.talend.core.model.process.EParameterFieldType;
+import org.talend.designer.core.ui.editor.nodes.Node;
+import org.talend.sdk.component.server.front.model.SimplePropertyDefinition;
+
+/**
+ * created by hcyi on Aug 27, 2019
+ * Detailled comment
+ *
+ */
+public class SettingVisitorTest {
+
+    @Test
+    public void testVisit4NotLeafNode() throws Exception {
+        final Node nodeMock = mockNode(metadata());
+        final OutputSchemaParameter parameter = new OutputSchemaParameter(nodeMock, "schema", "FLOW", null, true); //$NON-NLS-1$ //$NON-NLS-2$
+
+        SettingVisitor visitor = new SettingVisitor(nodeMock, parameter, new ArrayList());
+
+        PropertyNode propertyNode = getPropertyNode(PropertyTypes.STRING, EParameterFieldType.TEXT);
+        PropertyNode childPropertyNode = getPropertyNode(PropertyTypes.STRING, EParameterFieldType.TEXT);
+        propertyNode.addChild(childPropertyNode);
+
+        visitor.visit(propertyNode);
+        
+        Assertions.assertEquals(0, visitor.getSettings().size());
+    }
+
+    @Test
+    public void testVisit4LeafNodeObject() throws Exception {
+        final Node nodeMock = mockNode(metadata());
+        final OutputSchemaParameter parameter = new OutputSchemaParameter(nodeMock, "schema", "FLOW", null, true);//$NON-NLS-1$ //$NON-NLS-2$
+        
+        SettingVisitor visitor = new SettingVisitor(nodeMock, parameter, new ArrayList());
+        
+        PropertyNode propertyNode = getPropertyNode(PropertyTypes.OBJECT, EParameterFieldType.TEXT);
+        
+        visitor.visit(propertyNode);
+        
+        Assertions.assertEquals(0, visitor.getSettings().size());
+    }
+
+    private PropertyNode getPropertyNode(String propertyType, EParameterFieldType fieldType) {
+        SimplePropertyDefinition definition = new SimplePropertyDefinition();
+        definition.setName("propertyName1");
+        definition.setType(propertyType);
+        definition.setMetadata(new HashMap());
+        PropertyNode propertyNode = new PropertyNode(new PropertyDefinitionDecorator(definition), fieldType, false);
+        return propertyNode;
+    }
+
+    private Node mockNode(final IMetadataTable metadata) {
+        final Node nodeMock = mock(Node.class);
+        when(nodeMock.getMetadataFromConnector("FLOW")).thenReturn(metadata);
+        return nodeMock;
+    }
+
+    private IMetadataTable metadata() {
+        final IMetadataTable metadata = new MetadataTable();
+        final List<IMetadataColumn> columns = new ArrayList<>();
+
+        final IMetadataColumn c1 = new MetadataColumn();
+        c1.setLabel("c1");
+        columns.add(c1);
+
+        final IMetadataColumn c2 = new MetadataColumn();
+        c2.setLabel("c2");
+        columns.add(c2);
+        metadata.setListColumns(columns);
+        return metadata;
+    }
+}


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TUP-20950

**What is the new behavior?**
https://jira.talendforge.org/browse/TUP-20950

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


