### PR TITLE
TDI-42900 : usage of Thread.contextClassLoader (get/set) instead of S…

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tHiveConnection/tHiveConnection_jdbc.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tHiveConnection/tHiveConnection_jdbc.javajet
@@ -254,9 +254,9 @@ imports="
 					String hadoopConfDir_<%=cid%> = System.getenv("HADOOP_CONF_DIR");
 					if(hadoopConfDir_<%=cid%> != null){
 						final java.net.URL[] urlHadoop = new java.net.URL[] { new java.io.File(hadoopConfDir_<%=cid%>).toURI().toURL() };
-						final ClassLoader sysloader = Thread.currentThread().getContextClassLoader();
-						final java.net.URLClassLoader newSysLoader = new java.net.URLClassLoader(urlHadoop, sysloader);
-						Thread.currentThread().setContextClassLoader(newSysLoader);
+						final ClassLoader threadClassLoader = Thread.currentThread().getContextClassLoader();
+						final java.net.URLClassLoader newThreadClassLoader = new java.net.URLClassLoader(urlHadoop, threadClassLoader);
+						Thread.currentThread().setContextClassLoader(newThreadClassLoader);
 					}
 					org.apache.hadoop.conf.Configuration conf_<%=cid%> = new org.apache.hadoop.conf.Configuration();
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tHiveConnection/tHiveConnection_jdbc.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tHiveConnection/tHiveConnection_jdbc.javajet
@@ -253,10 +253,10 @@ imports="
 					// Add HADOOP_CONF_DIR to the classpath if it's present
 					String hadoopConfDir_<%=cid%> = System.getenv("HADOOP_CONF_DIR");
 					if(hadoopConfDir_<%=cid%> != null){
-						java.net.URLClassLoader sysloader = (java.net.URLClassLoader) ClassLoader.getSystemClassLoader();
-						java.lang.reflect.Method method = java.net.URLClassLoader.class.getDeclaredMethod("addURL", new Class[] { java.net.URL.class });
-						method.setAccessible(true);
-						method.invoke(sysloader,new Object[] { new java.io.File(hadoopConfDir_<%=cid%>).toURI().toURL() });
+						final java.net.URL[] urlHadoop = new java.net.URL[] { new java.io.File(hadoopConfDir_<%=cid%>).toURI().toURL() };
+						final ClassLoader sysloader = Thread.currentThread().getContextClassLoader();
+						final java.net.URLClassLoader newSysLoader = new java.net.URLClassLoader(urlHadoop, sysloader);
+						Thread.currentThread().setContextClassLoader(newSysLoader);
 					}
 					org.apache.hadoop.conf.Configuration conf_<%=cid%> = new org.apache.hadoop.conf.Configuration();
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tHiveConnection/tHiveConnection_jdbc.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tHiveConnection/tHiveConnection_jdbc.javajet
@@ -253,10 +253,10 @@ imports="
 					// Add HADOOP_CONF_DIR to the classpath if it's present
 					String hadoopConfDir_<%=cid%> = System.getenv("HADOOP_CONF_DIR");
 					if(hadoopConfDir_<%=cid%> != null){
-						final java.net.URL[] urlHadoop = new java.net.URL[] { new java.io.File(hadoopConfDir_<%=cid%>).toURI().toURL() };
-						final ClassLoader threadClassLoader = Thread.currentThread().getContextClassLoader();
-						final java.net.URLClassLoader newThreadClassLoader = new java.net.URLClassLoader(urlHadoop, threadClassLoader);
-						Thread.currentThread().setContextClassLoader(newThreadClassLoader);
+						java.net.URLClassLoader sysloader = (java.net.URLClassLoader) ClassLoader.getSystemClassLoader();
+						java.lang.reflect.Method method = java.net.URLClassLoader.class.getDeclaredMethod("addURL", new Class[] { java.net.URL.class });
+						method.setAccessible(true);
+						method.invoke(sysloader,new Object[] { new java.io.File(hadoopConfDir_<%=cid%>).toURI().toURL() });
 					}
 					org.apache.hadoop.conf.Configuration conf_<%=cid%> = new org.apache.hadoop.conf.Configuration();
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tLibraryLoad/tLibraryLoad_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLibraryLoad/tLibraryLoad_begin.javajet
@@ -17,17 +17,20 @@
 
 <% if(hotLibs!=null&&hotLibs.size() > 0){%>
 
-java.net.URLClassLoader sysloader_<%=cid %> = (java.net.URLClassLoader) ClassLoader.getSystemClassLoader();
-java.lang.reflect.Method method_<%=cid %> = java.net.URLClassLoader.class.getDeclaredMethod("addURL", new Class[] { java.net.URL.class });
-method_<%=cid %>.setAccessible(true);
+String[] libPaths_<%=cid %> = new String[] { <% for(Map<String, String> item : hotLibs) {%> <%=item.get("LIBPATH") %>, <%}%> };
 
-String[] libPaths_<%=cid %> = new String[] { <% for(Map<String, String> item : hotLibs){%> <%=item.get("LIBPATH") %>, <%}%> };
-for(String lib_<%=cid %>:libPaths_<%=cid %> ){
+java.util.List<java.net.URL> libURL_<%=cid %> = new java.util.ArrayList<>();
+
+for(String lib_<%=cid %>:libPaths_<%=cid %>) {
 	String separator_<%=cid %> = System.getProperty("path.separator");
 	String[] jarFiles_<%=cid %> = lib_<%=cid %>.split(separator_<%=cid %>);	
-	for(String jarFile_<%=cid %>:jarFiles_<%=cid %>){		
-		method_<%=cid %>.invoke(sysloader_<%=cid %>, new Object[] { new java.io.File(jarFile_<%=cid %>).toURL() });
+	for(String jarFile_<%=cid %> : jarFiles_<%=cid %>) {
+		libURL_<%=cid %>.add( new java.io.File(jarFile_<%=cid %>).toURI().toURL() );
 	}
 }
-
+java.net.URL[] libURLArray_<%=cid %> = libURL_<%=cid %>.toArray(new java.net.URL[] {});
+ClassLoader sysloader_<%=cid %> = Thread.currentThread().getContextClassLoader();
+java.net.URLClassLoader newSysLoader_<%=cid %> = new java.net.URLClassLoader(libURLArray_<%=cid %>, sysloader_<%=cid %>);
+Thread.currentThread().setContextClassLoader(newSysLoader_<%=cid %>);
 <%}%>
+

--- a/main/plugins/org.talend.designer.components.localprovider/components/tLibraryLoad/tLibraryLoad_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLibraryLoad/tLibraryLoad_begin.javajet
@@ -29,8 +29,8 @@ for(String lib_<%=cid %>:libPaths_<%=cid %>) {
 	}
 }
 java.net.URL[] libURLArray_<%=cid %> = libURL_<%=cid %>.toArray(new java.net.URL[] {});
-ClassLoader sysloader_<%=cid %> = Thread.currentThread().getContextClassLoader();
-java.net.URLClassLoader newSysLoader_<%=cid %> = new java.net.URLClassLoader(libURLArray_<%=cid %>, sysloader_<%=cid %>);
-Thread.currentThread().setContextClassLoader(newSysLoader_<%=cid %>);
+ClassLoader threadClassLoader_<%=cid %> = Thread.currentThread().getContextClassLoader();
+java.net.URLClassLoader newthreadClassLoader_<%=cid %> = new java.net.URLClassLoader(libURLArray_<%=cid %>, threadClassLoader_<%=cid %>);
+Thread.currentThread().setContextClassLoader(newthreadClassLoader_<%=cid %>);
 <%}%>
 


### PR DESCRIPTION
ClassLoader on java 11 (and 8) (with no cast, nor protected method call)
https://jira.talendforge.org/browse/TDI-42900

**What is the current behavior?** (You can also link to an open issue here)
Not run on Java11

**What is the new behavior?**
Ok with java 8 and java 11.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


