### PR TITLE
TESB-26772 Adds a way to externalise osgi-exclude.properties file

### DIFF
--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/esb/JobJavaScriptOSGIForESBManager.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/esb/JobJavaScriptOSGIForESBManager.java
@@ -14,6 +14,7 @@ package org.talend.repository.ui.wizards.exportjob.scriptsmanager.esb;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -84,6 +85,7 @@ import org.talend.repository.documentation.ExportFileResource;
 import org.talend.repository.ui.wizards.exportjob.scriptsmanager.JarBuilder;
 import org.talend.repository.ui.wizards.exportjob.scriptsmanager.JobJavaScriptsManager;
 import org.talend.repository.utils.EmfModelUtils;
+import org.talend.repository.utils.EsbConfigUtils;
 import org.talend.repository.utils.TemplateProcessor;
 
 import aQute.bnd.header.Attrs;
@@ -104,15 +106,35 @@ public class JobJavaScriptOSGIForESBManager extends JobJavaScriptsManager {
 
     protected static final char MANIFEST_ITEM_SEPARATOR = ',';
 
+    protected static final String OSGI_EXCLUDE_PROP_FILENAME = "osgi-exclude.properties"; ////$NON-NLS-1$
+
     @SuppressWarnings("serial")
     private static final Collection<String> EXCLUDED_MODULES = new ArrayList<String>() {
         {
-            try (InputStream is = RepositoryPlugin.getDefault().getBundle()
-                    .getEntry("/resources/osgi-exclude.properties").openStream()) { //$NON-NLS-1$
-                final Properties p = new Properties();
-                p.load(is);
-                for (Enumeration<?> e = p.propertyNames(); e.hasMoreElements();) {
-                    add((String) e.nextElement());
+            File propFile = null;
+            File esbConfigurationLocation = EsbConfigUtils.getEclipseEsbFolder();
+            
+            if (esbConfigurationLocation != null && esbConfigurationLocation.exists()
+                    && esbConfigurationLocation.isDirectory()) {
+                propFile = new File(esbConfigurationLocation.getAbsolutePath(), OSGI_EXCLUDE_PROP_FILENAME);
+            }
+
+            InputStream is = null;
+            try {
+                if (propFile != null && propFile.exists() && propFile.isFile()) {
+                    is = new FileInputStream(propFile);
+                } else {
+                    is = RepositoryPlugin.getDefault().getBundle()
+                            .getEntry("/resources/" + OSGI_EXCLUDE_PROP_FILENAME)
+                            .openStream();
+                }
+    
+                if (is != null) {
+                    final Properties p = new Properties();
+                    p.load(is);
+                    for (Enumeration<?> e = p.propertyNames(); e.hasMoreElements();) {
+                        add((String) e.nextElement());
+                    }
                 }
             } catch (IOException e) {
                 RepositoryPlugin.getDefault().getLog()


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
osgi-exclude.properties resource fileis included in org.talend.repository bundle and by this cannot be updated. In some rare case, user need to add an exclusion entry.

**What is the new behavior?**
This dev adds the opportunity to externalise osgi-exclude.properties
resource file from org.talend.repository bundle better than using the
one included in org.talend.repository budle jar file.

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No


