### PR TITLE
fix(TDI-42092): An error occurs on tFileOutputExcel after Iterate whe…

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileOutputExcel/tFileOutputExcel_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileOutputExcel/tFileOutputExcel_begin.javajet
@@ -777,7 +777,11 @@ if(!hasDynamic && isIncludeHeader){
 		xlsxTool_<%=cid%>.setRecalculateFormula(<%=recalculateFormula%>);
 		xlsxTool_<%=cid%>.setXY(<%=firstCellYAbsolute%>,<%=firstCellXStr%>,<%=firstCellYStr%>,<%=keepCellFormating%>);
 		<%if(!useStream){%>
-		xlsxTool_<%=cid%>.prepareXlsxFile(fileName_<%=cid%>);
+		java.util.concurrent.ConcurrentHashMap<java.lang.Object, java.lang.Object> chm_<%=cid%> = (java.util.concurrent.ConcurrentHashMap<java.lang.Object, java.lang.Object>) globalMap.get("concurrentHashMap");
+		java.lang.Object lockObj_<%=cid%> = chm_<%=cid%>.computeIfAbsent("EXCEL_OUTPUT_LOCK_OBJ_<%=cid%>", k -> new Object());
+		synchronized (lockObj_<%=cid%>) {
+			xlsxTool_<%=cid%>.prepareXlsxFile(fileName_<%=cid%>);
+		}
 		<%}else{%>
 		xlsxTool_<%=cid%>.prepareStream();
 		<%}%>


### PR DESCRIPTION
back port 42092 to 7.1
…n /tmp/profiles folder does not exist (#3419)

* fix(TDI-42092): An error occurs on tFileOutputExcel after
* Iterate when /tmp/profiles folder does not exist.
* reproduce in multithread env - each thread try create
* folder. First thread create. Second crash because folder exist

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


