### PR TITLE
TESB-26789 Bean called in routelet not found by main route

### DIFF
--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/DefaultRunProcessService.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/DefaultRunProcessService.java
@@ -855,6 +855,9 @@ public class DefaultRunProcessService implements IRunProcessService {
         if (ProcessUtils.isRequiredBeans(null, refProject)) {
             installRefCodeProject(ERepositoryObjectType.valueOf("BEANS"), refHelper, monitor); //$NON-NLS-1$
         }
+        
+        deleteRefProjects(refProject, refHelper);
+
     }
 
     private void installRefCodeProject(ERepositoryObjectType codeType, AggregatorPomsHelper refHelper, IProgressMonitor monitor)
@@ -870,6 +873,35 @@ public class DefaultRunProcessService implements IRunProcessService {
             argumentsMap.put(TalendProcessArgumentConstant.ARG_GOAL, TalendMavenConstants.GOAL_INSTALL);
             argumentsMap.put(TalendProcessArgumentConstant.ARG_PROGRAM_ARGUMENTS, TalendMavenConstants.ARG_MAIN_SKIP);
             codeProject.buildModules(monitor, null, argumentsMap);
+        }
+    }
+    
+    private void deleteRefProjects(Project refProject, AggregatorPomsHelper refHelper) throws Exception {
+        IProgressMonitor monitor = new NullProgressMonitor();
+        
+        deleteRefProject(ERepositoryObjectType.ROUTINES, refHelper, monitor);
+        
+        if (ProcessUtils.isRequiredPigUDFs(null, refProject)) {
+        	deleteRefProject(ERepositoryObjectType.PIG_UDF, refHelper, monitor);
+        }
+
+        if (ProcessUtils.isRequiredBeans(null, refProject)) {
+        	deleteRefProject(ERepositoryObjectType.valueOf("BEANS"), refHelper, monitor); //$NON-NLS-1$
+        }
+
+    }
+    
+    private void deleteRefProject(ERepositoryObjectType codeType, AggregatorPomsHelper refHelper, IProgressMonitor monitor)
+            throws Exception, CoreException {
+    	
+        if (!refHelper.getProjectRootPom().exists()) {
+            return;
+        }
+        
+        String projectTechName = refHelper.getProjectTechName();
+        ITalendProcessJavaProject codeProject = TalendJavaProjectManager.getExistingTalendCodeProject(codeType, projectTechName);
+       	
+        if (codeProject != null) {
             codeProject.getProject().delete(false, true, monitor);
             TalendJavaProjectManager.removeFromCodeJavaProjects(codeType, projectTechName);
         }


### PR DESCRIPTION
Original issue: beans package from referenced project become empty (does not have any classes inside) during Studio startup with main project. 

Issue is not reproduced in case of I put one break point in debug mode for this line (and wait 1 sec) https://github.com/Talend/tdi-studio-se/blob/7d8653fbf967826c046b02c16f1f7c6f329df20e/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/DefaultRunProcessService.java#L843

Original code works in this way:

- build Routines from referenced project
- remove routines referenced project from workspace
- build PigUDFs from referenced project
- remove PigUDFs referenced project from workspace
- build Beans from referenced project
- remove Beans referenced project from workspace

I see that removing of Routines project from workspace affects on Building of Beans project.  

Fixed code works in this way:
- build Routines from referenced project
- build PigUDFs from referenced project
- build Beans from referenced project
- remove routines referenced project from workspace
- remove PigUDFs referenced project from workspace
- remove Beans referenced project from workspace

So, general code logic is not changed, but original issue is not reproduced anymore.