### PR TITLE
bugfix(TUP-24563):Specifying a custom MVN URI in a Bean still ends up

### DIFF
--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/local/ExportItemUtil.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/local/ExportItemUtil.java
@@ -320,7 +320,7 @@ public class ExportItemUtil {
                 tdmService = (ITransformService) GlobalServiceRegister.getDefault().getService(ITransformService.class);
             }
             itemProjectMap.clear();
-            Set<String> jarNameList = new HashSet<String>();
+            Map<String,String> jarNameAndUrl = new HashMap<String,String>();
             Iterator<Item> iterator = allItems.iterator();
             Set<String> projectHasTdm = new HashSet<String>();
             while (iterator.hasNext()) {
@@ -409,7 +409,7 @@ public class ExportItemUtil {
                     List list = ((RoutineItem) item).getImports();
                     for (int i = 0; i < list.size(); i++) {
                         String jarName = ((IMPORTTypeImpl) list.get(i)).getMODULE();
-                        jarNameList.add(jarName.toString());
+                        jarNameAndUrl.put(jarName, ((IMPORTTypeImpl) list.get(i)).getMVN());
                     }
 
                 }
@@ -452,9 +452,10 @@ public class ExportItemUtil {
             // add the routines of the jars at the end, to add them only once in the export.
             IPath libPath = getProjectOutputPath().append(JavaUtils.JAVA_LIB_DIRECTORY);
             String libAbsPath = new Path(destinationDirectory.toString()).append(libPath.toString()).toPortableString();
-            for (String jarName : jarNameList) {
+            for (String jarName : jarNameAndUrl.keySet()) {
                 if (repositoryBundleService.contains(jarName)) {
-                    repositoryBundleService.retrieve(jarName, libAbsPath, new NullProgressMonitor());
+                	String mavenUri =  jarNameAndUrl.get(jarName);
+                    repositoryBundleService.retrieve(jarName, mavenUri, libAbsPath, new NullProgressMonitor());
                     toExport.put(new File(libAbsPath, jarName), libPath.append(jarName));
                 }
             }


### PR DESCRIPTION
turning into a reference to the default 6.0.0-SNAPSHOT version

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [ *] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ *] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ *] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


