### PR TITLE
Sbovsunovskyi/tdi 43065 t dtd validator and utf8

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tDTDValidator/tDTDValidator_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tDTDValidator/tDTDValidator_main.javajet
@@ -91,7 +91,7 @@ String xmlfile = ElementParameterParser.getValue(node, "__XMLFILE__");
 		
 		int offsetRoot<%=cid %>=sb<%=cid %>.indexOf("<"+rootnode<%=cid %>);
 		sb<%=cid%>.replace(0, offsetRoot<%=cid %>, reference<%=cid %>);		
-		is<%=cid %> = new java.io.ByteArrayInputStream(sb<%=cid%>.toString().getBytes("UTF-8")));
+		is<%=cid %> = new java.io.ByteArrayInputStream(sb<%=cid%>.toString().getBytes("UTF-8"));
 
 		class MyHandler<%=cid %> extends org.xml.sax.helpers.DefaultHandler{
 		    String errorMessage = null;

--- a/main/plugins/org.talend.designer.components.localprovider/components/tDTDValidator/tDTDValidator_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tDTDValidator/tDTDValidator_main.javajet
@@ -45,8 +45,8 @@ String xmlfile = ElementParameterParser.getValue(node, "__XMLFILE__");
 		java.lang.StringBuilder sb<%=cid %>=new java.lang.StringBuilder("");
 		
 		try{
-    		br<%=cid %> = new java.io.BufferedReader(new java.io.InputStreamReader(url<%=cid %>.openStream()));
-    		
+    		br<%=cid %> = new java.io.BufferedReader(new UnicodeReader(url<%=cid %>.openStream(), "UTF-8"));
+
     		char[] buffer<%=cid %> = new char[1024];
     		int length<%=cid %> = -1;
     		while ((length<%=cid %> = br<%=cid %>.read(buffer<%=cid %>)) != -1)
@@ -66,7 +66,9 @@ String xmlfile = ElementParameterParser.getValue(node, "__XMLFILE__");
 		dbf<%=cid %> = javax.xml.parsers.DocumentBuilderFactory.newInstance();
 		dbf<%=cid %>.setValidating(false);
 		db<%=cid %> = dbf<%=cid %>.newDocumentBuilder(); 
-		org.w3c.dom.Document doc<%=cid %> = db<%=cid %>.parse(new java.io.StringBufferInputStream(sb<%=cid%>.toString()));
+		org.w3c.dom.Document doc<%=cid %> = db<%=cid %>.parse(
+			new java.io.ByteArrayInputStream(sb<%=cid%>.toString().getBytes("UTF-8")));
+
 		String rootnode<%=cid %>=doc<%=cid %>.getDocumentElement().getNodeName();
 		
 		String encoding=null;
@@ -89,8 +91,8 @@ String xmlfile = ElementParameterParser.getValue(node, "__XMLFILE__");
 		
 		int offsetRoot<%=cid %>=sb<%=cid %>.indexOf("<"+rootnode<%=cid %>);
 		sb<%=cid%>.replace(0, offsetRoot<%=cid %>, reference<%=cid %>);		
-		is<%=cid %>=new java.io.StringBufferInputStream(sb<%=cid %>.toString());
-		
+		is<%=cid %> = new java.io.ByteArrayInputStream(sb<%=cid%>.toString().getBytes("UTF-8")));
+
 		class MyHandler<%=cid %> extends org.xml.sax.helpers.DefaultHandler{
 		    String errorMessage = null;
 		    public void error(org.xml.sax.SAXParseException e) throws org.xml.sax.SAXException {

--- a/main/plugins/org.talend.designer.components.localprovider/components/tDTDValidator/tDTDValidator_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tDTDValidator/tDTDValidator_main.javajet
@@ -45,7 +45,7 @@ String xmlfile = ElementParameterParser.getValue(node, "__XMLFILE__");
 		java.lang.StringBuilder sb<%=cid %>=new java.lang.StringBuilder("");
 		
 		try{
-    		br<%=cid %> = new java.io.BufferedReader(new UnicodeReader(url<%=cid %>.openStream(), "UTF-8"));
+    		br<%=cid %> = new java.io.BufferedReader(new UnicodeReader(url<%=cid %>.openStream(), null));
 
     		char[] buffer<%=cid %> = new char[1024];
     		int length<%=cid %> = -1;


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
tDTDValidate component does not work with Unicode files

**What is the new behavior?**
tDTDValidate component works with Unicode files

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
https://jira.talendforge.org/browse/TDI-43065

