### PR TITLE
TESB-27110 Missing tSendMail dependencies are added

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tSendMail/tSendMail_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSendMail/tSendMail_main.javajet
@@ -208,6 +208,8 @@ boolean isLog4jEnabled = ("true").equals(ElementParameterParser.getValue(node.ge
 		mc_<%=cid%>.addMailcap("multipart/*;; x-java-content-handler=com.sun.mail.handlers.multipart_mixed");
 		mc_<%=cid%>.addMailcap("message/rfc822;; x-java-content-handler=com.sun.mail.handlers.message_rfc822");
 		javax.activation.CommandMap.setDefaultCommandMap(mc_<%=cid%>);
+		// add com.sun.mail.handlers to job imports / depenencies (TESB-27110)
+		com.sun.mail.handlers.text_plain text_plain_h_<%=cid%> = null;
 		// -- Send the message --
 		javax.mail.Transport.send(msg_<%=cid %>);
 	} catch(java.lang.Exception e){


### PR DESCRIPTION
At this moment content handlers (com.sun.mail.handlers.*) can not be found by classloader because of they are not present in import section of generated bundles manifest. It leads to ClassNotFoundError in Runtime.

Current fix resolves this issue (codegenerator will find and add "import com.sun.mail.handlers.*; " to generated code and corresponding dependency to import section of bundles MANIFEST).

