### PR TITLE
fix(TDI-43212): improve code generation for query string

### DIFF
--- a/main/plugins/org.talend.designer.core.generic/src/main/java/org/talend/designer/core/generic/model/Component.java
+++ b/main/plugins/org.talend.designer.core.generic/src/main/java/org/talend/designer/core/generic/model/Component.java
@@ -1479,7 +1479,12 @@ public class Component extends AbstractBasicComponent {
             //as sql type value may have newline and return characters, which make compiler issue in java code,
             //so have to convert the newline characters to visible "\r", "\n" for pass the compiler issue and can't only convert them to white space as TDI-41898
             //jdbc drivers, salesforce driver can work like that sql : select * \nfrom Account, so it is ok
-            return NodeUtil.replaceCRLFInMEMO_SQL(value);
+            String replacedString = NodeUtil.replaceCRLFInMEMO_SQL(value).trim();
+
+            // For the case when sql field ends with extra semicolon, it has to be removed to avoid compilation error.
+            return replacedString.endsWith(";")
+                    ? replacedString.substring(0, replacedString.length() -1)
+                    : replacedString;
         }
         if (GenericTypeUtils.isSchemaType(property)) {
             // Handles embedded escaped quotes which might occur


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-43212
When the query String contains ending semicolon in newer version of tJDBC component compile error appears. (Starting from Studio 7.0)

**What is the new behavior?**
Remove the last semicolon that is present in query string.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


