### PR TITLE
fix(TUP-25319): When we deactivate the log4j option, DI need use default jars log4j2 needed

### DIFF
--- a/main/plugins/org.talend.designer.codegen/jet_stub/footer.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/footer.javajet
@@ -518,17 +518,13 @@
 			p_<%=jobCatcherNode.getUniqueName()%>.setProperty("appender.file.maxsize", "52428800");
 			p_<%=jobCatcherNode.getUniqueName()%>.setProperty("appender.file.maxbackup", "20");
 			p_<%=jobCatcherNode.getUniqueName()%>.setProperty("host", "false");
-				<%if(isLog4jEnabled) {%>
-					<%if(isLog4j1Enabled) {%>
-					org.apache.log4j.Logger.getLogger("runtime").setLevel(org.apache.log4j.Level.DEBUG);
-					<%}%>
-					
-					<%if(isLog4j2Enabled) {%>
-					org.apache.logging.log4j.core.config.Configurator.setLevel("runtime", org.apache.logging.log4j.Level.DEBUG);
-					<%}%>
-				<%} else {%>
-					org.apache.log4j.Logger.getLogger("runtime").setLevel(org.apache.log4j.Level.DEBUG);
-				<%}%>
+			<%if(isLog4j1Enabled) {%>
+			org.apache.log4j.Logger.getLogger("runtime").setLevel(org.apache.log4j.Level.DEBUG);
+			<%}%>
+			
+			<%if(isLog4j2Enabled) {%>
+			org.apache.logging.log4j.core.config.Configurator.setLevel("runtime", org.apache.logging.log4j.Level.DEBUG);
+			<%}%>
 			runtime_lineage_logger_<%=jobCatcherNode.getUniqueName()%> = org.talend.job.audit.JobEventAuditLoggerFactory.createJobAuditLogger(p_<%=jobCatcherNode.getUniqueName()%>);
 			<%
 			}
@@ -553,16 +549,12 @@
 					.filter(it -> it.startsWith("monitoring.audit.logger.properties."))
 					.forEach(key -> properties_<%=jobCatcherNode.getUniqueName()%>.setProperty(key.substring("monitoring.audit.logger.properties.".length()), System.getProperty(key)));
 
-				<%if(isLog4jEnabled) {%>
-					<%if(isLog4j1Enabled) {%>
-					org.apache.log4j.Logger.getLogger("audit").setLevel(org.apache.log4j.Level.DEBUG);
-					<%}%>
-					
-					<%if(isLog4j2Enabled) {%>
-					org.apache.logging.log4j.core.config.Configurator.setLevel("audit", org.apache.logging.log4j.Level.DEBUG);
-					<%}%>
-				<%} else {%>
-					org.apache.log4j.Logger.getLogger("audit").setLevel(org.apache.log4j.Level.DEBUG);
+				<%if(isLog4j1Enabled) {%>
+				org.apache.log4j.Logger.getLogger("audit").setLevel(org.apache.log4j.Level.DEBUG);
+				<%}%>
+				
+				<%if(isLog4j2Enabled) {%>
+				org.apache.logging.log4j.core.config.Configurator.setLevel("audit", org.apache.logging.log4j.Level.DEBUG);
 				<%}%>
 				auditLogger_<%=jobCatcherNode.getUniqueName()%> = org.talend.job.audit.JobEventAuditLoggerFactory.createJobAuditLogger(properties_<%=jobCatcherNode.getUniqueName()%>);
 			}


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TUP-25319

**What is the new behavior?**
https://jira.talendforge.org/browse/TUP-25319

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No