### PR TITLE
TUP-25343 [BUG] database can't dataview after set routine.encryption.key.v2

### DIFF
--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/runprocess/Processor.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/runprocess/Processor.java
@@ -389,16 +389,26 @@ public abstract class Processor implements IProcessor, IEclipseProcessor, Talend
     protected String[] addEncryptionFilePathParameter(String[] cmds) {
         String encryptionFilePath = System.getProperty(StudioKeysFileCheck.ENCRYPTION_KEY_FILE_SYS_PROP);
         File encryptionFile = new File(encryptionFilePath);
-        List<String> cmdList = new ArrayList<String>();
-        int cpIndex = ArrayUtils.indexOf(cmds, JavaUtils.JAVA_CP);
-        for (int i = 0; i < cpIndex; i++) {
-            cmdList.add(cmds[i]);
+        boolean isContained = false;
+        for (String cmd : cmds) {
+            if (cmd != null && cmd.trim().startsWith(StudioKeysFileCheck.ENCRYPTION_KEY_FILE_JVM_PARAM)) {
+                isContained = true;
+                break;
+            }
         }
-        cmdList.add(StudioKeysFileCheck.ENCRYPTION_KEY_FILE_JVM_PARAM + "=" + encryptionFile.toURI().getPath());
-        for (int i = cpIndex; i < cmds.length; i++) {
-            cmdList.add(cmds[i]);
+        if (!isContained) {
+            List<String> cmdList = new ArrayList<String>();
+            int cpIndex = ArrayUtils.indexOf(cmds, JavaUtils.JAVA_CP);
+            for (int i = 0; i < cpIndex; i++) {
+                cmdList.add(cmds[i]);
+            }
+            cmdList.add(StudioKeysFileCheck.ENCRYPTION_KEY_FILE_JVM_PARAM + "=" + encryptionFile.toURI().getPath());
+            for (int i = cpIndex; i < cmds.length; i++) {
+                cmdList.add(cmds[i]);
+            }
+            return cmdList.toArray(new String[0]);
         }
-        return cmdList.toArray(new String[0]);
+        return cmds;
     }
 
     /**

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/runprocess/Processor.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/runprocess/Processor.java
@@ -17,6 +17,8 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang.ArrayUtils;
@@ -34,6 +36,7 @@ import org.eclipse.debug.core.ILaunchConfiguration;
 import org.talend.commons.exception.ExceptionHandler;
 import org.talend.commons.exception.SystemException;
 import org.talend.commons.ui.runtime.exception.MessageBoxExceptionHandler;
+import org.talend.commons.utils.generation.JavaUtils;
 import org.talend.core.model.process.IContext;
 import org.talend.core.model.process.IProcess;
 import org.talend.core.model.process.IProcess2;
@@ -50,6 +53,7 @@ import org.talend.designer.runprocess.IProcessor;
 import org.talend.designer.runprocess.ProcessorException;
 import org.talend.designer.runprocess.ProcessorUtilities;
 import org.talend.repository.ui.wizards.exportjob.scriptsmanager.JobScriptsManager;
+import org.talend.utils.StudioKeysFileCheck;
 
 /**
  * DOC nrousseau class global comment. Detailled comment <br/>
@@ -361,6 +365,7 @@ public abstract class Processor implements IProcessor, IEclipseProcessor, Talend
             throws ProcessorException {
 
         String[] cmd = getCommandLine(true, false, statOption, traceOption, codeOptions);
+        cmd = addEncryptionFilePathParameter(cmd);
         logCommandLine(cmd, level);
         return exec(cmd, path);
     }
@@ -379,6 +384,21 @@ public abstract class Processor implements IProcessor, IEclipseProcessor, Talend
         } catch (IOException ioe) {
             throw new ProcessorException(Messages.getString("Processor.execFailed"), ioe); //$NON-NLS-1$
         }
+    }
+
+    protected String[] addEncryptionFilePathParameter(String[] cmds) {
+        String encryptionFilePath = System.getProperty(StudioKeysFileCheck.ENCRYPTION_KEY_FILE_SYS_PROP);
+        File encryptionFile = new File(encryptionFilePath);
+        List<String> cmdList = new ArrayList<String>();
+        int cpIndex = ArrayUtils.indexOf(cmds, JavaUtils.JAVA_CP);
+        for (int i = 0; i < cpIndex; i++) {
+            cmdList.add(cmds[i]);
+        }
+        cmdList.add(StudioKeysFileCheck.ENCRYPTION_KEY_FILE_JVM_PARAM + "=" + encryptionFile.toURI().getPath());
+        for (int i = cpIndex; i < cmds.length; i++) {
+            cmdList.add(cmds[i]);
+        }
+        return cmdList.toArray(new String[0]);
     }
 
     /**

--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/java/AbstractJavaProcessor.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/java/AbstractJavaProcessor.java
@@ -249,6 +249,8 @@ public abstract class AbstractJavaProcessor extends Processor implements IJavaPr
 
         checkExecutingCommands(path, cmds);
 
+        cmds = addEncryptionFilePathParameter(cmds);
+
         logCommandLine(cmds, level);
 
         return exec(cmds, path);

--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/java/JavaProcessor.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/java/JavaProcessor.java
@@ -161,6 +161,7 @@ import org.talend.repository.constants.BuildJobConstants;
 import org.talend.repository.ui.utils.UpdateLog4jJarUtils;
 import org.talend.repository.utils.EmfModelUtils;
 import org.talend.repository.utils.EsbConfigUtils;
+import org.talend.utils.StudioKeysFileCheck;
 import org.talend.utils.io.FilesUtils;
 
 /**
@@ -1808,6 +1809,17 @@ public class JavaProcessor extends AbstractJavaProcessor implements IJavaBreakpo
             wc.setAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, this.getMainClass());
             wc.setAttribute(IJavaLaunchConfigurationConstants.ATTR_STOP_IN_MAIN, true);
             wc.setAttribute(IJavaLaunchConfigurationConstants.ATTR_PROGRAM_ARGUMENTS, CTX_ARG + context.getName() + parameterStr);
+            StringBuilder vmArguments = new StringBuilder();
+            vmArguments.append(wc.getAttribute(IJavaLaunchConfigurationConstants.ATTR_VM_ARGUMENTS, ""));
+            if (vmArguments.length() > 0) {
+                vmArguments.append(" ");
+            }
+            String encryptionFilePath = System.getProperty(StudioKeysFileCheck.ENCRYPTION_KEY_FILE_SYS_PROP);
+            File encryptionFile = new File(encryptionFilePath);
+            if (encryptionFile.exists()) {
+                vmArguments.append(StudioKeysFileCheck.ENCRYPTION_KEY_FILE_JVM_PARAM + "=" + encryptionFile.toURI().getPath());
+            }
+            wc.setAttribute(IJavaLaunchConfigurationConstants.ATTR_VM_ARGUMENTS, vmArguments.toString());
             config = wc.doSave();
         }
         return config;

--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/java/JavaProcessor.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/java/JavaProcessor.java
@@ -1783,6 +1783,7 @@ public class JavaProcessor extends AbstractJavaProcessor implements IJavaBreakpo
             wc.setAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, this.getMainClass());
             wc.setAttribute(IJavaLaunchConfigurationConstants.ATTR_STOP_IN_MAIN, true);
             wc.setAttribute(IJavaLaunchConfigurationConstants.ATTR_PROGRAM_ARGUMENTS, CTX_ARG + context.getName());
+            setupEncryptionFilePathParameter(wc);
             config = wc.doSave();
         }
         return config;
@@ -1809,8 +1810,16 @@ public class JavaProcessor extends AbstractJavaProcessor implements IJavaBreakpo
             wc.setAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, this.getMainClass());
             wc.setAttribute(IJavaLaunchConfigurationConstants.ATTR_STOP_IN_MAIN, true);
             wc.setAttribute(IJavaLaunchConfigurationConstants.ATTR_PROGRAM_ARGUMENTS, CTX_ARG + context.getName() + parameterStr);
-            StringBuilder vmArguments = new StringBuilder();
-            vmArguments.append(wc.getAttribute(IJavaLaunchConfigurationConstants.ATTR_VM_ARGUMENTS, ""));
+            setupEncryptionFilePathParameter(wc);
+            config = wc.doSave();
+        }
+        return config;
+    }
+
+    private void setupEncryptionFilePathParameter(ILaunchConfigurationWorkingCopy wc) throws CoreException {
+        StringBuilder vmArguments = new StringBuilder();
+        vmArguments.append(wc.getAttribute(IJavaLaunchConfigurationConstants.ATTR_VM_ARGUMENTS, ""));
+        if (vmArguments.indexOf(StudioKeysFileCheck.ENCRYPTION_KEY_FILE_JVM_PARAM) < 0) {
             if (vmArguments.length() > 0) {
                 vmArguments.append(" ");
             }
@@ -1820,9 +1829,7 @@ public class JavaProcessor extends AbstractJavaProcessor implements IJavaBreakpo
                 vmArguments.append(StudioKeysFileCheck.ENCRYPTION_KEY_FILE_JVM_PARAM + "=" + encryptionFile.toURI().getPath());
             }
             wc.setAttribute(IJavaLaunchConfigurationConstants.ATTR_VM_ARGUMENTS, vmArguments.toString());
-            config = wc.doSave();
         }
-        return config;
     }
 
     /*


### PR DESCRIPTION
TUP-25343 [BUG] database can't dataview after set routine.encryption.key.v2
https://jira.talendforge.org/browse/TUP-25343

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


