### PR TITLE
fix(TUP-24148): tNetsuiteInput throws cast error when switching from use tNetsuiteConnection to use this component

### DIFF
--- a/main/plugins/org.talend.designer.core.generic/src/main/java/org/talend/designer/core/generic/controller/ComponentRefController.java
+++ b/main/plugins/org.talend.designer.core.generic/src/main/java/org/talend/designer/core/generic/controller/ComponentRefController.java
@@ -100,15 +100,20 @@ public class ComponentRefController extends AbstractElementPropertySectionContro
                                 for (int j = 0; j < param.getListItemsValue().length; j++) {
                                     if (((CCombo) ctrl).getText().equals(param.getListItemsDisplayName()[j])) {
                                         value = (String) param.getListItemsValue()[j];
-                                        if (j == 0 && (boolean) ((ElementParameter) propertyParameter)
-                                                .getTaggedValue(IGenericConstants.IS_PROPERTY_SHOW)) {
+                                        if (j == 0) {
                                             // The first item in the combo is
                                             // this component
                                             props.referenceType
                                                     .setValue(ComponentReferenceProperties.ReferenceType.THIS_COMPONENT);
                                             props.componentInstanceId.setValue(null);
                                             props.setReference(null);
-                                            propertyParameter.setShow(true);
+                                            boolean isPropertyShow = true;
+                                            Object isPropertyShowObj = ((ElementParameter) propertyParameter)
+                                                    .getTaggedValue(IGenericConstants.IS_PROPERTY_SHOW);
+                                            if (isPropertyShowObj != null) {
+                                                isPropertyShow = Boolean.valueOf(isPropertyShowObj.toString());
+                                            }
+                                            propertyParameter.setShow(isPropertyShow);
                                         } else {
                                             props.referenceType
                                                     .setValue(ComponentReferenceProperties.ReferenceType.COMPONENT_INSTANCE);


### PR DESCRIPTION
fix(TUP-24148): tNetsuiteInput throws cast error when switching from use tNetsuiteConnection to use this component
https://jira.talendforge.org/browse/TUP-24148

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


