### PR TITLE
fix(TDQ-17709): create number limit text controller

### DIFF
--- a/main/plugins/org.talend.designer.core/plugin.xml
+++ b/main/plugins/org.talend.designer.core/plugin.xml
@@ -390,6 +390,10 @@
             mapping="TEXT"
             name="Text"/>
       <generator
+            class="org.talend.designer.core.ui.editor.properties.controllers.generator.NumberLimitTextGenerator"
+            mapping="NUMBERLIMITTEXT"
+            name="NumberLimitText"/>
+      <generator
             class="org.talend.designer.core.ui.editor.properties.controllers.generator.ComboGenerator"
             mapping="CLOSED_LIST"
             name="Combo"/>

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/model/components/EmfComponent.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/model/components/EmfComponent.java
@@ -2578,6 +2578,14 @@ public class EmfComponent extends AbstractBasicComponent {
                 case PATTERN_PROPERTY:
                     newParam.setFieldType(EParameterFieldType.PATTERN_PROPERTY);
                     break;
+                case NUMBERLIMITTEXT:
+                    newParam.setFieldType(EParameterFieldType.NUMBERLIMITTEXT);
+                    if (item.getVALUE() == null || item.getVALUE().equals("")) { //$NON-NLS-1$
+                        newParam.setValue(""); //$NON-NLS-1$
+                    } else {
+                        newParam.setValue(item.getVALUE());
+                    }
+                    break;
                 default: // TEXT by default
                     newParam.setFieldType(EParameterFieldType.TEXT);
                     if (item.getVALUE() == null || item.getVALUE().equals("")) { //$NON-NLS-1$

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/properties/controllers/NumberLimitTextController.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/properties/controllers/NumberLimitTextController.java
@@ -54,10 +54,13 @@ public class NumberLimitTextController extends TextController {
                         return;
                     }
                     Pattern pattern = Pattern.compile("^\\.|\\d$"); //$NON-NLS-1$
-                    Pattern finalPattern = Pattern.compile("^1(\\.0)?|0(\\.\\d{1,5})?$"); //$NON-NLS-1$
+                    Pattern finalPattern = Pattern.compile("^1(\\.0{1,5})?|0(\\.\\d{1,5})?$"); //$NON-NLS-1$
                     Pattern exceptionPattern = Pattern.compile("^1\\d+|0\\d+$"); //$NON-NLS-1$
                     //when input character one by one then make sure they are valid
                     if (inputValue.length()<=1&&!pattern.matcher(inputValue).matches()) {
+                        e.doit = false;
+                        return;
+                    }else if(".".equals(inputValue)&&labelText.getText().length()>1) {
                         e.doit = false;
                         return;
                     }else {
@@ -88,6 +91,7 @@ public class NumberLimitTextController extends TextController {
                     if(inputValue.length()>1) {
                         e.doit = false;
                         return;
+                        
                     }
                 }
             }

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/properties/controllers/NumberLimitTextController.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/properties/controllers/NumberLimitTextController.java
@@ -1,0 +1,107 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.designer.core.ui.editor.properties.controllers;
+
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.swt.events.VerifyEvent;
+import org.eclipse.swt.events.VerifyListener;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Text;
+import org.talend.core.model.process.IElementParameter;
+import org.talend.core.ui.properties.tab.IDynamicProperty;
+/**
+ * The value of text field need to be is [0,1]
+ * And the length of decimal is less than 6
+ * 
+ */
+public class NumberLimitTextController extends TextController {
+
+    public NumberLimitTextController(IDynamicProperty dp) {
+        super(dp);
+    }
+
+    @Override
+    public Control createControl(Composite subComposite, IElementParameter param, int numInRow, int nbInRow, int top,
+            Control lastControl) {
+        Control currentControl=super.createControl(subComposite, param, numInRow, nbInRow, top, lastControl);
+        String paramName = param.getName();
+        final Text labelText = (Text) hashCurControls.get(paramName);
+        labelText.addVerifyListener(new VerifyListener() {
+
+
+            @Override
+            public void verifyText(VerifyEvent e) {
+                String inputValue = e.text;
+                String finalValue=labelText.getText()+e.text;
+                if(inputValue.length()>1) {
+                    finalValue=inputValue;
+                    //original value need to be show here no need to be check
+                }else {
+                    //support Backspace button 
+                    if(inputValue.isEmpty()) {
+                        return;
+                    }
+                    Pattern pattern = Pattern.compile("^\\.|\\d$"); //$NON-NLS-1$
+                    Pattern finalPattern = Pattern.compile("^1(\\.0)?|0(\\.\\d{1,5})?$"); //$NON-NLS-1$
+                    Pattern exceptionPattern = Pattern.compile("^1\\d+|0\\d+$"); //$NON-NLS-1$
+                    //when input character one by one then make sure they are valid
+                    if (inputValue.length()<=1&&!pattern.matcher(inputValue).matches()) {
+                        e.doit = false;
+                        return;
+                    }else {
+                        //when the text of original value is empty then we need to make sure the finalValue is valid
+                        if(StringUtils.isBlank(labelText.getText())&&!finalPattern.matcher(finalValue).matches()) {
+                            e.doit = false;
+                            return;
+                        }
+                        //when the text of original value is not empty we need to make sure both original value and final value are valid
+                        if(!StringUtils.isBlank(labelText.getText())&&!finalPattern.matcher(labelText.getText()).matches()&&!finalPattern.matcher(labelText.getText()+inputValue).matches()) {
+                            e.doit = false;
+                            return;
+                        }
+                        //make sure the final value is not special value
+                        if(exceptionPattern.matcher(labelText.getText()+inputValue).matches()) {
+                            e.doit = false;
+                            return;
+                        }
+                    }
+                }
+                try {
+                    double num=Double.valueOf(finalValue);
+                    if(num>1) {
+                        e.doit = false;
+                        return;
+                    }
+                } catch (Exception e1) {
+                    if(inputValue.length()>1) {
+                        e.doit = false;
+                        return;
+                    }
+                }
+            }
+        });
+        return currentControl;
+    }
+
+  
+    
+    
+    
+    
+    
+    
+    
+
+}

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/properties/controllers/generator/NumberLimitTextGenerator.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/properties/controllers/generator/NumberLimitTextGenerator.java
@@ -1,0 +1,26 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.designer.core.ui.editor.properties.controllers.generator;
+
+import org.talend.designer.core.ui.editor.properties.controllers.AbstractElementPropertySectionController;
+import org.talend.designer.core.ui.editor.properties.controllers.NumberLimitTextController;
+
+public class NumberLimitTextGenerator extends TextGenerator {
+
+    @Override
+    public AbstractElementPropertySectionController generate() {
+        return new NumberLimitTextController(dp);
+    }
+
+    
+}

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/properties/controllers/generator/TextGenerator.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/properties/controllers/generator/TextGenerator.java
@@ -24,7 +24,7 @@ import org.talend.designer.core.ui.editor.properties.controllers.TextController;
  */
 public class TextGenerator implements IControllerGenerator {
 
-    private IDynamicProperty dp;
+    protected IDynamicProperty dp;
 
     /*
      * (non-Javadoc)

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/properties/macrowidgets/tableeditor/PropertiesTableEditorView.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/properties/macrowidgets/tableeditor/PropertiesTableEditorView.java
@@ -79,6 +79,7 @@ import org.talend.designer.core.model.components.ElementParameter;
 import org.talend.designer.core.ui.celleditor.PatternCellEditor;
 import org.talend.designer.core.ui.celleditor.PatternPropertyCellEditor;
 import org.talend.designer.core.ui.editor.nodes.Node;
+import org.talend.designer.core.ui.editor.properties.controllers.NumberLimitTextController;
 import org.talend.designer.core.ui.event.CheckColumnSelectionListener;
 
 /**
@@ -869,28 +870,67 @@ public class PropertiesTableEditorView<B> extends AbstractDataTableEditorView<B>
                             }
                             break;
                         case NUMBERLIMITTEXT:
+                            
                             if(value==null||StringUtils.isBlank(value.toString()) ) {
                                 finalValue ="0";
-                            }else {
-                                try {
-                                    String strValue=value.toString();
-                                    double num=Double.valueOf(strValue);
-                                    if(num>=1) {
-                                        finalValue ="1";
-                                    }else if(strValue.trim().indexOf(".") == -1){
-                                        finalValue ="1";
-                                    }else {
-                                        int decimalLen = strValue.trim().length() - strValue.trim().indexOf(".")-1;
-                                        if(decimalLen<7){
-                                            finalValue =value;
-                                        }else{
-                                            finalValue =strValue.trim().substring(0, 8);
-                                        }
-                                    }
-                                } catch (Exception e) {
-                                    finalValue ="0";
-                                }
+                                break;
                             }
+                            String finalStrValue=value.toString();
+                            if(finalStrValue.startsWith(NumberLimitTextController.CONTEXPREFIX)||NumberLimitTextController.CONTEXPREFIX.startsWith(finalStrValue)) {
+                              //context mode no any limit
+                              finalValue =value;
+                              break;
+                            }else if(finalStrValue.length()>=9){
+                                //keep 6 digit after the Decimal point
+                                finalStrValue =finalStrValue.trim().substring(0, 8);
+                            }else if(finalStrValue.contains("-")) {
+                                //'-' is invalid input 
+                                finalStrValue =finalStrValue.trim().replaceAll("-", "");
+                            }
+
+                            try {
+                                double num=Double.valueOf(finalStrValue);
+                                if(num>1||num<0) {
+                                    finalValue="1";
+                                    break;
+                                }else if(num<0) {
+                                    finalValue="0";
+                                    break;
+                                }
+                                finalValue=finalStrValue;
+                            } catch (Exception e1) {
+                                // any exception then reset result be 0
+                                finalValue="0";
+                            }
+                            
+                            
+                            
+//                            if(value==null||StringUtils.isBlank(value.toString()) ) {
+//                                finalValue ="0";
+//                            }else {
+//                                try {
+//                                    String strValue=value.toString();
+//                                    if(NumberLimitTextController.contexPrefix.startsWith(strValue)||strValue.startsWith(NumberLimitTextController.contexPrefix)) {
+//                                        finalValue =value;
+//                                    }else {
+//                                        double num=Double.valueOf(strValue);
+//                                        if(num>=1) {
+//                                            finalValue ="1";
+//                                        }else if(strValue.trim().indexOf(".") == -1){
+//                                            finalValue ="1";
+//                                        }else {
+//                                            int decimalLen = strValue.trim().length() - strValue.trim().indexOf(".")-1;
+//                                            if(decimalLen<7){
+//                                                finalValue =value;
+//                                            }else{
+//                                                finalValue =strValue.trim().substring(0, 8);
+//                                            }
+//                                        }
+//                                    }
+//                                } catch (Exception e) {
+//                                    finalValue ="0";
+//                                }
+//                            }
                         default:
                         }
                         ((Map<String, Object>) bean).put(items[curCol], finalValue);

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/properties/macrowidgets/tableeditor/PropertiesTableEditorView.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/properties/macrowidgets/tableeditor/PropertiesTableEditorView.java
@@ -903,34 +903,6 @@ public class PropertiesTableEditorView<B> extends AbstractDataTableEditorView<B>
                                 finalValue="0";
                             }
                             
-                            
-                            
-//                            if(value==null||StringUtils.isBlank(value.toString()) ) {
-//                                finalValue ="0";
-//                            }else {
-//                                try {
-//                                    String strValue=value.toString();
-//                                    if(NumberLimitTextController.contexPrefix.startsWith(strValue)||strValue.startsWith(NumberLimitTextController.contexPrefix)) {
-//                                        finalValue =value;
-//                                    }else {
-//                                        double num=Double.valueOf(strValue);
-//                                        if(num>=1) {
-//                                            finalValue ="1";
-//                                        }else if(strValue.trim().indexOf(".") == -1){
-//                                            finalValue ="1";
-//                                        }else {
-//                                            int decimalLen = strValue.trim().length() - strValue.trim().indexOf(".")-1;
-//                                            if(decimalLen<7){
-//                                                finalValue =value;
-//                                            }else{
-//                                                finalValue =strValue.trim().substring(0, 8);
-//                                            }
-//                                        }
-//                                    }
-//                                } catch (Exception e) {
-//                                    finalValue ="0";
-//                                }
-//                            }
                         default:
                         }
                         ((Map<String, Object>) bean).put(items[curCol], finalValue);

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/properties/macrowidgets/tableeditor/PropertiesTableEditorView.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/properties/macrowidgets/tableeditor/PropertiesTableEditorView.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jface.viewers.CellEditor;
 import org.eclipse.jface.viewers.ColorCellEditor;
 import org.eclipse.jface.viewers.ComboBoxCellEditor;
@@ -865,6 +866,30 @@ public class PropertiesTableEditorView<B> extends AbstractDataTableEditorView<B>
                             if (value instanceof RGB) {
                                 RGB rgb = (RGB) value;
                                 finalValue = rgb.red + ";" + rgb.green + ";" + rgb.blue; //$NON-NLS-1$ //$NON-NLS-2$
+                            }
+                            break;
+                        case NUMBERLIMITTEXT:
+                            if(value==null||StringUtils.isBlank(value.toString()) ) {
+                                finalValue ="0";
+                            }else {
+                                try {
+                                    String strValue=value.toString();
+                                    double num=Double.valueOf(strValue);
+                                    if(num>=1) {
+                                        finalValue ="1";
+                                    }else if(strValue.trim().indexOf(".") == -1){
+                                        finalValue ="1";
+                                    }else {
+                                        int decimalLen = strValue.trim().length() - strValue.trim().indexOf(".")-1;
+                                        if(decimalLen<7){
+                                            finalValue =value;
+                                        }else{
+                                            finalValue =strValue.trim().substring(0, 8);
+                                        }
+                                    }
+                                } catch (Exception e) {
+                                    finalValue ="0";
+                                }
                             }
                         default:
                         }


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
Text filed on component view can input every thing. But for our threshold of tMatchGroup component. If the threshold is bigger than six decimal places then it will get exception result.
https://jira.talendforge.org/browse/TDQ-17709

**What is the new behavior?**
Create a new text controller NumberLimitTextController and make sure it is working for table.
And the new text field can input number and dot only. 
we add a limit to keep six decimal places on here

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


