### PR TITLE
TESB-27989 Fix publish DS to cloud as MS

### DIFF
--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/BuildJobFactory.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/BuildJobFactory.java
@@ -96,7 +96,10 @@ public class BuildJobFactory {
                 ERepositoryObjectType repositoryObjectType = ERepositoryObjectType.getItemType(processItem);
                 if (repositoryObjectType == ERepositoryObjectType.PROCESS_ROUTE && "ROUTE_MICROSERVICE".equals(type)) {
                     esb = true;
+                } else if ("REST_MS".equals(type)) {
+                    esb = true;
                 }
+
             }
 
             if (type != null) {


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
Dataservices are always published as OSGI bundles without taking care of the Job defined build type. 

**What is the new behavior?**
With this fix, DS with build type "Microservice" will be built and published with the appropriate format.

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

