### PR TITLE
fix(TDI-43610) : jsonutil keep decimal if any

### DIFF
--- a/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/pom.xml
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/pom.xml
@@ -7,7 +7,7 @@
    <groupId>net.sf.json-lib</groupId>
    <artifactId>json-lib</artifactId>
    <packaging>jar</packaging>
-   <version>2.4.4-talend</version>
+   <version>2.4.5-talend</version>
    <name>json-lib</name>
 
 	<properties>

--- a/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/main/java/net/sf/json/util/JSONUtils.java
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/main/java/net/sf/json/util/JSONUtils.java
@@ -105,7 +105,7 @@ public final class JSONUtils {
          return "null";
       }
 
-      // Shave off trailing zeros and decimal point, if possible.
+      // Shave off trailing zeros. Keep decimal to keep type double
 
       String s = Double.toString( d );
       if( s.indexOf( '.' ) > 0 && s.indexOf( 'e' ) < 0 && s.indexOf( 'E' ) < 0 ){
@@ -442,17 +442,19 @@ public final class JSONUtils {
       }
       testValidity( n );
 
-      // Shave off trailing zeros and decimal point, if possible.
+      // Shave off trailing zeros. Keep decimal to keep type double
 
       String s = n.toString();
       if( s.indexOf( '.' ) > 0 && s.indexOf( 'e' ) < 0 && s.indexOf( 'E' ) < 0 ){
-         while( s.endsWith( "0" ) ){
-            s = s.substring( 0, s.length() - 1 );
-         }
-         if( s.endsWith( "." ) ){
+         while(s.charAt(s.length() - 1) == '0'){
+            if(s.endsWith(".0")){
+               break;
+            }
+
             s = s.substring( 0, s.length() - 1 );
          }
       }
+
       return s;
    }
 

--- a/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/main/java/net/sf/json/util/JSONUtils.java
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/main/java/net/sf/json/util/JSONUtils.java
@@ -109,12 +109,13 @@ public final class JSONUtils {
 
       String s = Double.toString( d );
       if( s.indexOf( '.' ) > 0 && s.indexOf( 'e' ) < 0 && s.indexOf( 'E' ) < 0 ){
-         while( s.endsWith( "0" ) ){
+        while(s.charAt(s.length() - 1) == '0'){
+            if(s.endsWith(".0")){
+               break;
+            }
+
             s = s.substring( 0, s.length() - 1 );
-         }
-         if( s.endsWith( "." ) ){
-            s = s.substring( 0, s.length() - 1 );
-         }
+        }
       }
       return s;
    }

--- a/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/test/java/net/sf/json/util/TestJSONUtils.java
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/test/java/net/sf/json/util/TestJSONUtils.java
@@ -61,7 +61,25 @@ public class TestJSONUtils extends TestCase {
    }
 
    public void testDoubleToString_trailingZeros() {
-      assertEquals( "200", JSONUtils.doubleToString( 200.00000 ) );
+      assertEquals( "200.0", JSONUtils.doubleToString( 200.00000 ) );
+   }
+
+   public void testDoubleToString() {
+      Map<String, Double> expected = new HashMap<>();
+      expected.put("200.0", 200.0d);
+      expected.put("200.0", 200.000d);
+      expected.put("200.1", 200.1d);
+      expected.put("200.1", 200.10d);
+      expected.put("200.1", 200.1000d);
+      expected.put("200.12345", 200.12345d);
+      expected.put("200.12345", 200.123450000d);
+      expected.put("200.101", 200.101d);
+      expected.put("1.0E-8", 1.0E-8);
+      expected.put("200.0", 200d);
+
+      for(String key : expected.keySet()){
+         assertEquals(key,JSONUtils.doubleToString(expected.get(key)));
+      }
    }
 
    public void testGetFunctionParams() {

--- a/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/test/java/net/sf/json/util/TestJSONUtils.java
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/json-lib-talend/src/test/java/net/sf/json/util/TestJSONUtils.java
@@ -136,6 +136,28 @@ public class TestJSONUtils extends TestCase {
       }
    }
 
+   public void testNumberToString() {
+      Map<String, Number> expected = new HashMap<>();
+
+      expected.put("0", Integer.valueOf("00000"));
+      expected.put("123", Integer.valueOf("123"));
+      expected.put("-123", Integer.valueOf("-123"));
+
+      expected.put("0.0", Double.valueOf("0"));
+      expected.put("0.0", Double.valueOf("0.00000"));
+      expected.put("120.0001", Double.valueOf("120.0001000"));
+      expected.put("-120.0001", Double.valueOf("-120.0001000"));
+
+      expected.put("0.0", Float.valueOf("0"));
+      expected.put("0.0", Float.valueOf("0.00000"));
+      expected.put("120.0001", Float.valueOf("120.0001000"));
+      expected.put("-120.0001", Float.valueOf("-120.0001000"));
+
+      for(String key : expected.keySet()) {
+         assertEquals(key, JSONUtils.numberToString(expected.get(key)));
+      }
+   }
+
    public void testQuote_emptyString() {
       assertEquals( "\"\"", JSONUtils.quote( "" ) );
    }

--- a/main/plugins/org.talend.designer.components.localprovider/components/tExtractJSONFields/tExtractJSONFields_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tExtractJSONFields/tExtractJSONFields_java.xml
@@ -178,7 +178,7 @@
     <IMPORTS>
     		<IMPORT NAME="Java_DOM4J_2.1.1" MODULE="dom4j-2.1.1.jar" MVN="mvn:org.dom4j/dom4j/2.1.1" REQUIRED_IF="READ_BY == 'XPATH'" BundleID="" />
             <IMPORT NAME="Java_JAXEN_1.1.6" MODULE="jaxen-1.1.6.jar" MVN="mvn:jaxen/jaxen/1.1.6" REQUIRED_IF="READ_BY == 'XPATH'" BundleID="" />
-            <IMPORT NAME="json-lib" MODULE="json-lib-2.4.4-talend.jar" MVN="mvn:net.sf.json-lib/json-lib/2.4.4-talend" REQUIRED_IF="READ_BY == 'XPATH'" />
+            <IMPORT NAME="json-lib" MODULE="json-lib-2.4.5-talend.jar" MVN="mvn:net.sf.json-lib/json-lib/2.4.5-talend" REQUIRED_IF="READ_BY == 'XPATH'" />
             <IMPORT NAME="commons_lang" MODULE="commons-lang-2.6.jar" MVN="mvn:commons-lang/commons-lang/2.6"  UrlPath="platform:/plugin/org.talend.libraries.apache.common/lib/commons-lang-2.6.jar" REQUIRED_IF="READ_BY == 'XPATH'" />
             <IMPORT NAME="commons_logging" MODULE="commons-logging-1.1.1.jar" MVN="mvn:org.talend.libraries/commons-logging-1.1.1/6.0.0"  UrlPath="platform:/base/plugins/org.apache.commons.logging_1.1.1.v201101211721.jar" REQUIRED_IF="READ_BY == 'XPATH'" />
             <IMPORT NAME="ezmorph" MODULE="ezmorph-1.0.6.jar" MVN="mvn:org.talend.libraries/ezmorph-1.0.6/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.jackson/lib/ezmorph-1.0.6.jar" REQUIRED_IF="READ_BY == 'XPATH'" />

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileInputJSON/tFileInputJSON_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileInputJSON/tFileInputJSON_java.xml
@@ -163,7 +163,7 @@
 			<!-- xpath -->
 			<IMPORT NAME="Java_DOM4J_2.1.1" MODULE="dom4j-2.1.1.jar" MVN="mvn:org.dom4j/dom4j/2.1.1" REQUIRED_IF="(READ_BY == 'XPATH')" BundleID="" />
 			<IMPORT NAME="Java_JAXEN_1.1.6" MODULE="jaxen-1.1.6.jar" MVN="mvn:jaxen/jaxen/1.1.6" REQUIRED_IF="(READ_BY == 'XPATH')" BundleID="" />
-			<IMPORT NAME="json-lib" MODULE="json-lib-2.4.3-talend.jar" MVN="mvn:net.sf.json-lib/json-lib/2.4.3-talend" REQUIRED_IF="(READ_BY == 'XPATH')" />
+			<IMPORT NAME="json-lib" MODULE="json-lib-2.4.5-talend.jar" MVN="mvn:net.sf.json-lib/json-lib/2.4.5-talend" REQUIRED_IF="(READ_BY == 'XPATH')" />
 			<IMPORT NAME="commons_lang" MODULE="commons-lang-2.6.jar" MVN="mvn:commons-lang/commons-lang/2.6"  UrlPath="platform:/plugin/org.talend.libraries.apache.common/lib/commons-lang-2.6.jar"
 				REQUIRED_IF="(READ_BY == 'XPATH')" />
 			<IMPORT NAME="commons_logging" MODULE="commons-logging-1.1.1.jar" MVN="mvn:org.talend.libraries/commons-logging-1.1.1/6.0.0"  UrlPath="platform:/base/plugins/org.apache.commons.logging_1.1.1.v201101211721.jar"

--- a/main/plugins/org.talend.designer.components.localprovider/components/tWriteJSONFieldIn/tWriteJSONFieldIn_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tWriteJSONFieldIn/tWriteJSONFieldIn_java.xml
@@ -81,7 +81,7 @@
 			<IMPORT NAME="commons_lang" MODULE="commons-lang-2.6.jar" MVN="mvn:commons-lang/commons-lang/2.6"  UrlPath="platform:/plugin/org.talend.libraries.apache.common/lib/commons-lang-2.6.jar" REQUIRED="true" />
 			<IMPORT NAME="commons_logging" MODULE="commons-logging-1.1.1.jar" MVN="mvn:org.talend.libraries/commons-logging-1.1.1/6.0.0"  UrlPath="platform:/base/plugins/org.apache.commons.logging_1.1.1.v201101211721.jar" REQUIRED="true" />
 			<IMPORT NAME="ezmorph" MODULE="ezmorph-1.0.6.jar" MVN="mvn:org.talend.libraries/ezmorph-1.0.6/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.jackson/lib/ezmorph-1.0.6.jar" REQUIRED="true" />
-			<IMPORT NAME="json-lib" MODULE="json-lib-2.4.4-talend.jar" MVN="mvn:net.sf.json-lib/json-lib/2.4.4-talend" REQUIRED="true" />
+			<IMPORT NAME="json-lib" MODULE="json-lib-2.4.5-talend.jar" MVN="mvn:net.sf.json-lib/json-lib/2.4.5-talend" REQUIRED="true" />
 		</IMPORTS>
 	</CODEGENERATION>
 


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-43610

**What is the new behavior?**
A decimal value in a json with non-significant 0, keep at least one non-significant 0 to keep the double type "10.0000" -> "10.0"

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


