### PR TITLE
fix(TDI-43632): use defined pattern by user instead of static value

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryOutputBulk/tBigQueryOutputBulk_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryOutputBulk/tBigQueryOutputBulk_main.javajet
@@ -92,24 +92,10 @@
                 			            %>
                 			            row_<%=cid%>[curColumnIndex_<%=cid%>] = <%=conn.getName() %>.<%=column.getLabel() %>;
                 			            <%
-                			        }else if(javaType == JavaTypesManager.DATE && pattern == null){
-                			        	%>
-                			            row_<%=cid%>[curColumnIndex_<%=cid%>] = FormatterUtils.format_Date(<%=conn.getName() %>.<%=column.getLabel() %>, "yyyy-MM-dd");
-                			            <%
-                			        }else if(javaType == JavaTypesManager.DATE && pattern != null){
-                			            if(pattern.length() > 12){
-	                			            %> 
-	                			            row_<%=cid%>[curColumnIndex_<%=cid%>] = FormatterUtils.format_Date(<%=conn.getName() %>.<%=column.getLabel() %>, "yyyy-MM-dd HH:mm:ss");
-	                			            <%
-                			            }else if(pattern.length() == 12 || "\"\"".equals(pattern)) {	
-                			            	%>
-	                			            row_<%=cid%>[curColumnIndex_<%=cid%>] = FormatterUtils.format_Date(<%=conn.getName() %>.<%=column.getLabel() %>, "yyyy-MM-dd");
-	                			            <%
-                			            }else {
-                			            	%>
-	                			            row_<%=cid%>[curColumnIndex_<%=cid%>] = FormatterUtils.format_Date(<%=conn.getName() %>.<%=column.getLabel() %>, <%=pattern%>);
-	                			            <%
-                			            }
+						}else if(javaType == JavaTypesManager.DATE){
+						%>
+ 						row_<%=cid%>[curColumnIndex_<%=cid%>] = FormatterUtils.format_Date(<%=conn.getName() %>.<%=column.getLabel() %>, <%=(pattern != null && !("\"\"").equals(pattern)) ? pattern : "\"yyyy-MM-dd\""%>);
+ 						<%
                 			        }else if(javaType == JavaTypesManager.BYTE_ARRAY){
                 			            %>
                 			            row_<%=cid%>[curColumnIndex_<%=cid%>] = java.nio.charset.Charset.forName(<%=encoding %>).decode(java.nio.ByteBuffer.wrap(<%=conn.getName() %>.<%=column.getLabel() %>)).toString();


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-43632
Static pattern cut fraction seconds.
**What is the new behavior?**
Use user-defined pattern instead of static one.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


