### PR TITLE
fix(TUP-26197)needn't force to log4j2 when import old project which is

### DIFF
--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/preference/Log4jSettingPage.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/preference/Log4jSettingPage.java
@@ -70,17 +70,6 @@ public class Log4jSettingPage extends ProjectSettingPage {
         if (log4jBtn != null && !log4jBtn.isDisposed()) {
             initLog4jStatus();
         }
-        if (!combo.isEnabled()) {
-            combo.select(1);
-            IRunProcessService service = null;
-            if (GlobalServiceRegister.getDefault().isServiceRegistered(IRunProcessService.class)) {
-                service = (IRunProcessService) GlobalServiceRegister.getDefault().getService(IRunProcessService.class);
-            }
-            if (service != null) {
-                String logTemplate = service.getLogTemplate(Log4jPrefsConstants.LOG4J_VERSION2_FILEPATH);
-                templateTxt.setText(logTemplate);
-            }
-        }
         initListerner();
         return parent;
     }
@@ -143,8 +132,6 @@ public class Log4jSettingPage extends ProjectSettingPage {
         layout.marginHeight = 0;
         layout.horizontalSpacing = 8;
         composite.setLayout(layout);
-        combo.setEnabled(
-                Boolean.valueOf(Log4jPrefsSettingManager.getInstance().getValueOfPreNode(Log4jPrefsConstants.LOG4J_ENABLE_NODE)));
 
         return group;
     }


### PR DESCRIPTION
unactive and log4j1

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


