### PR TITLE
fix(TDI-42951): Improved query execution for Result size Auto

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryInput/ServiceAccountBigQueryHelper.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryInput/ServiceAccountBigQueryHelper.javajet
@@ -1,99 +1,95 @@
 <%@ jet
 %>
 class ServiceAccountBigQueryUtil_<%=cid%> {
-	private String projectId;
-	private String credentialsFile;
 	private com.google.cloud.bigquery.BigQuery bigQuery;
 	private boolean useLargeResult;
-	private String tempDataSet;
 	private String tempTable;
 
-	public ServiceAccountBigQueryUtil_<%=cid%>(String projectId, String credentialsFile, String resultSizeType, String tempDataSet) {
-		this.projectId = projectId;
-		this.credentialsFile = credentialsFile;
-		this.useLargeResult = "LARGE".equals(resultSizeType);
-		this.tempDataSet = tempDataSet;
+	public ServiceAccountBigQueryUtil_<%=cid%>() {
+		this.useLargeResult = "LARGE".equals("<%=resultSizeType%>");
 	}
 
 	private com.google.cloud.bigquery.BigQuery buildBigQuery() throws java.io.IOException {
-		com.google.auth.oauth2.GoogleCredentials credentials_<%=cid%>;
-		java.io.File credentialsFile_<%=cid%> = new java.io.File(credentialsFile);
-		try(java.io.FileInputStream credentialsStream_<%=cid%> = new java.io.FileInputStream(credentialsFile_<%=cid%>)) {
-			credentials_<%=cid%> = com.google.auth.oauth2.ServiceAccountCredentials.fromStream(credentialsStream_<%=cid%>);
+		com.google.auth.oauth2.GoogleCredentials credentials;
+		java.io.File credentialsFile = new java.io.File(<%=credentialsFile%>);
+		try(java.io.FileInputStream credentialsStream = new java.io.FileInputStream(credentialsFile)) {
+			credentials = com.google.auth.oauth2.ServiceAccountCredentials.fromStream(credentialsStream);
 		}
 
-		<% if(isLog4jEnabled) { %>
-			log.info("<%=cid%> - query " + <%=query%>);
-		<% } %>
-
-		com.google.cloud.bigquery.BigQuery bigquery_<%=cid%> = com.google.cloud.bigquery.BigQueryOptions.newBuilder()
-			.setCredentials(credentials_<%=cid%>)
-			.setProjectId(projectId)
+		com.google.cloud.bigquery.BigQuery bigquery = com.google.cloud.bigquery.BigQueryOptions.newBuilder()
+			.setCredentials(credentials)
+			.setProjectId(<%=projectId%>)
 			.build()
 			.getService();
 
-		return bigquery_<%=cid%>;
+		return bigquery;
 	}
 
-	private com.google.cloud.bigquery.Job buildJob(com.google.cloud.bigquery.BigQuery bigquery, com.google.cloud.bigquery.QueryJobConfiguration.Builder queryConfiguration, com.google.cloud.bigquery.JobId jobId) throws InterruptedException {
-		com.google.cloud.bigquery.Job job_<%=cid%> = bigquery.create(com.google.cloud.bigquery.JobInfo.newBuilder(queryConfiguration.build()).setJobId(jobId).build());
+	private com.google.cloud.bigquery.Job buildJob(com.google.cloud.bigquery.BigQuery bigquery, com.google.cloud.bigquery.QueryJobConfiguration queryConfiguration, com.google.cloud.bigquery.JobId jobId) throws InterruptedException {
+		com.google.cloud.bigquery.Job job = bigquery.create(com.google.cloud.bigquery.JobInfo.newBuilder(queryConfiguration).setJobId(jobId).build());
 
 		<% if(isLog4jEnabled) {	%>
 		log.info("<%=cid%> - Sending job " + jobId + " with query: " + <%=query%>);
 		<% } %>
 
-		job_<%=cid%> = job_<%=cid%>.waitFor();
+		job = job.waitFor();
 
-		if (job_<%=cid%> == null) {
+		if (job == null) {
 			throw new RuntimeException("Job no longer exists");
-		} else if (job_<%=cid%>.getStatus().getError() != null) {
-			throw new RuntimeException(job_<%=cid%>.getStatus().getError().toString());
+		} else if (job.getStatus().getError() != null) {
+			throw new RuntimeException(job.getStatus().getError().toString());
 		}
 
 		<% if(isLog4jEnabled) { %>
 			log.info("<%=cid%> - Job " + jobId + " finished successfully.");
 		<% } %>
 
-		return job_<%=cid%>;
+		return job;
 	}
 
 	private com.google.cloud.bigquery.Job executeQuerySmallResult(String query, boolean useLegacySql) throws java.io.IOException, InterruptedException {
 		bigQuery = buildBigQuery();
-		com.google.cloud.bigquery.QueryJobConfiguration.Builder queryConfiguration_<%=cid%> = com.google.cloud.bigquery.QueryJobConfiguration.newBuilder(query).setUseLegacySql(useLegacySql);
-		com.google.cloud.bigquery.JobId jobId_<%=cid%> = com.google.cloud.bigquery.JobId.of(projectId, java.util.UUID.randomUUID().toString());
-		return buildJob(bigQuery, queryConfiguration_<%=cid%>, jobId_<%=cid%>);
+		com.google.cloud.bigquery.QueryJobConfiguration queryConfiguration = com.google.cloud.bigquery.QueryJobConfiguration.newBuilder(query)
+			.setUseLegacySql(useLegacySql)
+			.build();
+		com.google.cloud.bigquery.JobId jobId = com.google.cloud.bigquery.JobId.of(<%=projectId%>, java.util.UUID.randomUUID().toString());
+		return buildJob(bigQuery, queryConfiguration, jobId);
 	}
 
 	private com.google.cloud.bigquery.Job executeQueryLargeResult(String query, boolean useLegacySql) throws java.io.IOException, InterruptedException {
-		bigQuery= buildBigQuery();
-		com.google.cloud.bigquery.QueryJobConfiguration.Builder queryConfiguration_<%=cid%> = com.google.cloud.bigquery.QueryJobConfiguration.newBuilder(query).setUseLegacySql(useLegacySql);
+		if (bigQuery == null) {
+			bigQuery = buildBigQuery();
+		}
 
 		<%if (isCustomTemporaryName) {%>
-			String tempDataset_<%=cid%> = tempDataSet;
-		<%            if(isLog4jEnabled){	%>
-			log.info("<%=cid%> - temporary Dataset name : " + tempDataset_<%=cid%>);
+			String tempDataset = <%=tempDataset%>;
+		<%  if(isLog4jEnabled){	%>
+				log.info("<%=cid%> - temporary Dataset name : " + tempDataset);
 		<%
 			}
 		} else {
 		%>
-			com.google.cloud.bigquery.QueryJobConfiguration jobConfDryRun_<%=cid%> = queryConfiguration_<%=cid%> .setDryRun(true).build();
-			com.google.cloud.bigquery.Job jobDryRun_<%=cid%> = bigQuery.create(com.google.cloud.bigquery.JobInfo.of(jobConfDryRun_<%=cid%>));
+			com.google.cloud.bigquery.QueryJobConfiguration jobConfDryRun = com.google.cloud.bigquery.QueryJobConfiguration.newBuilder(query)
+				.setUseLegacySql(useLegacySql)
+				.setDryRun(true)
+				.build();
+			com.google.cloud.bigquery.Job jobDryRun = bigQuery.create(com.google.cloud.bigquery.JobInfo.of(jobConfDryRun));
 
-			String queryLocation_<%=cid%> =jobDryRun_<%=cid%>.getJobId().getLocation();
-			String location_<%=cid%> = queryLocation_<%=cid%> == null ? "US" : queryLocation_<%=cid%>;
-			String tempDataset_<%=cid%> = java.util.UUID.randomUUID().toString().replaceAll("-", "")
+			String queryLocation =jobDryRun.getJobId().getLocation();
+			String location = queryLocation == null ? "US" : queryLocation;
+			String tempDataset = java.util.UUID.randomUUID().toString().replaceAll("-", "")
 			+ Integer.toHexString(java.util.concurrent.ThreadLocalRandom.current().nextInt())
 			+ Integer.toHexString(java.util.concurrent.ThreadLocalRandom.current().nextInt());
 
 			<% if(isLog4jEnabled){	%>
-			log.info("<%=cid%> - query location :" + queryLocation_<%=cid%>);
-			log.info("<%=cid%> - temporary dataset location :" + location_<%=cid%>);
-			log.info("<%=cid%> - temporary Dataset name : " + tempDataset_<%=cid%>);
+			log.info("<%=cid%> - query location :" + queryLocation);
+			log.info("<%=cid%> - temporary dataset location :" + location);
+			log.info("<%=cid%> - temporary Dataset name : " + tempDataset);
 
 			<% } %>
 
-			com.google.cloud.bigquery.DatasetInfo datasetInfo_<%=cid%> = com.google.cloud.bigquery.DatasetInfo.newBuilder(tempDataset_<%=cid%>).setLocation(location_<%=cid%>).build();
-			com.google.cloud.bigquery.Dataset dataset_<%=cid%> = bigQuery.create(datasetInfo_<%=cid%>);
+			com.google.cloud.bigquery.DatasetInfo datasetInfo = com.google.cloud.bigquery.DatasetInfo.newBuilder(tempDataset).setLocation(location).build();
+			com.google.cloud.bigquery.Dataset dataset = bigQuery.create(datasetInfo);
 		<%
 		}
 		%>
@@ -105,50 +101,55 @@ class ServiceAccountBigQueryUtil_<%=cid%> {
 		<%
 			}
 		%>
-		queryConfiguration_<%=cid%>
+		com.google.cloud.bigquery.QueryJobConfiguration queryConfiguration = com.google.cloud.bigquery.QueryJobConfiguration.newBuilder(query)
+			.setUseLegacySql(useLegacySql)
 			.setDryRun(false)
 			.setAllowLargeResults(true)
-			.setDestinationTable(com.google.cloud.bigquery.TableId.of(tempDataset_<%=cid%>, tempTable));
+			.setDestinationTable(com.google.cloud.bigquery.TableId.of(tempDataset, tempTable))
+			.build();
 
-		com.google.cloud.bigquery.JobId jobId_<%=cid%>  = com.google.cloud.bigquery.JobId
+		com.google.cloud.bigquery.JobId jobId  = com.google.cloud.bigquery.JobId
 			.newBuilder().setProject(<%=projectId%>)
 			.setJob(java.util.UUID.randomUUID().toString())
 			.build();
 
 		<% if(isLog4jEnabled){ %>
-			log.info("<%=cid%> - job location : " + jobId_<%=cid%>.getLocation());
+			log.info("<%=cid%> - job location : " + jobId.getLocation());
 		<% } %>
-		return buildJob(bigQuery, queryConfiguration_<%=cid%>, jobId_<%=cid%>);
+		return buildJob(bigQuery, queryConfiguration, jobId);
 	}
 
 	public com.google.cloud.bigquery.Job executeQuery(String query, boolean useLegacySql) throws Exception {
 
-		com.google.cloud.bigquery.Job job_<%=cid%>;
+		com.google.cloud.bigquery.Job job;
 
-		if (useLargeResult) {
-			job_<%=cid%> = executeQueryLargeResult(query, useLegacySql);
-		} else {
+		<%if ("SMALL".equals(resultSizeType)) {%>
+			job = executeQuerySmallResult(query, useLegacySql);
+		<%} else if ("LARGE".equals(resultSizeType)) {%>
+			job = executeQueryLargeResult(query, useLegacySql);
+		<%} else {%>
 			try {
-				job_<%=cid%> = executeQuerySmallResult(query, useLegacySql);
+				job = executeQuerySmallResult(query, useLegacySql);
 			} catch (com.google.cloud.bigquery.BigQueryException e) {
-				job_<%=cid%> = executeQueryLargeResult(query, useLegacySql);
+				job = executeQueryLargeResult(query, useLegacySql);
 				useLargeResult = true;
 			}
-		}
-		return job_<%=cid%>;
+		<%}%>
+
+		return job;
 	}
 
 	public void cleanup() throws Exception {
-		if(useLargeResult){
+		if(useLargeResult) {
 <%
 			if (isCustomTemporaryName) {
 %>
-				bigQuery.delete(com.google.cloud.bigquery.TableId.of(tempDataSet, tempTable));
+				bigQuery.delete(com.google.cloud.bigquery.TableId.of(<%=tempDataset%>, tempTable));
 <%
 			} else {
 %>
-				com.google.cloud.bigquery.DatasetId datasetId_<%=cid%> = com.google.cloud.bigquery.DatasetId.of(projectId, tempDataSet);
-				bigQuery.delete(datasetId_<%=cid%>, com.google.cloud.bigquery.BigQuery.DatasetDeleteOption.deleteContents());
+				com.google.cloud.bigquery.DatasetId datasetId = com.google.cloud.bigquery.DatasetId.of(<%=projectId%>, <%=tempDataset%>);
+				bigQuery.delete(datasetId, com.google.cloud.bigquery.BigQuery.DatasetDeleteOption.deleteContents());
 <%
 			}%>
 		}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryInput/ServiceAccountBigQueryHelper.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryInput/ServiceAccountBigQueryHelper.javajet
@@ -61,14 +61,12 @@ class ServiceAccountBigQueryUtil_<%=cid%> {
 			bigQuery = buildBigQuery();
 		}
 
-		<%if (isCustomTemporaryName) {%>
+		<% if (isCustomTemporaryName) { %>
 			String tempDataset = <%=tempDataset%>;
-		<%  if(isLog4jEnabled){	%>
+		<% if(isLog4jEnabled) { %>
 				log.info("<%=cid%> - temporary Dataset name : " + tempDataset);
-		<%
-			}
-		} else {
-		%>
+		<% }
+		} else { %>
 			com.google.cloud.bigquery.QueryJobConfiguration jobConfDryRun = com.google.cloud.bigquery.QueryJobConfiguration.newBuilder(query)
 				.setUseLegacySql(useLegacySql)
 				.setDryRun(true)
@@ -81,7 +79,7 @@ class ServiceAccountBigQueryUtil_<%=cid%> {
 			+ Integer.toHexString(java.util.concurrent.ThreadLocalRandom.current().nextInt())
 			+ Integer.toHexString(java.util.concurrent.ThreadLocalRandom.current().nextInt());
 
-			<% if(isLog4jEnabled){	%>
+			<% if (isLog4jEnabled) { %>
 			log.info("<%=cid%> - query location :" + queryLocation);
 			log.info("<%=cid%> - temporary dataset location :" + location);
 			log.info("<%=cid%> - temporary Dataset name : " + tempDataset);
@@ -90,17 +88,13 @@ class ServiceAccountBigQueryUtil_<%=cid%> {
 
 			com.google.cloud.bigquery.DatasetInfo datasetInfo = com.google.cloud.bigquery.DatasetInfo.newBuilder(tempDataset).setLocation(location).build();
 			com.google.cloud.bigquery.Dataset dataset = bigQuery.create(datasetInfo);
-		<%
-		}
-		%>
+		<% } %>
 		tempTable = java.util.UUID.randomUUID().toString().replaceAll("-", "")
 		+ Integer.toHexString(java.util.concurrent.ThreadLocalRandom.current().nextInt())
 		+ Integer.toHexString(java.util.concurrent.ThreadLocalRandom.current().nextInt());
-		<% if(isLog4jEnabled){	%>
+		<% if(isLog4jEnabled) { %>
 			log.info("<%=cid%> - temporary table name : " + tempTable);
-		<%
-			}
-		%>
+		<% } %>
 		com.google.cloud.bigquery.QueryJobConfiguration queryConfiguration = com.google.cloud.bigquery.QueryJobConfiguration.newBuilder(query)
 			.setUseLegacySql(useLegacySql)
 			.setDryRun(false)
@@ -123,35 +117,30 @@ class ServiceAccountBigQueryUtil_<%=cid%> {
 
 		com.google.cloud.bigquery.Job job;
 
-		<%if ("SMALL".equals(resultSizeType)) {%>
+		<% if ("SMALL".equals(resultSizeType)) { %>
 			job = executeQuerySmallResult(query, useLegacySql);
-		<%} else if ("LARGE".equals(resultSizeType)) {%>
+		<% } else if ("LARGE".equals(resultSizeType)) { %>
 			job = executeQueryLargeResult(query, useLegacySql);
-		<%} else {%>
+		<% } else { %>
 			try {
 				job = executeQuerySmallResult(query, useLegacySql);
 			} catch (com.google.cloud.bigquery.BigQueryException e) {
 				job = executeQueryLargeResult(query, useLegacySql);
 				useLargeResult = true;
 			}
-		<%}%>
+		<% } %>
 
 		return job;
 	}
 
 	public void cleanup() throws Exception {
 		if(useLargeResult) {
-<%
-			if (isCustomTemporaryName) {
-%>
+			<% if (isCustomTemporaryName) { %>
 				bigQuery.delete(com.google.cloud.bigquery.TableId.of(<%=tempDataset%>, tempTable));
-<%
-			} else {
-%>
+			<% } else { %>
 				com.google.cloud.bigquery.DatasetId datasetId = com.google.cloud.bigquery.DatasetId.of(<%=projectId%>, <%=tempDataset%>);
 				bigQuery.delete(datasetId, com.google.cloud.bigquery.BigQuery.DatasetDeleteOption.deleteContents());
-<%
-			}%>
+			<% } %>
 		}
 	}
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryInput/ServiceAccountBigQueryHelper.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryInput/ServiceAccountBigQueryHelper.javajet
@@ -6,31 +6,34 @@ class ServiceAccountBigQueryUtil_<%=cid%> {
 	private String tempTable;
 
 	public ServiceAccountBigQueryUtil_<%=cid%>() {
-		this.useLargeResult = "LARGE".equals("<%=resultSizeType%>");
+		this.useLargeResult = <%="LARGE".equals(resultSizeType)%>;
 	}
 
 	private com.google.cloud.bigquery.BigQuery buildBigQuery() throws java.io.IOException {
+		if (bigQuery != null) {
+			return bigQuery;
+		}
 		com.google.auth.oauth2.GoogleCredentials credentials;
 		java.io.File credentialsFile = new java.io.File(<%=credentialsFile%>);
 		try(java.io.FileInputStream credentialsStream = new java.io.FileInputStream(credentialsFile)) {
 			credentials = com.google.auth.oauth2.ServiceAccountCredentials.fromStream(credentialsStream);
 		}
 
-		com.google.cloud.bigquery.BigQuery bigquery = com.google.cloud.bigquery.BigQueryOptions.newBuilder()
+		com.google.cloud.bigquery.BigQuery result = com.google.cloud.bigquery.BigQueryOptions.newBuilder()
 			.setCredentials(credentials)
 			.setProjectId(<%=projectId%>)
 			.build()
 			.getService();
 
-		return bigquery;
+		return result;
 	}
 
 	private com.google.cloud.bigquery.Job buildJob(com.google.cloud.bigquery.BigQuery bigquery, com.google.cloud.bigquery.QueryJobConfiguration queryConfiguration, com.google.cloud.bigquery.JobId jobId) throws InterruptedException {
 		com.google.cloud.bigquery.Job job = bigquery.create(com.google.cloud.bigquery.JobInfo.newBuilder(queryConfiguration).setJobId(jobId).build());
 
-		<% if(isLog4jEnabled) {	%>
-		log.info("<%=cid%> - Sending job " + jobId + " with query: " + <%=query%>);
-		<% } %>
+		<%if(isLog4jEnabled) {%>
+			log.info("<%=cid%> - Sending job " + jobId + " with query: " + <%=query%>);
+		<%}%>
 
 		job = job.waitFor();
 
@@ -40,9 +43,9 @@ class ServiceAccountBigQueryUtil_<%=cid%> {
 			throw new RuntimeException(job.getStatus().getError().toString());
 		}
 
-		<% if(isLog4jEnabled) { %>
+		<%if(isLog4jEnabled) {%>
 			log.info("<%=cid%> - Job " + jobId + " finished successfully.");
-		<% } %>
+		<%}%>
 
 		return job;
 	}
@@ -57,16 +60,14 @@ class ServiceAccountBigQueryUtil_<%=cid%> {
 	}
 
 	private com.google.cloud.bigquery.Job executeQueryLargeResult(String query, boolean useLegacySql) throws java.io.IOException, InterruptedException {
-		if (bigQuery == null) {
-			bigQuery = buildBigQuery();
-		}
+		bigQuery = buildBigQuery();
 
-		<% if (isCustomTemporaryName) { %>
+		<%if (isCustomTemporaryName) {%>
 			String tempDataset = <%=tempDataset%>;
-		<% if(isLog4jEnabled) { %>
+			<%if(isLog4jEnabled) {%>
 				log.info("<%=cid%> - temporary Dataset name : " + tempDataset);
-		<% }
-		} else { %>
+			<%}
+		} else {%>
 			com.google.cloud.bigquery.QueryJobConfiguration jobConfDryRun = com.google.cloud.bigquery.QueryJobConfiguration.newBuilder(query)
 				.setUseLegacySql(useLegacySql)
 				.setDryRun(true)
@@ -79,22 +80,21 @@ class ServiceAccountBigQueryUtil_<%=cid%> {
 			+ Integer.toHexString(java.util.concurrent.ThreadLocalRandom.current().nextInt())
 			+ Integer.toHexString(java.util.concurrent.ThreadLocalRandom.current().nextInt());
 
-			<% if (isLog4jEnabled) { %>
-			log.info("<%=cid%> - query location :" + queryLocation);
-			log.info("<%=cid%> - temporary dataset location :" + location);
-			log.info("<%=cid%> - temporary Dataset name : " + tempDataset);
-
-			<% } %>
+			<%if (isLog4jEnabled) {%>
+				log.info("<%=cid%> - query location :" + queryLocation);
+				log.info("<%=cid%> - temporary dataset location :" + location);
+				log.info("<%=cid%> - temporary Dataset name : " + tempDataset);
+			<%}%>
 
 			com.google.cloud.bigquery.DatasetInfo datasetInfo = com.google.cloud.bigquery.DatasetInfo.newBuilder(tempDataset).setLocation(location).build();
 			com.google.cloud.bigquery.Dataset dataset = bigQuery.create(datasetInfo);
-		<% } %>
+		<%}%>
 		tempTable = java.util.UUID.randomUUID().toString().replaceAll("-", "")
-		+ Integer.toHexString(java.util.concurrent.ThreadLocalRandom.current().nextInt())
-		+ Integer.toHexString(java.util.concurrent.ThreadLocalRandom.current().nextInt());
-		<% if(isLog4jEnabled) { %>
+			+ Integer.toHexString(java.util.concurrent.ThreadLocalRandom.current().nextInt())
+			+ Integer.toHexString(java.util.concurrent.ThreadLocalRandom.current().nextInt());
+		<%if(isLog4jEnabled) {%>
 			log.info("<%=cid%> - temporary table name : " + tempTable);
-		<% } %>
+		<%}%>
 		com.google.cloud.bigquery.QueryJobConfiguration queryConfiguration = com.google.cloud.bigquery.QueryJobConfiguration.newBuilder(query)
 			.setUseLegacySql(useLegacySql)
 			.setDryRun(false)
@@ -107,9 +107,9 @@ class ServiceAccountBigQueryUtil_<%=cid%> {
 			.setJob(java.util.UUID.randomUUID().toString())
 			.build();
 
-		<% if(isLog4jEnabled){ %>
+		<%if(isLog4jEnabled){%>
 			log.info("<%=cid%> - job location : " + jobId.getLocation());
-		<% } %>
+		<%}%>
 		return buildJob(bigQuery, queryConfiguration, jobId);
 	}
 
@@ -117,30 +117,32 @@ class ServiceAccountBigQueryUtil_<%=cid%> {
 
 		com.google.cloud.bigquery.Job job;
 
-		<% if ("SMALL".equals(resultSizeType)) { %>
+		<%if ("SMALL".equals(resultSizeType)) {%>
 			job = executeQuerySmallResult(query, useLegacySql);
-		<% } else if ("LARGE".equals(resultSizeType)) { %>
+		<%}%>
+		<%if ("LARGE".equals(resultSizeType)) {%>
 			job = executeQueryLargeResult(query, useLegacySql);
-		<% } else { %>
+		<%}%>
+		<%if ("AUTO".equals(resultSizeType)) {%>
 			try {
 				job = executeQuerySmallResult(query, useLegacySql);
 			} catch (com.google.cloud.bigquery.BigQueryException e) {
 				job = executeQueryLargeResult(query, useLegacySql);
 				useLargeResult = true;
 			}
-		<% } %>
+		<%}%>
 
 		return job;
 	}
 
 	public void cleanup() throws Exception {
 		if(useLargeResult) {
-			<% if (isCustomTemporaryName) { %>
+			<%if (isCustomTemporaryName) {%>
 				bigQuery.delete(com.google.cloud.bigquery.TableId.of(<%=tempDataset%>, tempTable));
-			<% } else { %>
+			<%} else {%>
 				com.google.cloud.bigquery.DatasetId datasetId = com.google.cloud.bigquery.DatasetId.of(<%=projectId%>, <%=tempDataset%>);
 				bigQuery.delete(datasetId, com.google.cloud.bigquery.BigQuery.DatasetDeleteOption.deleteContents());
-			<% } %>
+			<%}%>
 		}
 	}
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryInput/ServiceAccountBigQueryHelper.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryInput/ServiceAccountBigQueryHelper.javajet
@@ -1,0 +1,157 @@
+<%@ jet
+%>
+class ServiceAccountBigQueryUtil_<%=cid%> {
+	private String projectId;
+	private String credentialsFile;
+	private com.google.cloud.bigquery.BigQuery bigQuery;
+	private boolean useLargeResult;
+	private String tempDataSet;
+	private String tempTable;
+
+	public ServiceAccountBigQueryUtil_<%=cid%>(String projectId, String credentialsFile, String resultSizeType, String tempDataSet) {
+		this.projectId = projectId;
+		this.credentialsFile = credentialsFile;
+		this.useLargeResult = "LARGE".equals(resultSizeType);
+		this.tempDataSet = tempDataSet;
+	}
+
+	private com.google.cloud.bigquery.BigQuery buildBigQuery() throws java.io.IOException {
+		com.google.auth.oauth2.GoogleCredentials credentials_<%=cid%>;
+		java.io.File credentialsFile_<%=cid%> = new java.io.File(credentialsFile);
+		try(java.io.FileInputStream credentialsStream_<%=cid%> = new java.io.FileInputStream(credentialsFile_<%=cid%>)) {
+			credentials_<%=cid%> = com.google.auth.oauth2.ServiceAccountCredentials.fromStream(credentialsStream_<%=cid%>);
+		}
+
+		<% if(isLog4jEnabled) { %>
+			log.info("<%=cid%> - query " + <%=query%>);
+		<% } %>
+
+		com.google.cloud.bigquery.BigQuery bigquery_<%=cid%> = com.google.cloud.bigquery.BigQueryOptions.newBuilder()
+			.setCredentials(credentials_<%=cid%>)
+			.setProjectId(projectId)
+			.build()
+			.getService();
+
+		return bigquery_<%=cid%>;
+	}
+
+	private com.google.cloud.bigquery.Job buildJob(com.google.cloud.bigquery.BigQuery bigquery, com.google.cloud.bigquery.QueryJobConfiguration.Builder queryConfiguration, com.google.cloud.bigquery.JobId jobId) throws InterruptedException {
+		com.google.cloud.bigquery.Job job_<%=cid%> = bigquery.create(com.google.cloud.bigquery.JobInfo.newBuilder(queryConfiguration.build()).setJobId(jobId).build());
+
+		<% if(isLog4jEnabled) {	%>
+		log.info("<%=cid%> - Sending job " + jobId + " with query: " + <%=query%>);
+		<% } %>
+
+		job_<%=cid%> = job_<%=cid%>.waitFor();
+
+		if (job_<%=cid%> == null) {
+			throw new RuntimeException("Job no longer exists");
+		} else if (job_<%=cid%>.getStatus().getError() != null) {
+			throw new RuntimeException(job_<%=cid%>.getStatus().getError().toString());
+		}
+
+		<% if(isLog4jEnabled) { %>
+			log.info("<%=cid%> - Job " + jobId + " finished successfully.");
+		<% } %>
+
+		return job_<%=cid%>;
+	}
+
+	private com.google.cloud.bigquery.Job executeQuerySmallResult(String query, boolean useLegacySql) throws java.io.IOException, InterruptedException {
+		bigQuery = buildBigQuery();
+		com.google.cloud.bigquery.QueryJobConfiguration.Builder queryConfiguration_<%=cid%> = com.google.cloud.bigquery.QueryJobConfiguration.newBuilder(query).setUseLegacySql(useLegacySql);
+		com.google.cloud.bigquery.JobId jobId_<%=cid%> = com.google.cloud.bigquery.JobId.of(projectId, java.util.UUID.randomUUID().toString());
+		return buildJob(bigQuery, queryConfiguration_<%=cid%>, jobId_<%=cid%>);
+	}
+
+	private com.google.cloud.bigquery.Job executeQueryLargeResult(String query, boolean useLegacySql) throws java.io.IOException, InterruptedException {
+		bigQuery= buildBigQuery();
+		com.google.cloud.bigquery.QueryJobConfiguration.Builder queryConfiguration_<%=cid%> = com.google.cloud.bigquery.QueryJobConfiguration.newBuilder(query).setUseLegacySql(useLegacySql);
+
+		<%if (isCustomTemporaryName) {%>
+			String tempDataset_<%=cid%> = tempDataSet;
+		<%            if(isLog4jEnabled){	%>
+			log.info("<%=cid%> - temporary Dataset name : " + tempDataset_<%=cid%>);
+		<%
+			}
+		} else {
+		%>
+			com.google.cloud.bigquery.QueryJobConfiguration jobConfDryRun_<%=cid%> = queryConfiguration_<%=cid%> .setDryRun(true).build();
+			com.google.cloud.bigquery.Job jobDryRun_<%=cid%> = bigQuery.create(com.google.cloud.bigquery.JobInfo.of(jobConfDryRun_<%=cid%>));
+
+			String queryLocation_<%=cid%> =jobDryRun_<%=cid%>.getJobId().getLocation();
+			String location_<%=cid%> = queryLocation_<%=cid%> == null ? "US" : queryLocation_<%=cid%>;
+			String tempDataset_<%=cid%> = java.util.UUID.randomUUID().toString().replaceAll("-", "")
+			+ Integer.toHexString(java.util.concurrent.ThreadLocalRandom.current().nextInt())
+			+ Integer.toHexString(java.util.concurrent.ThreadLocalRandom.current().nextInt());
+
+			<% if(isLog4jEnabled){	%>
+			log.info("<%=cid%> - query location :" + queryLocation_<%=cid%>);
+			log.info("<%=cid%> - temporary dataset location :" + location_<%=cid%>);
+			log.info("<%=cid%> - temporary Dataset name : " + tempDataset_<%=cid%>);
+
+			<% } %>
+
+			com.google.cloud.bigquery.DatasetInfo datasetInfo_<%=cid%> = com.google.cloud.bigquery.DatasetInfo.newBuilder(tempDataset_<%=cid%>).setLocation(location_<%=cid%>).build();
+			com.google.cloud.bigquery.Dataset dataset_<%=cid%> = bigQuery.create(datasetInfo_<%=cid%>);
+		<%
+		}
+		%>
+		tempTable = java.util.UUID.randomUUID().toString().replaceAll("-", "")
+		+ Integer.toHexString(java.util.concurrent.ThreadLocalRandom.current().nextInt())
+		+ Integer.toHexString(java.util.concurrent.ThreadLocalRandom.current().nextInt());
+		<% if(isLog4jEnabled){	%>
+			log.info("<%=cid%> - temporary table name : " + tempTable);
+		<%
+			}
+		%>
+		queryConfiguration_<%=cid%>
+			.setDryRun(false)
+			.setAllowLargeResults(true)
+			.setDestinationTable(com.google.cloud.bigquery.TableId.of(tempDataset_<%=cid%>, tempTable));
+
+		com.google.cloud.bigquery.JobId jobId_<%=cid%>  = com.google.cloud.bigquery.JobId
+			.newBuilder().setProject(<%=projectId%>)
+			.setJob(java.util.UUID.randomUUID().toString())
+			.build();
+
+		<% if(isLog4jEnabled){ %>
+			log.info("<%=cid%> - job location : " + jobId_<%=cid%>.getLocation());
+		<% } %>
+		return buildJob(bigQuery, queryConfiguration_<%=cid%>, jobId_<%=cid%>);
+	}
+
+	public com.google.cloud.bigquery.Job executeQuery(String query, boolean useLegacySql) throws Exception {
+
+		com.google.cloud.bigquery.Job job_<%=cid%>;
+
+		if (useLargeResult) {
+			job_<%=cid%> = executeQueryLargeResult(query, useLegacySql);
+		} else {
+			try {
+				job_<%=cid%> = executeQuerySmallResult(query, useLegacySql);
+			} catch (com.google.cloud.bigquery.BigQueryException e) {
+				job_<%=cid%> = executeQueryLargeResult(query, useLegacySql);
+				useLargeResult = true;
+			}
+		}
+		return job_<%=cid%>;
+	}
+
+	public void cleanup() throws Exception {
+		if(useLargeResult){
+<%
+			if (isCustomTemporaryName) {
+%>
+				bigQuery.delete(com.google.cloud.bigquery.TableId.of(tempDataSet, tempTable));
+<%
+			} else {
+%>
+				com.google.cloud.bigquery.DatasetId datasetId_<%=cid%> = com.google.cloud.bigquery.DatasetId.of(projectId, tempDataSet);
+				bigQuery.delete(datasetId_<%=cid%>, com.google.cloud.bigquery.BigQuery.DatasetDeleteOption.deleteContents());
+<%
+			}%>
+		}
+	}
+
+}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryInput/tBigQueryInput_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryInput/tBigQueryInput_begin.javajet
@@ -279,88 +279,22 @@
 	<%
 	} else if (authMode.equals("SERVICEACCOUNT")) {
 	%>
+		final String PROJECT_ID_<%=cid%> = <%=projectId%>;
 		com.google.auth.oauth2.GoogleCredentials credentials_<%=cid%>;
 		java.io.File credentialsFile_<%=cid%> = new java.io.File(<%=credentialsFile%>);
 		try(java.io.FileInputStream credentialsStream_<%=cid%> = new java.io.FileInputStream(credentialsFile_<%=cid%>)) {
 		    credentials_<%=cid%> = com.google.auth.oauth2.ServiceAccountCredentials.fromStream(credentialsStream_<%=cid%>);
 		}
 
-		String query_<%=cid%> = <%=query%>;
+		<%@ include file="@{org.talend.designer.components.localprovider}/components/tBigQueryInput/ServiceAccountBigQueryHelper.javajet"%>
+
 		<% if(isLog4jEnabled) { %>
 			log.info("<%=cid%> - query " + <%=query%>);
 		<% } %>
 
-		com.google.cloud.bigquery.BigQuery bigquery_<%=cid%> = com.google.cloud.bigquery.BigQueryOptions.newBuilder()
-				.setCredentials(credentials_<%=cid%>)
-				.setProjectId(<%=projectId%>)
-				.build()
-				.getService();
+		ServiceAccountBigQueryUtil_<%=cid%> serviceAccountBigQueryUtil_<%=cid%> = new ServiceAccountBigQueryUtil_<%=cid%>(PROJECT_ID_<%=cid%>, <%=credentialsFile%>, "<%=resultSizeType%>", <%=tempDataset%>);
 
-		com.google.cloud.bigquery.QueryJobConfiguration.Builder queryConfiguration_<%=cid%> = com.google.cloud.bigquery.QueryJobConfiguration.newBuilder(<%=query%>).setUseLegacySql(<%=useLegacySql%>);
-
-     <%if (resultSizeType.equals("LARGE") || resultSizeType.equals("AUTO")) {
-          if (isCustomTemporaryName) {%>
-              String tempDataset_<%=cid%> = <%=tempDataset%>;
-<%            if(isLog4jEnabled){	%>
-                  log.info("<%=cid%> - temporary Dataset name : " + tempDataset_<%=cid%>);
-<%
-              }
-          } else {
-%>
-          com.google.cloud.bigquery.QueryJobConfiguration jobConfDryRun_<%=cid%> = queryConfiguration_<%=cid%> .setDryRun(true).build();
-          com.google.cloud.bigquery.Job jobDryRun_<%=cid%> = bigquery_<%=cid%>.create(com.google.cloud.bigquery.JobInfo.of(jobConfDryRun_<%=cid%>));
-
-          String queryLocation_<%=cid%> =jobDryRun_<%=cid%>.getJobId().getLocation();
-          String location_<%=cid%> = queryLocation_<%=cid%> == null ? "US" : queryLocation_<%=cid%>;
-          String tempDataset_<%=cid%> = java.util.UUID.randomUUID().toString().replaceAll("-", "")
-             + Integer.toHexString(java.util.concurrent.ThreadLocalRandom.current().nextInt())
-             + Integer.toHexString(java.util.concurrent.ThreadLocalRandom.current().nextInt());
-
-              <% if(isLog4jEnabled){	%>
-                  log.info("<%=cid%> - query location :" + queryLocation_<%=cid%>);
-                  log.info("<%=cid%> - temporary dataset location :" + location_<%=cid%>);
-                  log.info("<%=cid%> - temporary Dataset name : " + tempDataset_<%=cid%>);
-
-              <% } %>
-
-         com.google.cloud.bigquery.DatasetInfo datasetInfo_<%=cid%> = com.google.cloud.bigquery.DatasetInfo.newBuilder(tempDataset_<%=cid%>).setLocation(location_<%=cid%>).build();
-         com.google.cloud.bigquery.Dataset dataset_<%=cid%> = bigquery_<%=cid%> .create(datasetInfo_<%=cid%>);
-<%
-         }
-%>
-          String tempTable_<%=cid%> = java.util.UUID.randomUUID().toString().replaceAll("-", "")
-             + Integer.toHexString(java.util.concurrent.ThreadLocalRandom.current().nextInt())
-             + Integer.toHexString(java.util.concurrent.ThreadLocalRandom.current().nextInt());
-          <% if(isLog4jEnabled){	%>
-              log.info("<%=cid%> - temporary table name : " + tempTable_<%=cid%>);
-<%
-            }
-%>
-         queryConfiguration_<%=cid%>
-             .setDryRun(false)
-             .setAllowLargeResults(true)
-             .setDestinationTable(com.google.cloud.bigquery.TableId.of(tempDataset_<%=cid%>, tempTable_<%=cid%>));
-
-         com.google.cloud.bigquery.JobId jobId_<%=cid%>  = com.google.cloud.bigquery.JobId
-						.newBuilder().setProject(<%=projectId%>)
-						.setJob(java.util.UUID.randomUUID().toString())
-						.build();
-
-		       <% if(isLog4jEnabled){ %>
-			     log.info("<%=cid%> - job location : " + jobId_<%=cid%>.getLocation());
-		      <% } %>
-		 <% } else { %>
-		    com.google.cloud.bigquery.JobId jobId_<%=cid%> = com.google.cloud.bigquery.JobId.of(<%=projectId%>,java.util.UUID.randomUUID().toString());
-
-	   <% } %>
-	       com.google.cloud.bigquery.Job job_<%=cid%> = bigquery_<%=cid%>.create(com.google.cloud.bigquery.JobInfo.newBuilder(queryConfiguration_<%=cid%>.build()).setJobId(jobId_<%=cid%>).build());
-
-
-		<% if(isLog4jEnabled) {	%>
-			log.info("<%=cid%> - Sending job " + jobId_<%=cid%> + " with query: " + <%=query%>);
-		<% } %>
-
-		job_<%=cid%> = job_<%=cid%>.waitFor();
+		com.google.cloud.bigquery.Job job_<%=cid%> = serviceAccountBigQueryUtil_<%=cid%>.executeQuery(<%=query%>, <%=useLegacySql%>);
 
 		if (job_<%=cid%> == null) {
 			throw new RuntimeException("Job no longer exists");
@@ -368,9 +302,13 @@
 			throw new RuntimeException(job_<%=cid%>.getStatus().getError().toString());
 		}
 
-		<% if(isLog4jEnabled) { %>
-			log.info("<%=cid%> - Job " + jobId_<%=cid%> + " finished successfully.");
-		<% } %>
+		<%
+			if(isLog4jEnabled){
+		%>
+			log.info("<%=cid%> - Retrieving records from dataset.");
+		<%
+			}
+		%>
 		com.google.cloud.bigquery.TableResult result_<%=cid%> = job_<%=cid%>.getQueryResults();
 		//Dynamic start
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryInput/tBigQueryInput_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryInput/tBigQueryInput_begin.javajet
@@ -279,12 +279,6 @@
 	<%
 	} else if (authMode.equals("SERVICEACCOUNT")) {
 	%>
-		final String PROJECT_ID_<%=cid%> = <%=projectId%>;
-		com.google.auth.oauth2.GoogleCredentials credentials_<%=cid%>;
-		java.io.File credentialsFile_<%=cid%> = new java.io.File(<%=credentialsFile%>);
-		try(java.io.FileInputStream credentialsStream_<%=cid%> = new java.io.FileInputStream(credentialsFile_<%=cid%>)) {
-		    credentials_<%=cid%> = com.google.auth.oauth2.ServiceAccountCredentials.fromStream(credentialsStream_<%=cid%>);
-		}
 
 		<%@ include file="@{org.talend.designer.components.localprovider}/components/tBigQueryInput/ServiceAccountBigQueryHelper.javajet"%>
 
@@ -292,15 +286,9 @@
 			log.info("<%=cid%> - query " + <%=query%>);
 		<% } %>
 
-		ServiceAccountBigQueryUtil_<%=cid%> serviceAccountBigQueryUtil_<%=cid%> = new ServiceAccountBigQueryUtil_<%=cid%>(PROJECT_ID_<%=cid%>, <%=credentialsFile%>, "<%=resultSizeType%>", <%=tempDataset%>);
+		ServiceAccountBigQueryUtil_<%=cid%> serviceAccountBigQueryUtil_<%=cid%> = new ServiceAccountBigQueryUtil_<%=cid%>();
 
 		com.google.cloud.bigquery.Job job_<%=cid%> = serviceAccountBigQueryUtil_<%=cid%>.executeQuery(<%=query%>, <%=useLegacySql%>);
-
-		if (job_<%=cid%> == null) {
-			throw new RuntimeException("Job no longer exists");
-		} else if (job_<%=cid%>.getStatus().getError() != null) {
-			throw new RuntimeException(job_<%=cid%>.getStatus().getError().toString());
-		}
 
 		<%
 			if(isLog4jEnabled){

--- a/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryInput/tBigQueryInput_end.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryInput/tBigQueryInput_end.javajet
@@ -28,18 +28,8 @@ imports="
   	} else if (authMode.equals("SERVICEACCOUNT")) {
   	%>
   		}
-        <% if (resultSizeType.equals("LARGE") || resultSizeType.equals("AUTO")) {
-              if (isCustomTemporaryName) {
-%>
-                  bigquery_<%=cid%>.delete(com.google.cloud.bigquery.TableId.of(tempDataset_<%=cid%>, tempTable_<%=cid%>));
-<%
-              } else {
-%>
-                  com.google.cloud.bigquery.DatasetId datasetId_<%=cid%> = com.google.cloud.bigquery.DatasetId.of(<%=projectId%>, tempDataset_<%=cid%>);
-                  bigquery_<%=cid%>.delete(datasetId_<%=cid%>, com.google.cloud.bigquery.BigQuery.DatasetDeleteOption.deleteContents());
-<%
-              }
-          }
+        serviceAccountBigQueryUtil_<%=cid%>.cleanup();
+        <%
       } else {
           throw new IllegalArgumentException("authentication mode should be either \"SERVICEACCOUNT\" or \"OAUTH\", but it is " + authMode);
       }


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

https://jira.talendforge.org/browse/TDI-42951

The component tBigQueryInput in case of Authentication Mode - Service Account & Result Size - Auto -> executes a query always as for large results. Auto result size uses when the volume of the query result is not certain. So we we use much more resources than we need during Auto result size.

**What is the new behavior?**

Now during Auto result size, component will try to perform small, in case of error - large

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


