### PR TITLE
fix(TCOMP-1677): correct configuration value for non String context item

### DIFF
--- a/main/plugins/org.talend.sdk.component.studio-integration/jet_stub/generic/configuration.javajet
+++ b/main/plugins/org.talend.sdk.component.studio-integration/jet_stub/generic/configuration.javajet
@@ -113,7 +113,10 @@ final java.util.Map<String, String> configuration_<%=cid%> = new java.util.HashM
                     }
                 } else {
                     value = ElementParameterParser.getStringElementParameterValue(p);
-                    if (!org.talend.core.model.utils.ContextParameterUtils.isDynamic(value)) {
+                    if (org.talend.core.model.utils.ContextParameterUtils.isDynamic(value)) {
+                        value = "String.valueOf(" + value + ")";
+                    }
+                    else {
                         value = org.talend.core.model.utils.TalendTextUtils.removeQuotes(value);
                         value = org.talend.core.model.utils.TalendTextUtils.addQuotes(value);
                     }


### PR DESCRIPTION
 set correct configuration value for non String context item

**What is the current behavior?** (You can also link to an open issue here)

For tacokit components, when using a context item that is not a String type, there's compilation error due to the fact the type do not match the Map<String, String> for component's configuration.

**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


