### PR TITLE
fix(TUP-26539): Add back standard job node

### DIFF
--- a/main/plugins/org.talend.repository.view.di/src/main/java/org/talend/repository/view/di/viewer/tester/StandardJobNodePropertyTester.java
+++ b/main/plugins/org.talend.repository.view.di/src/main/java/org/talend/repository/view/di/viewer/tester/StandardJobNodePropertyTester.java
@@ -40,9 +40,8 @@ public class StandardJobNodePropertyTester extends AbstractNodeTester {
             ProjectRepositoryNode root = (ProjectRepositoryNode) repositoryNode.getRoot();
             // FIXME, only load the related plugin, then can display the standard node, else same TOS, only Job Designs
             // with standard job by default, and be children directly.
-            if (root != null
-                    && (PluginChecker.isStormPluginLoader() || PluginChecker.isMapReducePluginLoader() || PluginChecker
-                            .isJobLetPluginLoaded())) {
+            if ((repositoryNode instanceof ProjectRepositoryNode || root != null) && (PluginChecker.isStormPluginLoader()
+                    || PluginChecker.isMapReducePluginLoader() || PluginChecker.isJobLetPluginLoaded())) {
                 return true;
             }
         }


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TUP-26539

**What is the new behavior?**
If it is ProjectRepositoryNode or its root is not null, add "standard job" node.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


