### PR TITLE
fix(TDI-44010): Fix adding NBLine to globalMap

### DIFF
--- a/main/plugins/org.talend.sdk.component.studio-integration/jet_stub/generic/input/input_end.javajet
+++ b/main/plugins/org.talend.sdk.component.studio-integration/jet_stub/generic/input/input_end.javajet
@@ -43,5 +43,6 @@ final String cid = node.getUniqueName();
             }
         }
     }
+    globalMap.put("<%=cid %>_NB_LINE", nbLineInput_<%=cid%>);
     globalMap.remove("mapper_<%=cid%>");
     globalMap.remove("input_<%=cid%>");

--- a/main/plugins/org.talend.sdk.component.studio-integration/jet_stub/generic/processor/processor_end.javajet
+++ b/main/plugins/org.talend.sdk.component.studio-integration/jet_stub/generic/processor/processor_end.javajet
@@ -53,4 +53,5 @@
         processor_<%=cid%>.stop();
     }
 
+    globalMap.put("<%=cid %>_NB_LINE", nbLineInput_<%=cid%>);
     globalMap.remove("processor_<%=cid%>");


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-44010
NB_Line is null when there are not entries for iteration for Input and Output components

**What is the new behavior?**
Now NB_Line is add to globalMap in the ending javajet by default


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


