### PR TITLE
fix(TDI-44129):  Spatial / PostGIS / Error on GeomFromText

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/templates/db_output_bulk.skeleton
+++ b/main/plugins/org.talend.designer.components.localprovider/components/templates/db_output_bulk.skeleton
@@ -156,7 +156,7 @@ public class CLASS {
                     if ("MDSYS.SDO_GEOMETRY".equalsIgnoreCase(this.getColumn().getType())) {
                         return "?";
                     } else {
-                        return "GeomFromText(?, ?)";    // For PostGIS
+                        return "ST_GeomFromText(?, ?)";    // For PostGIS
                     }
                 } else {
                     return this.sqlStmt;


### PR DESCRIPTION
Fix for:
* https://github.com/talend-spatial/talend-spatial/issues/82
* https://jira.talendforge.org/browse/TDI-44129

See https://postgis.net/docs/reference.html

```
	
PostGIS has begun a transition from the existing naming convention to an SQL-MM-centric convention. As a result, most of the functions that you know and love have been renamed using the standard spatial type (ST) prefix. Previous functions are still available, though are not listed in this document where updated functions are equivalent. The non ST_ functions not listed in this documentation are deprecated and will be removed in a future release so STOP USING THEM.
```

**What is the current behavior?** 

DB exception


**What is the new behavior?**

No exception

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard

**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No


