### PR TITLE
TUP-27026 - Update Log4j 2 to 2.13.2

### DIFF
--- a/main/plugins/org.talend.designer.components.libs/libs_src/talend-job-monitoring/pom.xml
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/talend-job-monitoring/pom.xml
@@ -9,6 +9,7 @@
     <version>1.1</version>
 	
 	<properties>
+        <log4j2.version>2.13.2</log4j2.version>
 		<talend.nexus.url>https://artifacts-oss.talend.com</talend.nexus.url>
 	</properties>
 	
@@ -78,13 +79,13 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.12.1</version>
+            <version>${log4j2.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.12.1</version>
+            <version>${log4j2.version}</version>
             <optional>true</optional>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This task is to update Log4j 2 to 2.13.2 due to the following CVE:

[CVE-2020-9488] Improper validation of certificate with host mismatch in Apache Log4j SMTP appender

https://seclists.org/oss-sec/2020/q2/72

 