### PR TITLE
TDI-44140 - Update Commons Compress to 1.19

### DIFF
--- a/main/plugins/org.talend.libraries.excel/pom.xml
+++ b/main/plugins/org.talend.libraries.excel/pom.xml
@@ -53,7 +53,7 @@
 								<artifactItem>
 									<groupId>org.apache.commons</groupId>
 									<artifactId>commons-compress</artifactId>
-									<version>1.18</version>
+									<version>1.19</version>
 								</artifactItem>
 								<artifactItem>
 									<groupId>org.apache.commons</groupId>


### PR DESCRIPTION
This task is to update Commons Compress to at least version 1.19 to pick up some CVE fixes (https://commons.apache.org/proper/commons-compress/security-reports.html#Apache_Commons_Compress_Security_Vulnerabilities)