### PR TITLE
fix(TDI-44174): Component manager is not thread safe

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tRunJob/tRunJob_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tRunJob/tRunJob_main.javajet
@@ -249,7 +249,10 @@ String inputConnName = null;
 			}
 
 			<% if(useIndependentProcess){ %>
-		  		paraList_<%=cid %>.add("-Dtalend.component.manager.m2.repository=" + System.getProperty("talend.component.manager.m2.repository"));
+			    String m2 = System.getProperty("talend.component.manager.m2.repository");
+		  		if (m2 != null){
+		  		  paraList_<%=cid %>.add("-Dtalend.component.manager.m2.repository=" + m2);
+		  		}
 			<%}%>
 
 			<%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tRunJob/tRunJob_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tRunJob/tRunJob_main.javajet
@@ -246,6 +246,7 @@ String inputConnName = null;
 	    			}
 		  		}
 		  		%>
+		  		paraList_<%=cid %>.add("-Dtalend.component.manager.m2.repository=" + System.getProperty("talend.component.manager.m2.repository"));
 			}
 			
 			<%

--- a/main/plugins/org.talend.designer.components.localprovider/components/tRunJob/tRunJob_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tRunJob/tRunJob_main.javajet
@@ -246,9 +246,12 @@ String inputConnName = null;
 	    			}
 		  		}
 		  		%>
-		  		paraList_<%=cid %>.add("-Dtalend.component.manager.m2.repository=" + System.getProperty("talend.component.manager.m2.repository"));
 			}
-			
+
+			<% if(useIndependentProcess){ %>
+		  		paraList_<%=cid %>.add("-Dtalend.component.manager.m2.repository=" + System.getProperty("talend.component.manager.m2.repository"));
+			<%}%>
+
 			<%
 			if(use_custom_jvm_setting) {
 			%>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tRunJob/tRunJob_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tRunJob/tRunJob_main.javajet
@@ -248,12 +248,12 @@ String inputConnName = null;
 		  		%>
 			}
 
-			<% if(useIndependentProcess){ %>
-			    String m2 = System.getProperty("talend.component.manager.m2.repository");
-		  		if (m2 != null){
-		  		  paraList_<%=cid %>.add("-Dtalend.component.manager.m2.repository=" + m2);
-		  		}
-			<%}%>
+            <% if(useIndependentProcess){ %>
+                String m2 = System.getProperty("talend.component.manager.m2.repository");
+                if (m2 != null){
+                    paraList_<%=cid %>.add("-Dtalend.component.manager.m2.repository=" + m2);
+                }
+            <%}%>
 
 			<%
 			if(use_custom_jvm_setting) {


### PR DESCRIPTION
- this fixes the case when run as independent job is checked and the `m2.repository` automatically defaults to user's m2 in exported job.
- issue on singleton will be fix by component-runtime upgrade.

https://jira.talendforge.org/browse/TDI-44174

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


