### PR TITLE
TESB-29285, TESB-29284 Error occurred when execute a microservice jar which is built by a tresrequest job with embedded trestclient job

### DIFF
--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/DefaultRunProcessService.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/DefaultRunProcessService.java
@@ -242,7 +242,8 @@ public class DefaultRunProcessService implements IRunProcessService {
         if (GlobalServiceRegister.getDefault().isServiceRegistered(IESBMicroService.class)) {
             microService = GlobalServiceRegister.getDefault().getService(IESBMicroService.class);
 
-            if (ProcessorUtilities.isExportJobAsMicroService()) {
+            if (ProcessorUtilities.isExportJobAsMicroService() && property != null && property.getAdditionalProperties() != null
+                    && "REST_MS".equals(property.getAdditionalProperties().get(TalendProcessArgumentConstant.ARG_BUILD_TYPE))) {
                 if (microService != null) {
                     IProcessor processor = microService.createJavaProcessor(process, property, filenameFromLabel, false);
                     if (processor != null) {

--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/DefaultRunProcessService.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/DefaultRunProcessService.java
@@ -242,15 +242,6 @@ public class DefaultRunProcessService implements IRunProcessService {
         if (GlobalServiceRegister.getDefault().isServiceRegistered(IESBMicroService.class)) {
             microService = GlobalServiceRegister.getDefault().getService(IESBMicroService.class);
 
-            if (ProcessorUtilities.isExportJobAsMicroService() && property != null && property.getAdditionalProperties() != null
-                    && "REST_MS".equals(property.getAdditionalProperties().get(TalendProcessArgumentConstant.ARG_BUILD_TYPE))) {
-                if (microService != null) {
-                    IProcessor processor = microService.createJavaProcessor(process, property, filenameFromLabel, false);
-                    if (processor != null) {
-                        return processor;
-                    }
-                }
-            }
             if (property != null && property.getAdditionalProperties() != null
                     && "REST_MS".equals(property.getAdditionalProperties().get(TalendProcessArgumentConstant.ARG_BUILD_TYPE))) {
                 if (microService != null) {

--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/JavaJobScriptsExportWSWizardPage.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/JavaJobScriptsExportWSWizardPage.java
@@ -461,12 +461,11 @@ public class JavaJobScriptsExportWSWizardPage extends JavaJobScriptsExportWizard
                 if (exportType == JobExportType.ROUTE || exportType == JobExportType.SERVICE) {
                     continue;
                 } else if (exportType.equals(JobExportType.OSGI)) {
-                    if (isESBJob && "OSGI".equals(getProcessItem().getProperty().getAdditionalProperties().get(TalendProcessArgumentConstant.ARG_BUILD_TYPE))) {
+                    if (isESBJob) {
                         exportTypeCombo.add(exportType.label);
                     }
                 } else if (exportType.equals(JobExportType.MSESB)) {
-                    if (GlobalServiceRegister.getDefault().isServiceRegistered(IESBMicroService.class) && canESBMicroServiceJob &&
-                             "REST_MS".equals(getProcessItem().getProperty().getAdditionalProperties().get(TalendProcessArgumentConstant.ARG_BUILD_TYPE))) {
+                    if (GlobalServiceRegister.getDefault().isServiceRegistered(IESBMicroService.class) && canESBMicroServiceJob) {
                         exportTypeCombo.add(exportType.label);
                     } else {
                         // reset export type to POJO
@@ -475,8 +474,7 @@ public class JavaJobScriptsExportWSWizardPage extends JavaJobScriptsExportWizard
                         }
                     }
                 } else if (exportType.equals(JobExportType.MSESB_IMAGE)) {
-                    if (GlobalServiceRegister.getDefault().isServiceRegistered(IESBMicroService.class) && canESBMicroServiceJob&&
-                             "REST_MS".equals(getProcessItem().getProperty().getAdditionalProperties().get(TalendProcessArgumentConstant.ARG_BUILD_TYPE))) {
+                    if (GlobalServiceRegister.getDefault().isServiceRegistered(IESBMicroService.class) && canESBMicroServiceJob) {
                         if(canESBMicroServiceDockerImage) {
                             exportTypeCombo.add(exportType.label);
                         }

--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/JavaJobScriptsExportWSWizardPage.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/JavaJobScriptsExportWSWizardPage.java
@@ -461,11 +461,12 @@ public class JavaJobScriptsExportWSWizardPage extends JavaJobScriptsExportWizard
                 if (exportType == JobExportType.ROUTE || exportType == JobExportType.SERVICE) {
                     continue;
                 } else if (exportType.equals(JobExportType.OSGI)) {
-                    if (isESBJob) {
+                    if (isESBJob && "OSGI".equals(getProcessItem().getProperty().getAdditionalProperties().get(TalendProcessArgumentConstant.ARG_BUILD_TYPE))) {
                         exportTypeCombo.add(exportType.label);
                     }
                 } else if (exportType.equals(JobExportType.MSESB)) {
-                    if (GlobalServiceRegister.getDefault().isServiceRegistered(IESBMicroService.class) && canESBMicroServiceJob) {
+                    if (GlobalServiceRegister.getDefault().isServiceRegistered(IESBMicroService.class) && canESBMicroServiceJob &&
+                             "REST_MS".equals(getProcessItem().getProperty().getAdditionalProperties().get(TalendProcessArgumentConstant.ARG_BUILD_TYPE))) {
                         exportTypeCombo.add(exportType.label);
                     } else {
                         // reset export type to POJO
@@ -474,7 +475,8 @@ public class JavaJobScriptsExportWSWizardPage extends JavaJobScriptsExportWizard
                         }
                     }
                 } else if (exportType.equals(JobExportType.MSESB_IMAGE)) {
-                    if (GlobalServiceRegister.getDefault().isServiceRegistered(IESBMicroService.class) && canESBMicroServiceJob) {
+                    if (GlobalServiceRegister.getDefault().isServiceRegistered(IESBMicroService.class) && canESBMicroServiceJob&&
+                             "REST_MS".equals(getProcessItem().getProperty().getAdditionalProperties().get(TalendProcessArgumentConstant.ARG_BUILD_TYPE))) {
                         if(canESBMicroServiceDockerImage) {
                             exportTypeCombo.add(exportType.label);
                         }


### PR DESCRIPTION
Currently if we are building Job (parent) as microservice and the Job contains child Job,
this child Jobs also will be automatically build as microservice, even if it supports only OSGI or Standalone build type. So we only need to check what is the real build type of the Job (and this check `ProcessorUtilities.isExportJobAsMicroService()` isn't needed)