### PR TITLE
fix(TUP-27374): Get default jvm arguments

### DIFF
--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/java/JavaProcessor.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/java/JavaProcessor.java
@@ -1688,11 +1688,10 @@ public class JavaProcessor extends AbstractJavaProcessor implements IJavaBreakpo
             List<String> vmList = new JobVMArgumentsUtil().readString(replaceAll);
             vmargs = vmList.toArray(new String[0]);
         } catch (Exception e) {
-            LOGGER.error(e);
+            LOGGER.debug(e.getMessage(), e);
             // UI can not be loaded, use default jvm args
             vmargs = JobVMArgumentsUtil.DEFAULT_JVM_ARGS;
         }
-        LOGGER.info("vmargs: " + vmargs);
         return vmargs;
     }
 

--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/java/JavaProcessor.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/java/JavaProcessor.java
@@ -41,6 +41,7 @@ import java.util.zip.ZipInputStream;
 
 import org.apache.commons.codec.binary.Base64InputStream;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Logger;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IMarker;
@@ -215,6 +216,8 @@ public class JavaProcessor extends AbstractJavaProcessor implements IJavaBreakpo
     private String jobId;
 
     private String jobVersion;
+
+    private static final Logger LOGGER = Logger.getLogger(JavaProcessor.class);
 
     /**
      * Set current status.
@@ -1658,13 +1661,22 @@ public class JavaProcessor extends AbstractJavaProcessor implements IJavaBreakpo
                 }
             }
         }
-        // if not check or the value is empty, should use preference
-        if (string == null || "".equals(string)) { //$NON-NLS-1$
-            string = RunProcessPlugin.getDefault().getPreferenceStore().getString(RunProcessPrefsConstants.VMARGUMENTS);
+        // https://jira.talendforge.org/browse/TUP-27374
+        String[] vmargs = null;
+        try {
+            // if not check or the value is empty, should use preference
+            if (string == null || "".equals(string)) { //$NON-NLS-1$
+                string = RunProcessPlugin.getDefault().getPreferenceStore().getString(RunProcessPrefsConstants.VMARGUMENTS);
+            }
+            String replaceAll = string.trim();
+            List<String> vmList = new JobVMArgumentsUtil().readString(replaceAll);
+            vmargs = vmList.toArray(new String[0]);
+        } catch (Exception e) {
+            LOGGER.error(e);
+            // UI can not be loaded, use default jvm args
+            vmargs = JobVMArgumentsUtil.DEFAULT_JVM_ARGS;
         }
-        String replaceAll = string.trim();
-        List<String> vmList = new JobVMArgumentsUtil().readString(replaceAll);
-        String[] vmargs = vmList.toArray(new String[0]);
+        LOGGER.info("vmargs: " + vmargs);
         return vmargs;
     }
 

--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/prefs/RunProcessPreferenceInitializer.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/prefs/RunProcessPreferenceInitializer.java
@@ -28,6 +28,7 @@ import org.talend.designer.maven.template.AbstractMavenTemplateManager;
 import org.talend.designer.maven.template.MavenTemplateManager;
 import org.talend.designer.runprocess.IRunProcessService;
 import org.talend.designer.runprocess.RunProcessPlugin;
+import org.talend.designer.runprocess.utils.JobVMArgumentsUtil;
 
 import us.monoid.json.JSONArray;
 import us.monoid.json.JSONException;
@@ -54,8 +55,9 @@ public class RunProcessPreferenceInitializer extends AbstractPreferenceInitializ
         JSONObject root = new JSONObject();
         try {
             JSONArray args = new JSONArray();
-            args.put("-Xms256M");//$NON-NLS-1$
-            args.put("-Xmx1024M");//$NON-NLS-1$
+            for (String arg : JobVMArgumentsUtil.DEFAULT_JVM_ARGS) {
+                args.put(arg);
+            }
             root.put("JOB_RUN_VM_ARGUMENTS", args);//$NON-NLS-1$
         } catch (JSONException e) {
             ExceptionHandler.process(e);

--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/utils/JobVMArgumentsUtil.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/utils/JobVMArgumentsUtil.java
@@ -29,6 +29,8 @@ public class JobVMArgumentsUtil {
 
     private static final List<String> EMPTY_STRING_LIST = Collections.unmodifiableList(new ArrayList<String>());
 
+    public static final String[] DEFAULT_JVM_ARGS = new String[] { "-Xms256M", "-Xmx1024M" };
+
     public List<String> readString(String stringList) {
         if (stringList == null || "".equals(stringList)) { //$NON-NLS-1$
             return EMPTY_STRING_LIST;

--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/utils/JobVMArgumentsUtil.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/utils/JobVMArgumentsUtil.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.log4j.Logger;
 import org.talend.commons.exception.ExceptionHandler;
 
 import us.monoid.json.JSONArray;
@@ -26,6 +27,8 @@ import us.monoid.json.JSONObject;
  * DOC hwang  class global comment. Detailled comment
  */
 public class JobVMArgumentsUtil {
+
+    private static final Logger LOGGER = Logger.getLogger(JobVMArgumentsUtil.class);
 
     private static final List<String> EMPTY_STRING_LIST = Collections.unmodifiableList(new ArrayList<String>());
 
@@ -46,7 +49,10 @@ public class JobVMArgumentsUtil {
                 }
             }
         } catch (JSONException e) {
-            ExceptionHandler.process(e);
+            for (String arg : JobVMArgumentsUtil.DEFAULT_JVM_ARGS) {
+                result.add(arg);
+            }
+            LOGGER.debug(e.getMessage(), e);
         }
         return result;
     }


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TUP-27374

**What is the new behavior?**
Get default jvm arguments if studio can not load it from preference store.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


