### PR TITLE
TDI-44342 : Ignore microseconds in BigQuery datetime

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryInput/tBigQueryInput_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryInput/tBigQueryInput_begin.javajet
@@ -529,7 +529,12 @@
 									%>
 
 										if (value_<%=cid%>.toString().contains("-")) {
-											<%=connName%>.<%=columnName%> = ParserUtils.parseTo_Date(value_<%=cid%>.toString(),<%=patternValue%>);
+											String sValue_<%=cid%> = value_<%=cid%>.toString();
+											if (sValue_<%=cid%>.matches(".*\\.\\d{6}")) {
+												// microseconds must be ignored
+												sValue_<%=cid%> = sValue_<%=cid%>.substring(0, sValue_<%=cid%>.length() - 3);
+											}
+											<%=connName%>.<%=columnName%> = ParserUtils.parseTo_Date(sValue_<%=cid%>,<%=patternValue%>);
 										} else {
 											<%=connName%>.<%=columnName%> = ParserUtils.parseTo_Date(value_<%=cid%>.toString());
 										}

--- a/main/plugins/org.talend.designer.components.localprovider/components/tBigQuerySQLRow/tBigQuerySQLRow_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tBigQuerySQLRow/tBigQuerySQLRow_main.javajet
@@ -183,8 +183,18 @@
 										<%=connName%>.<%=columnName%> = value_<%=cid%>;
 									<%		
 									} else if(javaType == JavaTypesManager.DATE) {						
-									%>					
-										<%=connName%>.<%=columnName%> = ParserUtils.parseTo_Date(value_<%=cid%>.toString());				
+									%>
+										if (value_<%=cid%>.toString().contains("-")) {
+											String sValue_<%=cid%> = value_<%=cid%>.toString();
+											if (sValue_<%=cid%>.matches(".*\\.\\d{6}")) {
+												// microseconds must be ignored
+												sValue_<%=cid%> = sValue_<%=cid%>.substring(0, sValue_<%=cid%>.length() - 3);
+											}
+
+											<%=connName%>.<%=columnName%> = ParserUtils.parseTo_Date(sValue_<%=cid%>,<%=patternValue%>);
+										} else{
+											<%=connName%>.<%=columnName%>=ParserUtils.parseTo_Date(value_<%=cid%>.toString());
+										}
 									<%		
 									} else if(advancedSeparator && JavaTypesManager.isNumberType(javaType)) { 
 									%>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TDI-44342

**What is the current behavior?** (You can also link to an open issue here)
DateTime columns are not correctly read from BigQuery. This is because BigQuery stores date with a microsecond precision while Java can only hanlde to milliseconds.

**What is the new behavior?**
The datetime string is cut to remove the last three digits to conform to java Date precision.

**What kind of change does this PR introduce?**

- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x ] No




