### PR TITLE
TDI-44374 - Update BeanUtils to 1.9.4 in talend-ws

### DIFF
--- a/main/plugins/org.talend.designer.components.libs/libs_src/talend-ws/pom.xml
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/talend-ws/pom.xml
@@ -85,7 +85,7 @@
 		<dependency>
 			<groupId>commons-beanutils</groupId>
 			<artifactId>commons-beanutils</artifactId>
-			<version>1.8.3</version>
+			<version>1.9.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.cxf</groupId>


### PR DESCRIPTION
Veracode is reporting a high level CVE against BeanShell 1.8.3 in:

tdi-studio-se/main/plugins/org.talend.designer.components.libs/libs_src/talend-ws
This task is to update it to 1.9.4.