### PR TITLE
TESB-29285 Error occurred when execute a microservice jar which is built by a tresrequest job with embedded trestclient job

### DIFF
--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/DefaultRunProcessService.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/DefaultRunProcessService.java
@@ -242,14 +242,6 @@ public class DefaultRunProcessService implements IRunProcessService {
         if (GlobalServiceRegister.getDefault().isServiceRegistered(IESBMicroService.class)) {
             microService = GlobalServiceRegister.getDefault().getService(IESBMicroService.class);
 
-            if (ProcessorUtilities.isExportJobAsMicroService()) {
-                if (microService != null) {
-                    IProcessor processor = microService.createJavaProcessor(process, property, filenameFromLabel, false);
-                    if (processor != null) {
-                        return processor;
-                    }
-                }
-            }
             if (property != null && property.getAdditionalProperties() != null
                     && "REST_MS".equals(property.getAdditionalProperties().get(TalendProcessArgumentConstant.ARG_BUILD_TYPE))) {
                 if (microService != null) {


### PR DESCRIPTION
Currently if we are building Job (parent) as microservice and the Job contains child Job,
this child Jobs also will be automatically build as microservice, even if it supports only OSGI or Standalone build type. So we only need to check what is the real build type of the Job (and this check `ProcessorUtilities.isExportJobAsMicroService()` isn't needed)