### PR TITLE
TESB-29690 Ensure WSDL is included in WS consumer build.

### DIFF
--- a/main/plugins/org.talend.designer.maven.job/resources/templates/osgi/assembly_job_template.xml
+++ b/main/plugins/org.talend.designer.maven.job/resources/templates/osgi/assembly_job_template.xml
@@ -14,6 +14,7 @@
             <outputDirectory>${file.separator}</outputDirectory>
             <includes>
                 <include>${talend.job.path}/**/*.class</include>
+                <include>${talend.job.path}/**/*.wsdl</include>
                 <include>__tdm/**</include>
             </includes>
         </fileSet>
@@ -22,8 +23,8 @@
             <outputDirectory>${file.separator}</outputDirectory>
             <includes>
                 <include>OSGI-INF/**</include>
-        				<include>TALEND-INF/**</include>
-        				<include>MAVEN-INF/**</include>
+                <include>TALEND-INF/**</include>
+                <include>MAVEN-INF/**</include>
             </includes>
         </fileSet>
         <fileSet> <!-- add resources -->
@@ -46,8 +47,8 @@
             <includes>
                 <include>**</include>
             </includes>
-        </fileSet>	
-        
+        </fileSet>
+
         <fileSet> <!-- add metadata -->
             <directory>${basedir}/src/main/resources</directory>
             <outputDirectory>${file.separator}</outputDirectory>
@@ -55,7 +56,7 @@
                 <include>metadata/**</include>
             </includes>
         </fileSet>
-        
+
         <fileSet>
             <directory>${current.resources.dir}</directory>
             <outputDirectory>${file.separator}</outputDirectory>

--- a/main/plugins/org.talend.designer.maven.job/resources/templates/osgi/assembly_route_template.xml
+++ b/main/plugins/org.talend.designer.maven.job/resources/templates/osgi/assembly_route_template.xml
@@ -1,67 +1,68 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <assembly
-	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
-	<id>jar-with-dependencies</id>
-	<includeBaseDirectory>false</includeBaseDirectory>
-	<formats>
-		<format>jar</format>
-	</formats>
+    xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>jar-with-dependencies</id>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <formats>
+        <format>jar</format>
+    </formats>
 
-	<fileSets>
+    <fileSets>
 
-		<fileSet> <!-- add java classes -->
-			<directory>${project.build.outputDirectory}</directory>
-			<outputDirectory>${file.separator}</outputDirectory>
-			<includes>
-				<include>${talend.job.path}/**/*.class</include>
-				<include>__tdm/**</include>
-			</includes>
-		</fileSet>
-		
-		<fileSet> <!-- add osgi resources -->
-			<directory>${current.bundle.resources.dir}</directory>
-			<outputDirectory>${file.separator}</outputDirectory>
-			<includes>
-				<include>OSGI-INF/**</include>
-				<include>TALEND-INF/**</include>
-				<include>MAVEN-INF/**</include>
-			</includes>
-		</fileSet>
+        <fileSet> <!-- add java classes -->
+            <directory>${project.build.outputDirectory}</directory>
+            <outputDirectory>${file.separator}</outputDirectory>
+            <includes>
+                <include>${talend.job.path}/**/*.class</include>
+                <include>${talend.job.path}/**/*.wsdl</include>
+                <include>__tdm/**</include>
+            </includes>
+        </fileSet>
 
-		<fileSet> <!-- add route resources -->
-			<directory>${current.bundle.resources.dir}/resources</directory>
-			<outputDirectory>${file.separator}</outputDirectory>
-			<includes>
-				<include>**</include>
-			</includes>
-		</fileSet>
+        <fileSet> <!-- add osgi resources -->
+            <directory>${current.bundle.resources.dir}</directory>
+            <outputDirectory>${file.separator}</outputDirectory>
+            <includes>
+                <include>OSGI-INF/**</include>
+                <include>TALEND-INF/**</include>
+                <include>MAVEN-INF/**</include>
+            </includes>
+        </fileSet>
 
-		<fileSet> <!-- add route lib -->
-			<directory>${current.bundle.resources.dir}/lib</directory>
-			<outputDirectory>lib</outputDirectory>
-			<includes>
-				<include>**</include>
-			</includes>
-		</fileSet>
+        <fileSet> <!-- add route resources -->
+            <directory>${current.bundle.resources.dir}/resources</directory>
+            <outputDirectory>${file.separator}</outputDirectory>
+            <includes>
+                <include>**</include>
+            </includes>
+        </fileSet>
 
-		<fileSet><!-- add context resources -->
-			<directory>${current.resources.dir}</directory>
-			<outputDirectory>${file.separator}</outputDirectory>
-			<includes>
-				<include>${talend.job.path}/**</include>
-			</includes>
-		</fileSet>
-		
-		<fileSet><!-- add context resources -->
-			<directory>${resources.path}</directory>
-			<outputDirectory>${file.separator}</outputDirectory>
-			<includes>
-				<include>${talend.job.path}/**</include>
-			</includes>
-		</fileSet>
-        
+        <fileSet> <!-- add route lib -->
+            <directory>${current.bundle.resources.dir}/lib</directory>
+            <outputDirectory>lib</outputDirectory>
+            <includes>
+                <include>**</include>
+            </includes>
+        </fileSet>
+
+        <fileSet> <!-- add context resources -->
+            <directory>${current.resources.dir}</directory>
+            <outputDirectory>${file.separator}</outputDirectory>
+            <includes>
+                <include>${talend.job.path}/**</include>
+            </includes>
+        </fileSet>
+
+        <fileSet> <!-- add context resources -->
+            <directory>${resources.path}</directory>
+            <outputDirectory>${file.separator}</outputDirectory>
+            <includes>
+                <include>${talend.job.path}/**</include>
+            </includes>
+        </fileSet>
+
         <fileSet> <!-- add provided-lib -->
             <directory>${current.bundle.resources.dir}/provided-lib</directory>
             <outputDirectory>lib</outputDirectory>
@@ -69,8 +70,8 @@
                 <include>**</include>
             </includes>
         </fileSet>
-	</fileSets>
-	
+    </fileSets>
+
 <!-- 	<dependencySets>
 		<dependencySet>
 			<outputDirectory>lib</outputDirectory>

--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/maven/MavenJavaProcessor.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/maven/MavenJavaProcessor.java
@@ -389,8 +389,9 @@ public class MavenJavaProcessor extends JavaProcessor {
         if (!isMainJob && isGoalInstall) {
             if (!buildCacheManager.isJobBuild(getProperty())) {
                 deleteExistedJobJarFile(talendJavaProject);
-                if ("ROUTE".equalsIgnoreCase(getBuildType(getProperty())) && project != null &&
-                		ERepositoryObjectType.PROCESS.equals(ERepositoryObjectType.getType(getProperty()))) {
+                String buildType = getBuildType(getProperty());
+                if (("ROUTE".equalsIgnoreCase(buildType) || "OSGI".equalsIgnoreCase(buildType)) && project != null &&
+                        ERepositoryObjectType.PROCESS.equals(ERepositoryObjectType.getType(getProperty()))) {
                     // TESB-23870
                     // child routes job project must be compiled explicitly for
                     // correct child job manifest generation during OSGi packaging


### PR DESCRIPTION
This fix includes fixes for TESB-27081 and TESB-27583 handling missing SOAP Action due to missing WSDL and TESB-2960 ensuring the WSDL is present for properly configuring the SOAP 1.2 binding.

**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TESB-27081
https://jira.talendforge.org/browse/TESB-27583
https://jira.talendforge.org/browse/TESB-29690

**What is the new behavior?**
The WSDL document is added as resource to jobs which are web service consumer, ensuring proper web service calls.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

The code changes of this PR are already included in published patches for Studio V7.1.1 and the productive codebase of Studio V7.3.1.
