### PR TITLE
TESB-29647 Bundle version does not use 'Custom Version' for jobs

### DIFF
--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/esb/JobJavaScriptOSGIForESBManager.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/esb/JobJavaScriptOSGIForESBManager.java
@@ -922,7 +922,14 @@ public class JobJavaScriptOSGIForESBManager extends JobJavaScriptsManager {
         }
         analyzer.setProperty(Analyzer.BUNDLE_NAME, bundleName);
         analyzer.setProperty(Analyzer.BUNDLE_SYMBOLICNAME, symbolicName);
-        analyzer.setProperty(Analyzer.BUNDLE_VERSION, getBundleVersion());
+        String bundleVersion = null;
+        if (processItem.getProperty().getAdditionalProperties() != null &&
+            processItem.getProperty().getAdditionalProperties().containsKey("USER_VERSION")) {
+            bundleVersion = (String) processItem.getProperty().getAdditionalProperties().get("USER_VERSION");
+        } else {
+            bundleVersion = getBundleVersion();
+        }
+        analyzer.setProperty(Analyzer.BUNDLE_VERSION, bundleVersion);
         IBrandingService brandingService = (IBrandingService) GlobalServiceRegister.getDefault().getService(
                 IBrandingService.class);
         analyzer.setProperty(Analyzer.BUNDLE_VENDOR, brandingService.getFullProductName() + " (" //$NON-NLS-1$


### PR DESCRIPTION
If the job's deployment "Custom Version" is different than that of the job's item version, then the job's bundle uses the job's item version instead of "Custom Version". This PR is to make bundle use "Custom Version"