### PR TITLE
TESB-29664 Random port will be used when REST Engpoint in tRESTRequest is empty

### DIFF
--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/esb/JobJavaScriptOSGIForESBManager.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/esb/JobJavaScriptOSGIForESBManager.java
@@ -603,7 +603,7 @@ public class JobJavaScriptOSGIForESBManager extends JobJavaScriptsManager {
             // TESB-24998 Add context bean in blueprint
             endpointInfo.put("useContextBean", true); //$NON-NLS-1$
             endpointInfo.put("defaultContext", processItem.getProcess().getDefaultContext()); //$NON-NLS-1$
-        } else if (!endpointUri.isEmpty() && !endpointUri.contains("://") && !endpointUri.startsWith("/")) { //$NON-NLS-1$ //$NON-NLS-2$
+        } else if (!endpointUri.contains("://") && !endpointUri.startsWith("/")) { //$NON-NLS-1$ //$NON-NLS-2$
             endpointUri = '/' + endpointUri;
         }
 


### PR DESCRIPTION
To fix this issue we can use '/' instead of empty endpoint. Then we can access service with this URL http://localhost:8040/services