### PR TITLE
TESB-27583 TESB-29690 Ensure WSDL is included in WS consumer build.

### DIFF
--- a/main/plugins/org.talend.designer.maven.job/resources/templates/osgi/assembly_job_template.xml
+++ b/main/plugins/org.talend.designer.maven.job/resources/templates/osgi/assembly_job_template.xml
@@ -14,6 +14,7 @@
             <outputDirectory>${file.separator}</outputDirectory>
             <includes>
                 <include>${talend.job.path}/**/*.class</include>
+                <include>${talend.job.path}/**/*.wsdl</include>
                 <include>__tdm/**</include>
             </includes>
         </fileSet>

--- a/main/plugins/org.talend.designer.maven.job/resources/templates/osgi/assembly_route_template.xml
+++ b/main/plugins/org.talend.designer.maven.job/resources/templates/osgi/assembly_route_template.xml
@@ -16,6 +16,7 @@
             <outputDirectory>${file.separator}</outputDirectory>
             <includes>
                 <include>${talend.job.path}/**/*.class</include>
+                <include>${talend.job.path}/**/*.wsdl</include>
                 <include>__tdm/**</include>
             </includes>
         </fileSet>

--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/maven/MavenJavaProcessor.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/maven/MavenJavaProcessor.java
@@ -389,7 +389,8 @@ public class MavenJavaProcessor extends JavaProcessor {
         if (!isMainJob && isGoalInstall) {
             if (!buildCacheManager.isJobBuild(getProperty())) {
                 deleteExistedJobJarFile(talendJavaProject);
-                if ("ROUTE".equalsIgnoreCase(getBuildType(getProperty())) && project != null &&
+                String buildType = getBuildType(getProperty());
+                if (("ROUTE".equalsIgnoreCase(buildType) || "OSGI".equalsIgnoreCase(buildType)) && project != null &&
                         ERepositoryObjectType.PROCESS.equals(ERepositoryObjectType.getType(getProperty()))) {
                     // TESB-23870
                     // child routes job project must be compiled explicitly for


### PR DESCRIPTION
This fix corrects TESB-27081 and TESB-27583 ensuring SOAP Action is set from binding definition in WSDL, and TESB-2960 ensuring the WSDL is present for properly configuring the SOAP 1.2 binding. This fix is identical with the temporarily reverted fix from pull request #4926.

**What is the current behavior?** (You can also link to an open issue here)
Due to missing WSDL resource WS clients configure default values which may be incompatible with the server side.

**What is the new behavior?**
Inclusion of the WSDL in WS clients built as OSGi bundles is ensured.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
This is a re-submit of PR #4926 which has already been approved but was temporarily reverted.

