### PR TITLE
fix(TUP-27588)tCreateTable data types mapping in the schema editor is

### DIFF
--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/cmd/ChangeValuesFromRepository.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/cmd/ChangeValuesFromRepository.java
@@ -358,7 +358,7 @@ public class ChangeValuesFromRepository extends ChangeMetadataCommand {
                     param.setRepositoryValue(repositoryValue);
                     param.setRepositoryValueUsed(true);
                 }
-                if (StringUtils.equals("MAPPING", param.getName())) {//$NON-NLS-1$
+                if (connection instanceof DatabaseConnection && StringUtils.equals("MAPPING", param.getName())) {//$NON-NLS-1$
                     repositoryValue = param.getName();
                 }
                 if (repositoryValue == null


### PR DESCRIPTION
always Mysql after dragging and dropping from database Metadata

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


