### PR TITLE
TUP-28130 Remove Loop limit column for target schema's path loop expression table, for json type meta data.

### DIFF
--- a/main/plugins/org.talend.repository.json/src/org/talend/repository/json/ui/wizards/extraction/ExtractionLoopWithJSONXPathEditorView.java
+++ b/main/plugins/org.talend.repository.json/src/org/talend/repository/json/ui/wizards/extraction/ExtractionLoopWithJSONXPathEditorView.java
@@ -13,7 +13,6 @@
 package org.talend.repository.json.ui.wizards.extraction;
 
 import org.eclipse.jface.viewers.CellEditor;
-import org.eclipse.jface.viewers.TextCellEditor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Table;
@@ -191,32 +190,6 @@ public class ExtractionLoopWithJSONXPathEditorView extends AbstractDataTableEdit
         column.setMinimumWidth(50);
         column.setDefaultInternalValue(""); //$NON-NLS-1$
         // //////////////////////////////////////////////////////////////////////////////////////
-
-        // //////////////////////////////////////////////////////////////////////////////////////
-        // Loop limit
-        column = new TableViewerCreatorColumn(tableViewerCreator);
-        column.setTitle("Loop limit");
-        column.setBeanPropertyAccessors(new IBeanPropertyAccessors<JSONXPathLoopDescriptor, Integer>() {
-
-            @Override
-            public Integer get(JSONXPathLoopDescriptor bean) {
-                return bean.getLimitBoucle();
-            }
-
-            @Override
-            public void set(JSONXPathLoopDescriptor bean, Integer value) {
-                if (value != null) {
-                    bean.setLimitBoucle(value.intValue());
-                } else {
-                    bean.setLimitBoucle(0);
-                }
-            }
-
-        });
-        column.setModifiable(true);
-        column.setWidth(59);
-        column.setCellEditor(new TextCellEditor(table), intValueAdapter);
-
     }
 
     public JSONExtractorLoopModel getModel() {


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TUP-28130
'Loop limit' does not limit the number of loop

**What is the new behavior?**
Remove loop limit column for json type meta data.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


