### PR TITLE
fix(TCOMP-1749): validation with ActiveIf broken (#5121)

### DIFF
--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/listener/ActiveIfListener.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/listener/ActiveIfListener.java
@@ -78,6 +78,8 @@ public class ActiveIfListener implements PropertyChangeListener {
         sourceParameter.setShow(show);
         sourceParameter.redraw(); // request source parameter redraw
         sourceParameter.firePropertyChange("show", null, show);
+        //need to revalidate to either show or hide the validation label
+        sourceParameter.firePropertyChange("value", null, sourceParameter.getValue());
     }
 
     private boolean evaluateCondition(final PropertyDefinitionDecorator.Condition cond) {

--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/listener/PropertyValidator.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/listener/PropertyValidator.java
@@ -17,8 +17,10 @@ package org.talend.sdk.component.studio.model.parameter.listener;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.util.Collections;
 import java.util.regex.Pattern;
 
+import org.talend.sdk.component.studio.model.parameter.TaCoKitElementParameter;
 import org.talend.sdk.component.studio.model.parameter.ValidationLabel;
 
 /**
@@ -49,7 +51,7 @@ public abstract class PropertyValidator implements PropertyChangeListener {
             return;
         }
 
-        if (isContextualValue(event.getNewValue())) {
+        if (isContextualValue(event.getNewValue()) || hideValidation(event.getSource())) {
             label.hideConstraint(validationMessage);
         } else if (!validate(event.getNewValue())) {
             label.showConstraint(validationMessage);
@@ -57,6 +59,20 @@ public abstract class PropertyValidator implements PropertyChangeListener {
             label.hideConstraint(validationMessage);
         }
     }
+    
+    /**
+     * Check if the source parameter is hidden. 
+     * If it is hidden we need to disable validation for it.
+     * @param source element parameter to check
+     * @return
+     */
+    private boolean hideValidation(Object source) {
+		if(source instanceof TaCoKitElementParameter) {
+			TaCoKitElementParameter parameter = (TaCoKitElementParameter)source;
+			return !parameter.isShow(Collections.emptyList());
+		}
+		return false;
+	}
 
     /**
      * Checks whether {@code value} is raw data or contains {@code context} variable.

--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/listener/ValidationListener.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/listener/ValidationListener.java
@@ -17,11 +17,13 @@ package org.talend.sdk.component.studio.model.parameter.listener;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import org.talend.sdk.component.studio.Lookups;
 import org.talend.sdk.component.studio.model.action.Action;
+import org.talend.sdk.component.studio.model.parameter.TaCoKitElementParameter;
 import org.talend.sdk.component.studio.model.parameter.ValidationLabel;
 
 public class ValidationListener extends Action<String> implements PropertyChangeListener {
@@ -36,6 +38,11 @@ public class ValidationListener extends Action<String> implements PropertyChange
     @Override
     public void propertyChange(final PropertyChangeEvent event) {
         if(!"value".equals(event.getPropertyName())){
+            return;
+        }
+        if(event.getSource() instanceof TaCoKitElementParameter 
+        		&& !((TaCoKitElementParameter)event.getSource()).isShow(Collections.emptyList())) {
+            label.hideValidation();
             return;
         }
         CompletableFuture.supplyAsync(this::validate, Lookups.uiActionsThreadPool().getExecutor()).thenAccept(


### PR DESCRIPTION
* Don't show validation results for hidden parameters

* Revalidate parameters on show/hide property change

Co-authored-by: Dmytro Chmyga <dmytro.chmyga@synapse.com>

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


