### PR TITLE
chore(TDI-44765): remove guava:13.0

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryBulkExec/tBigQueryBulkExec_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryBulkExec/tBigQueryBulkExec_java.xml
@@ -239,7 +239,7 @@
          <IMPORT NAME="google-http-client-1.25.0.jar" MODULE="google-http-client-1.25.0.jar" MVN="mvn:com.google.http-client/google-http-client/1.25.0"  REQUIRED="true" />
          <IMPORT NAME="google-oauth-client-1.25.0.jar" MODULE="google-oauth-client-1.25.0.jar" MVN="mvn:com.google.oauth-client/google-oauth-client/1.25.0" REQUIRED="true" />
          <IMPORT NAME="google-http-client-jackson2-1.25.0.jar" MODULE="google-http-client-jackson2-1.25.0.jar" MVN="mvn:com.google.http-client/google-http-client-jackson2/1.25.0"  REQUIRED="true" />
-		<IMPORT NAME="guava-jdk5-13.0.jar" MODULE="guava-jdk5-13.0.jar" MVN="mvn:org.talend.libraries/guava-jdk5-13.0/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.guava/lib/guava-jdk5-13.0.jar" REQUIRED="true" />
+         <IMPORT NAME="guava-20.0.jar" MODULE="guava-20.0.jar" MVN="mvn:com.google.guava/guava/20.0" REQUIRED="true" />
 		<IMPORT NAME="jackson-core-2.10.1.jar" MODULE="jackson-core-2.10.1.jar" MVN="mvn:com.fasterxml.jackson.core/jackson-core/2.10.1" REQUIRED="true" />
 		<!-- REQUIRED FOR GOOGLE STORAGE -->
 		<IMPORT NAME="jets3t-0.9.1" MODULE="jets3t-0.9.1.jar" MVN="mvn:org.talend.libraries/jets3t-0.9.1/6.0.0"  REQUIRED="true" />
@@ -256,7 +256,6 @@
 		<IMPORT NAME="google-auth-library-oauth2-http-0.20.0.jar" MODULE="google-auth-library-oauth2-http-0.20.0.jar" MVN="mvn:com.google.auth/google-auth-library-oauth2-http/0.20.0" REQUIRED_IF="AUTH_MODE == 'SERVICEACCOUNT'" />
 		<IMPORT NAME="google-cloud-core-1.93.4.jar" MODULE="google-cloud-core-1.93.4.jar" MVN="mvn:com.google.cloud/google-cloud-core/1.93.4" REQUIRED_IF="AUTH_MODE == 'SERVICEACCOUNT'" />
 		<IMPORT NAME="google-cloud-core-http-1.32.0.jar" MODULE="google-cloud-core-http-1.32.0.jar" MVN="mvn:com.google.cloud/google-cloud-core-http/1.32.0" REQUIRED_IF="AUTH_MODE == 'SERVICEACCOUNT'" />
-		<IMPORT NAME="guava-20.0.jar" MODULE="guava-20.0.jar" MVN="mvn:com.google.guava/guava/20.0" REQUIRED_IF="AUTH_MODE == 'SERVICEACCOUNT'" />
 		<IMPORT NAME="gax-1.27.0.jar" MODULE="gax-1.27.0.jar" MVN="mvn:com.google.api/gax/1.27.0" REQUIRED_IF="(AUTH_MODE == 'SERVICEACCOUNT') OR (AUTH_TYPE == 'GS_SERVICE_ACCOUNT')" />
 		<IMPORT NAME="google-http-client-appengine-1.25.0.jar" MODULE="google-http-client-appengine-1.25.0.jar" MVN="mvn:com.google.http-client/google-http-client-appengine/1.25.0" REQUIRED_IF="(AUTH_MODE == 'SERVICEACCOUNT') OR (AUTH_TYPE == 'GS_SERVICE_ACCOUNT')" />
 		<IMPORT NAME="api-common-1.6.0.jar" MODULE="api-common-1.6.0.jar" MVN="mvn:com.google.api/api-common/1.6.0" REQUIRED_IF="(AUTH_MODE == 'SERVICEACCOUNT') OR (AUTH_TYPE == 'GS_SERVICE_ACCOUNT')" />

--- a/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryInput/tBigQueryInput_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tBigQueryInput/tBigQueryInput_java.xml
@@ -185,7 +185,7 @@
 		 <IMPORT NAME="google-http-client-1.25.0.jar" MODULE="google-http-client-1.25.0.jar" MVN="mvn:com.google.http-client/google-http-client/1.25.0"  REQUIRED="true" />
 		 <IMPORT NAME="google-oauth-client-1.25.0.jar" MODULE="google-oauth-client-1.25.0.jar" MVN="mvn:com.google.oauth-client/google-oauth-client/1.25.0" REQUIRED="true" />
 		 <IMPORT NAME="google-http-client-jackson2-1.25.0.jar" MODULE="google-http-client-jackson2-1.25.0.jar" MVN="mvn:com.google.http-client/google-http-client-jackson2/1.25.0"  REQUIRED="true" />
-		<IMPORT NAME="guava-jdk5-13.0.jar" MODULE="guava-jdk5-13.0.jar" MVN="mvn:org.talend.libraries/guava-jdk5-13.0/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.guava/lib/guava-jdk5-13.0.jar" REQUIRED="true" />
+		 <IMPORT NAME="guava-20.0.jar" MODULE="guava-20.0.jar" MVN="mvn:com.google.guava/guava/20.0" REQUIRED="true" />
 		<IMPORT NAME="jackson-core-2.10.1.jar" MODULE="jackson-core-2.10.1.jar" MVN="mvn:com.fasterxml.jackson.core/jackson-core/2.10.1" REQUIRED="true" />
 		<IMPORT NAME="google-cloud-bigquery-1.60.0.jar" MODULE="google-cloud-bigquery-1.60.0.jar" MVN="mvn:com.google.cloud/google-cloud-bigquery/1.60.0" REQUIRED_IF="AUTH_MODE == 'SERVICEACCOUNT'" />
 		<IMPORT NAME="google-http-client-jackson-1.25.0.jar" MODULE="google-http-client-jackson-1.25.0.jar" MVN="mvn:com.google.http-client/google-http-client-jackson/1.25.0" REQUIRED_IF="AUTH_MODE == 'SERVICEACCOUNT'" />
@@ -196,7 +196,6 @@
 		<IMPORT NAME="google-auth-library-oauth2-http-0.20.0.jar" MODULE="google-auth-library-oauth2-http-0.20.0.jar" MVN="mvn:com.google.auth/google-auth-library-oauth2-http/0.20.0" REQUIRED_IF="AUTH_MODE == 'SERVICEACCOUNT'" />
 		<IMPORT NAME="google-cloud-core-1.93.4.jar" MODULE="google-cloud-core-1.93.4.jar" MVN="mvn:com.google.cloud/google-cloud-core/1.93.4" REQUIRED_IF="AUTH_MODE == 'SERVICEACCOUNT'" />
 		<IMPORT NAME="google-cloud-core-http-1.32.0.jar" MODULE="google-cloud-core-http-1.32.0.jar" MVN="mvn:com.google.cloud/google-cloud-core-http/1.32.0" REQUIRED_IF="AUTH_MODE == 'SERVICEACCOUNT'" />
-		<IMPORT NAME="guava-20.0.jar" MODULE="guava-20.0.jar" MVN="mvn:com.google.guava/guava/20.0" REQUIRED_IF="AUTH_MODE == 'SERVICEACCOUNT'" />
 		<IMPORT NAME="gax-1.27.0.jar" MODULE="gax-1.27.0.jar" MVN="mvn:com.google.api/gax/1.27.0" REQUIRED_IF="AUTH_MODE == 'SERVICEACCOUNT'" />
 		<IMPORT NAME="google-http-client-appengine-1.25.0.jar" MODULE="google-http-client-appengine-1.25.0.jar" MVN="mvn:com.google.http-client/google-http-client-appengine/1.25.0" REQUIRED_IF="AUTH_MODE == 'SERVICEACCOUNT'" />
 		<IMPORT NAME="api-common-1.6.0.jar" MODULE="api-common-1.6.0.jar" MVN="mvn:com.google.api/api-common/1.6.0" REQUIRED_IF="AUTH_MODE == 'SERVICEACCOUNT'" />

--- a/main/plugins/org.talend.designer.components.localprovider/components/tBigQuerySQLRow/tBigQuerySQLRow_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tBigQuerySQLRow/tBigQuerySQLRow_java.xml
@@ -172,9 +172,7 @@
             <IMPORT NAME="google-http-client-1.25.0.jar" MODULE="google-http-client-1.25.0.jar" MVN="mvn:com.google.http-client/google-http-client/1.25.0"  REQUIRED="true" />
             <IMPORT NAME="google-oauth-client-1.25.0.jar" MODULE="google-oauth-client-1.25.0.jar" MVN="mvn:com.google.oauth-client/google-oauth-client/1.25.0" REQUIRED="true" />
             <IMPORT NAME="google-http-client-jackson2-1.25.0.jar" MODULE="google-http-client-jackson2-1.25.0.jar" MVN="mvn:com.google.http-client/google-http-client-jackson2/1.25.0"  REQUIRED="true" />
-            <IMPORT NAME="guava-jdk5-13.0.jar" MODULE="guava-jdk5-13.0.jar"
-                    MVN="mvn:org.talend.libraries/guava-jdk5-13.0/6.0.0"
-                    UrlPath="platform:/plugin/org.talend.libraries.guava/lib/guava-jdk5-13.0.jar" REQUIRED="true"/>
+            <IMPORT NAME="guava-20.0.jar" MODULE="guava-20.0.jar" MVN="mvn:com.google.guava/guava/20.0" REQUIRED="true"/>
             <IMPORT NAME="jackson-core-2.10.1.jar" MODULE="jackson-core-2.10.1.jar"
                     MVN="mvn:com.fasterxml.jackson.core/jackson-core/2.10.1" REQUIRED="true"/>
             <IMPORT NAME="google-cloud-bigquery-1.60.0.jar" MODULE="google-cloud-bigquery-1.60.0.jar"
@@ -199,8 +197,6 @@
                     MVN="mvn:com.google.cloud/google-cloud-core/1.93.4" REQUIRED_IF="AUTH_MODE == 'SERVICEACCOUNT'"/>
             <IMPORT NAME="google-cloud-core-http-1.32.0.jar" MODULE="google-cloud-core-http-1.32.0.jar"
                     MVN="mvn:com.google.cloud/google-cloud-core-http/1.32.0"
-                    REQUIRED_IF="AUTH_MODE == 'SERVICEACCOUNT'"/>
-            <IMPORT NAME="guava-20.0.jar" MODULE="guava-20.0.jar" MVN="mvn:com.google.guava/guava/20.0"
                     REQUIRED_IF="AUTH_MODE == 'SERVICEACCOUNT'"/>
             <IMPORT NAME="gax-1.27.0.jar" MODULE="gax-1.27.0.jar" MVN="mvn:com.google.api/gax/1.27.0"
                     REQUIRED_IF="AUTH_MODE == 'SERVICEACCOUNT'"/>


### PR DESCRIPTION
* remove guava:13.0 dependency use 20.0 instead of it

**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-44765

**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard

**What kind of change does this PR introduce?**

- [x] Bugfix
- [x] Refactoring (no functional changes, no api changes)

**Does this PR introduce a breaking change?**

- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
It's a port from maintenance/7.3

