### PR TITLE
fix(TCOMP-1770): bump component-runtime to 1.1.25

### DIFF
--- a/main/plugins/org.talend.sdk.component.studio-integration/pom.xml
+++ b/main/plugins/org.talend.sdk.component.studio-integration/pom.xml
@@ -14,7 +14,7 @@
   <description>Studio integration of the Talend Component Kit framework.</description>
 
   <properties>
-    <component-runtime.version>1.1.24</component-runtime.version>
+    <component-runtime.version>1.1.25</component-runtime.version>
     <commons-lang3.version>3.6</commons-lang3.version>
     <mockito.version>2.23.0</mockito.version>
     <oro.version>2.0.8</oro.version>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TCOMP-1770
https://jira.talendforge.org/browse/TDI-44874

**Related PR**
- https://github.com/Talend/studio-full-master/pull/439
- https://github.com/Talend/tcommon-studio-ee/pull/1522
- https://github.com/Talend/tcommon-studio-se/pull/3637
- https://github.com/Talend/tdi-studio-se/pull/5201
