### PR TITLE
fix(TDI-44893): upgrade libraries, update code, remove old libs

### DIFF
--- a/main/plugins/org.talend.designer.components.libs/libs_src/soap/pom.xml
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/soap/pom.xml
@@ -3,14 +3,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.talend.components</groupId>
 	<artifactId>components-soap</artifactId>
-	<version>2.2-20200730</version>
+	<version>2.3-20200918</version>
 	<packaging>jar</packaging>
 	
 	<name>talend-soap</name>
 	
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<cxf.version>3.1.1</cxf.version>
 		<talend.nexus.url>https://artifacts-oss.talend.com</talend.nexus.url>
 	</properties>
 	
@@ -46,19 +45,14 @@
   			<systemPath>${java.home}/lib/rt.jar</systemPath>
 		</dependency>
 		<dependency>
-			<groupId>jdom</groupId>
-			<artifactId>jdom</artifactId>
-			<version>1.1</version>
+			<groupId>org.dom4j</groupId>
+			<artifactId>dom4j</artifactId>
+			<version>2.1.3</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sun.xml.messaging.saaj</groupId>
 			<artifactId>saaj-impl</artifactId>
-			<version>1.3.2</version>
-		</dependency>
-		<dependency>
-			<groupId>javax.activation</groupId>
-			<artifactId>activation</artifactId>
-			<version>1.1</version>
+			<version>1.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>xerces</groupId>
@@ -68,7 +62,7 @@
 		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
-			<version>1.9</version>
+			<version>1.14</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/main/plugins/org.talend.designer.components.libs/libs_src/soap/src/main/java/org/talend/soap/SOAPUtil.java
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/soap/src/main/java/org/talend/soap/SOAPUtil.java
@@ -32,8 +32,7 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
 import org.apache.commons.codec.binary.Base64;
-import org.jdom.input.DOMBuilder;
-import org.jdom.output.XMLOutputter;
+import org.dom4j.io.DOMReader;
 import org.talend.soap.sun.SunNtlmAuthenticationUpdater;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -44,8 +43,6 @@ import com.sun.xml.messaging.saaj.soap.SOAPPartImpl;
 public class SOAPUtil {
 
     private static final String vmVendor = System.getProperty("java.vendor.url");
-
-    private static final String ibmVmVendor = "http://www.ibm.com/";
 
     private static final String sunVmVendor = "http://java.sun.com/";
 
@@ -140,12 +137,7 @@ public class SOAPUtil {
         StreamSource preppedMsgSrc = new StreamSource(stream);
         soapPart.setContent(preppedMsgSrc);
 
-        // InputStream stream = new FileInputStream(new File("d://soap.txt"));
-        // StreamSource preppedMsgSrc = new StreamSource(stream);
-        // soapPart.setContent(preppedMsgSrc);
-
         message.saveChanges();
-        // Send the message
 
         SOAPMessage reply = connection.call(message, destination);
 
@@ -226,7 +218,7 @@ public class SOAPUtil {
         Node content;
         Element headerRootElem = document.createElement("Header");
 
-        Iterator childElements = header.getChildElements();
+        Iterator<javax.xml.soap.Node> childElements = header.getChildElements();
         org.w3c.dom.Node domNode = null;
         while (childElements.hasNext()) {
             domNode = (org.w3c.dom.Node) childElements.next();
@@ -246,10 +238,9 @@ public class SOAPUtil {
     }
 
     private String Doc2StringWithoutDeclare(Document doc) {
-        DOMBuilder builder = new DOMBuilder();
-        org.jdom.Document jdomDoc = builder.build(doc);
-        XMLOutputter outputter = new XMLOutputter();
-        return outputter.outputString(jdomDoc.getRootElement());
+        DOMReader reader = new DOMReader();
+        org.dom4j.Document document = reader.read(doc);
+        return document.getRootElement().asXML();
     }
 
 	/**

--- a/main/plugins/org.talend.designer.components.localprovider/components/tSOAP/tSOAP_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tSOAP/tSOAP_java.xml
@@ -130,7 +130,7 @@
 	      NUM_ROW="10"
 	      SHOW_IF="USE_KERBEROS == 'true'"
 	    />
-	    
+
  	    <PARAMETER
  	      NAME="ENFORCE_NTLM"
  	      FIELD="CHECK"
@@ -144,17 +144,14 @@
 
 	<CODEGENERATION>
 		<IMPORTS>
-			<IMPORT NAME="activation" MODULE="activation.jar" MVN="mvn:org.talend.libraries/activation/6.0.0" REQUIRED="true" BundleID="" />
-			<IMPORT NAME="jaxqname" MODULE="jax-qname.jar" MVN="mvn:org.talend.libraries/jax-qname/6.0.0" REQUIRED="true" BundleID="" />
-			<IMPORT NAME="jaxpapi" MODULE="jaxp-api.jar" MVN="mvn:org.talend.libraries/jaxp-api/6.0.0" REQUIRED="true" BundleID="" />
-			<IMPORT NAME="jaxpri" MODULE="jaxp-ri.jar" MVN="mvn:org.talend.libraries/jaxp-ri/6.0.0" REQUIRED="true" BundleID="" />
-			<IMPORT NAME="saajapi" MODULE="saaj-api-1.3.jar" MVN="mvn:org.talend.libraries/saaj-api-1.3/6.0.0" REQUIRED="true" BundleID="" />
-			<IMPORT NAME="saajimpl" MODULE="saaj-impl-1.3.2.jar" MVN="mvn:org.talend.libraries/saaj-impl-1.3.2/6.0.0" REQUIRED="true" BundleID="" />
-			<IMPORT NAME="jdom" MODULE="jdom-1.1.jar" MVN="mvn:org.talend.libraries/jdom-1.1/6.0.0" UrlPath="platform:/plugin/org.talend.libraries.jdom/lib/jdom-1.1.jar" REQUIRED="true" BundleID="org.apache.servicemix.bundles.jdom" />
-			<IMPORT NAME="componentns-soap" MODULE="components-soap-2.2-20200824.jar" MVN="mvn:org.talend.components/components-soap/2.2-20200824" REQUIRED="true" />
+			<IMPORT NAME="saajimpl" MODULE="saaj-impl-1.5.2.jar" MVN="mvn:com.sun.xml.messaging.saaj/saaj-impl/1.5.2" REQUIRED="true"/>
+			<IMPORT NAME="dom4j-2.1.3" MODULE="dom4j-2.1.3.jar" MVN="mvn:org.dom4j/dom4j/2.1.3" REQUIRED="true" />
+			<IMPORT NAME="components-soap" MODULE="components-soap-2.3-20200918.jar" MVN="mvn:org.talend.components/components-soap/2.3-20200918" REQUIRED="true" />
+			<IMPORT NAME="stax-ex-1.8.3" MODULE="stax-ex-1.8.3.jar" MVN="mvn:org.jvnet.staxex/stax-ex/1.8.3" REQUIRED="true" />
+			<IMPORT NAME="jakarta.xml.soap-api-1.4.2" MODULE="jakarta.xml.soap-api-1.4.2.jar" MVN="mvn:jakarta.xml.soap/jakarta.xml.soap-api/1.4.2" REQUIRED="true" />
 			<IMPORT NAME="xercesImpl-2.12.0" MODULE="xercesImpl-2.12.0.jar" MVN="mvn:xerces/xercesImpl/2.12.0" REQUIRED="true"/>
 			<IMPORT NAME="xml-apis-1.4.01" MODULE="xml-apis-1.4.01.jar" MVN="mvn:xml-apis/xml-apis/1.4.01" REQUIRED="true" />
-			<IMPORT NAME="commons-codec-1.14" MODULE="commons-codec-1.14.jar" MVN="mvn:commons-codec/commons-codec/1.14" REQUIRED="true" BundleID="" />
+			<IMPORT NAME="commons-codec-1.14" MODULE="commons-codec-1.14.jar" MVN="mvn:commons-codec/commons-codec/1.14" REQUIRED="true" />
 		</IMPORTS>
 	</CODEGENERATION>
 

--- a/main/plugins/org.talend.designer.components.localprovider/pom.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/pom.xml
@@ -97,7 +97,7 @@
 								<artifactItem>
 									<groupId>org.talend.components</groupId>
 									<artifactId>components-soap</artifactId>
-									<version>2.2-20200824</version>
+									<version>2.3-20200918</version>
 									<type>jar</type>
 									<overWrite>true</overWrite>
 									<outputDirectory>${soap.dir}</outputDirectory>


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-44893

**What is the new behavior?**
Upgraded libraries:
- saaj-impl - 1.5.2: the main fix of the Jira.
- commons-codec - 1.14: as in tSOAP_java.xml
- stax-ex-1.8.3: comes as compile dependency for saaj-impl
- jakarta.xml.soap-api-1.4.2: comes as compile dependency for saaj-impl

Removed libraries:
- jdom - 1.1: old version, replaced with newer **org.dom4j**
- javax.activation: comes as **com.sun.activation:jakarta.activation:jar** as provided jar
- jaxqname: replaced with **xml-apis**
- jaxpapi: replaced with **xml-apis**
- jaxpri: replaced with **xercesImpl**
- saajapi: removed as no relation to newest saaj-impl

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


