### PR TITLE
fix(TESB-30317): [CI Builder] Some models throw error "context file d…

### DIFF
--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/java/JavaProcessor.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/java/JavaProcessor.java
@@ -1996,21 +1996,19 @@ public class JavaProcessor extends AbstractJavaProcessor implements IJavaBreakpo
                 tProcessJvaProject.createSubFolder(null, resourcesFolder, jobContextFolderPath.toString());
             }
 
+            if (!extResourcePath.exists()) {
+                tProcessJvaProject.createSubFolder(null, externalResourcesFolder, jobContextFolderPath.toString());
+            }
+
             resourcesPath.refreshLocal(IResource.DEPTH_INFINITE, null);
+            extResourcePath.refreshLocal(IResource.DEPTH_INFINITE, null);
+            for (IResource resource : extResourcePath.members()) {
+                IFile context = resourcesPath.getFile(resource.getName());
 
-            try {
-	            for (IResource resource : extResourcePath.members()) {
-	                IFile context = resourcesPath.getFile(resource.getName());
-
-	                if (context.exists()) {
-	                    context.delete(true, null);
-	                }
-	                resource.copy(context.getFullPath(), true, null);
-	            }
-            } catch(Exception e) {
-            	RunProcessPlugin.getDefault().getLog()
-                .log(new Status(IStatus.WARNING, RunProcessPlugin.getDefault().getBundle().getSymbolicName(),
-                        e.getMessage()));
+                if (context.exists()) {
+                    context.delete(true, null);
+                }
+                resource.copy(context.getFullPath(), true, null);
             }
 
             resourcesPath.refreshLocal(IResource.DEPTH_INFINITE, null);

--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/java/JavaProcessor.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/java/JavaProcessor.java
@@ -1991,20 +1991,26 @@ public class JavaProcessor extends AbstractJavaProcessor implements IJavaBreakpo
 
             IFolder extResourcePath = externalResourcesFolder.getFolder(jobContextFolderPath);
             IFolder resourcesPath = resourcesFolder.getFolder(jobContextFolderPath);
-            
+
             if(!resourcesPath.exists()) {
                 tProcessJvaProject.createSubFolder(null, resourcesFolder, jobContextFolderPath.toString());
             }
 
             resourcesPath.refreshLocal(IResource.DEPTH_INFINITE, null);
 
-            for (IResource resource : extResourcePath.members()) {
-                IFile context = resourcesPath.getFile(resource.getName());
+            try {
+	            for (IResource resource : extResourcePath.members()) {
+	                IFile context = resourcesPath.getFile(resource.getName());
 
-                if (context.exists()) {
-                    context.delete(true, null);
-                }
-                resource.copy(context.getFullPath(), true, null);
+	                if (context.exists()) {
+	                    context.delete(true, null);
+	                }
+	                resource.copy(context.getFullPath(), true, null);
+	            }
+            } catch(Exception e) {
+            	RunProcessPlugin.getDefault().getLog()
+                .log(new Status(IStatus.WARNING, RunProcessPlugin.getDefault().getBundle().getSymbolicName(),
+                        e.getMessage()));
             }
 
             resourcesPath.refreshLocal(IResource.DEPTH_INFINITE, null);


### PR DESCRIPTION
…oesn't exist" during CITEST compilation phase

Fix by catching error from the members() function call which will throw error if the folder it is working with doens't exist.

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


