### PR TITLE
Fix: TUP-28773 Dialog title is incorrect when using 'Import an existing project'

### DIFF
--- a/main/plugins/org.talend.repository/src/main/java/messages.properties
+++ b/main/plugins/org.talend.repository/src/main/java/messages.properties
@@ -329,6 +329,7 @@ ImportItemsWizardPage_ZipImport_badFormat = Source file is not a valid Zip file.
 ImportDemoProjectPage.overwrite=Overwrite
 ImportProjectAction.messageDialogContent.projectImportedSuccessfully=Project has been successfully imported in your workspace
 ImportProjectAction.messageDialogContent.projectImportedFinish=Project has been imported in your workspace, but some invalid items can't be imported finally.
+ImportProjectAction.messageDialogTitle.project=Project imported
 ImportProjectAction.messageDialogTitle.projectFailed=Import failed
 ImportProjectAction.messageDialogContent.projectImportedFailed=Your project cannot be imported because of invalid items.
 ImportProjectAction.messageDialogContent.projectsImportedFailed=Your project(s) <{0}> cannot be imported because of invalid items.


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TUP-28773

**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


