### PR TITLE
fix(TDI-44866) : mscrm 11 not java11 compatible - maintenance

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmInput/tMicrosoftCrmInput_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmInput/tMicrosoftCrmInput_java.xml
@@ -27523,7 +27523,7 @@
                 <IMPORT NAME="jcifs" MODULE="jcifs-1.3.0.jar" MVN="mvn:org.talend.libraries/jcifs-1.3.0/6.0.0"  REQUIRED_IF="((AUTH_TYPE == 'ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2011')) OR (API_VERSION=='API_2007')" />
                 <!-- 2011 -->
                 <!-- crm client -->
-                <IMPORT NAME="talend-mscrm" MODULE="talend-mscrm-3.4-20200824.jar" MVN="mvn:org.talend.components/talend-mscrm/3.4-20200824"  UrlPath="platform:/plugin/org.talend.libraries.crm/lib/talend-mscrm-3.4-20200824.jar" REQUIRED_IF="(((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011' OR API_VERSION =='API_2016_ODATA' OR API_VERSION =='API_2018_ODATA')) OR ((AUTH_TYPE=='ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016' OR MS_CRM_VERSION == 'CRM_2018')))" />
+                <IMPORT NAME="talend-mscrm" MODULE="talend-mscrm-3.4-20200923.jar" MVN="mvn:org.talend.components/talend-mscrm/3.4-20200923"  UrlPath="platform:/plugin/org.talend.libraries.crm/lib/talend-mscrm-3.4-20200923.jar" REQUIRED_IF="(((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011' OR API_VERSION =='API_2016_ODATA' OR API_VERSION =='API_2018_ODATA')) OR ((AUTH_TYPE=='ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016' OR MS_CRM_VERSION == 'CRM_2018')))" />
                 <!-- axis2 1.7.4 -->
                 <IMPORT NAME="activation-1.1" MODULE="activation-1.1.jar" MVN="mvn:org.talend.libraries/activation-1.1/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.apache.axis2/lib/activation-1.1.jar" REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')" />
                 <IMPORT NAME="axiom-api-1.2.20" MODULE="axiom-api-1.2.20.jar" MVN="mvn:org.talend.libraries/axiom-api-1.2.20/6.0.0"  REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')" />

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmOutput/tMicrosoftCrmOutput_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMicrosoftCrmOutput/tMicrosoftCrmOutput_java.xml
@@ -38286,7 +38286,7 @@
             <IMPORT NAME="jcifs" MODULE="jcifs-1.3.0.jar" MVN="mvn:org.talend.libraries/jcifs-1.3.0/6.0.0"  REQUIRED_IF="((AUTH_TYPE == 'ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2011')) OR (API_VERSION=='API_2007')" />
             <!-- 2011 -->
             <!-- crm client -->
-            <IMPORT NAME="talend-mscrm" MODULE="talend-mscrm-3.4-20200824.jar" MVN="mvn:org.talend.components/talend-mscrm/3.4-20200824"  UrlPath="platform:/plugin/org.talend.libraries.crm/lib/talend-mscrm-3.4-20200824.jar" REQUIRED_IF="((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011' OR API_VERSION =='API_2016_ODATA' OR API_VERSION =='API_2018_ODATA')) OR ((AUTH_TYPE == 'ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016' OR MS_CRM_VERSION == 'CRM_2018'))" />
+            <IMPORT NAME="talend-mscrm" MODULE="talend-mscrm-3.4-20200923.jar" MVN="mvn:org.talend.components/talend-mscrm/3.4-20200923"  UrlPath="platform:/plugin/org.talend.libraries.crm/lib/talend-mscrm-3.4-20200923.jar" REQUIRED_IF="((AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011' OR API_VERSION =='API_2016_ODATA' OR API_VERSION =='API_2018_ODATA')) OR ((AUTH_TYPE == 'ON_PREMISE') AND (MS_CRM_VERSION == 'CRM_2016' OR MS_CRM_VERSION == 'CRM_2018'))" />
             <!-- axis2 1.7.4 -->
             <IMPORT NAME="activation-1.1" MODULE="activation-1.1.jar" MVN="mvn:org.talend.libraries/activation-1.1/6.0.0"  UrlPath="platform:/plugin/org.talend.libraries.apache.axis2/lib/activation-1.1.jar" REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')" />
             <IMPORT NAME="axiom-api-1.2.20" MODULE="axiom-api-1.2.20.jar" MVN="mvn:org.talend.libraries/axiom-api-1.2.20/6.0.0"  REQUIRED_IF="(AUTH_TYPE=='ONLINE') AND (API_VERSION=='API_2011')" />

--- a/main/plugins/org.talend.libraries.crm/pom.xml
+++ b/main/plugins/org.talend.libraries.crm/pom.xml
@@ -47,7 +47,7 @@
                             <artifactItem>
                                 <groupId>org.talend.components</groupId>
                                 <artifactId>talend-mscrm</artifactId>
-                                <version>3.4-20200824</version>
+                                <version>3.4-20200923</version>
                                 <type>jar</type>
                                 <overWrite>true</overWrite>
                                 <outputDirectory>${libs.dir}</outputDirectory>


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-44866
tMicrosoftCrmInput/Output configured on-premise + v2011 generate a ClassNotFoundException if executed within java 11.

**What is the new behavior?**
The not found exception has been change by another one. In maintenance branch, only change the lib version to use the one from master 3.4-20200923.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
