### PR TITLE
TUP-28778 Add 'if' judgment  before type conversion.

### DIFF
--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/AbstractTalendEditor.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/AbstractTalendEditor.java
@@ -1650,26 +1650,28 @@ public abstract class AbstractTalendEditor extends GraphicalEditorWithFlyoutPale
                 final StructuredSelection newSelection = (StructuredSelection) viewer.getSelection();
                 if (!newSelection.isEmpty() && newSelection.getFirstElement() instanceof TalendEntryEditPart) {
                     TalendEntryEditPart editPart = (TalendEntryEditPart) newSelection.getFirstElement();
-                    TalendCombinedTemplateCreationEntry entry =
-                            (TalendCombinedTemplateCreationEntry) editPart.getModel();
-                    IComponent newComponent = entry.getComponent();
-                    if (newComponent != null && newComponent instanceof StitchPseudoComponent) {
-                        if (newComponent.equals(previousComponent)) { // check if we are clicking on it for a 2nd time
-                            StitchPseudoComponent stitchPseudoComponent = (StitchPseudoComponent) newComponent;
-                            try {
-                                final URL compURL = new URL(stitchPseudoComponent.getConnectorURL()
-                                        + StitchDataLoaderConstants.getUTMParamSuffix());
-                                PlatformUI.getWorkbench().getBrowserSupport().getExternalBrowser().openURL(compURL);
-                            } catch (PartInitException | MalformedURLException e) {
-                                ExceptionHandler.process(e);
+                    if(editPart.getModel() instanceof TalendCombinedTemplateCreationEntry) {
+                        TalendCombinedTemplateCreationEntry entry =
+                                (TalendCombinedTemplateCreationEntry) editPart.getModel();
+                        IComponent newComponent = entry.getComponent();
+                        if (newComponent != null && newComponent instanceof StitchPseudoComponent) {
+                            if (newComponent.equals(previousComponent)) { // check if we are clicking on it for a 2nd time
+                                StitchPseudoComponent stitchPseudoComponent = (StitchPseudoComponent) newComponent;
+                                try {
+                                    final URL compURL = new URL(stitchPseudoComponent.getConnectorURL()
+                                            + StitchDataLoaderConstants.getUTMParamSuffix());
+                                    PlatformUI.getWorkbench().getBrowserSupport().getExternalBrowser().openURL(compURL);
+                                } catch (PartInitException | MalformedURLException e) {
+                                    ExceptionHandler.process(e);
+                                }
+                                previousComponent = null; // remove the registered selection
+                            } else { // if it's the first time selecting a stitch connector
+                                previousComponent = newComponent; // register the first click
                             }
+                            super.mouseUp(mouseEvent, viewer); // simulate the release of button to avoid dropping on canvas
+                        } else { // user click at another component after a stitch component
                             previousComponent = null; // remove the registered selection
-                        } else { // if it's the first time selecting a stitch connector
-                            previousComponent = newComponent; // register the first click
                         }
-                        super.mouseUp(mouseEvent, viewer); // simulate the release of button to avoid dropping on canvas
-                    } else { // user click at another component after a stitch component
-                        previousComponent = null; // remove the registered selection
                     }
                 } else { // user clicks at somewhere outside the palette: the canvas for instance
                     previousComponent = null; // remove the registered selection


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TUP-28778
"java.lang.ClassCastException" thrown in error log when d&d Input/Output/Trigger Input/Trigger Output from Palette into joblet

**What is the new behavior?**
NO "ClassCastException" thrown in error log and Searchable Stitch connectors works as before.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


