### PR TITLE
TESB-30623 Ensure routine classes are compiled before the routines library is created.

### DIFF
--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/esb/JobJavaScriptOSGIForESBManager.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/ui/wizards/exportjob/scriptsmanager/esb/JobJavaScriptOSGIForESBManager.java
@@ -56,6 +56,7 @@ import org.apache.commons.collections.map.MultiKeyMap;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
 import org.talend.commons.exception.ExceptionHandler;
 import org.talend.commons.exception.PersistenceException;
@@ -124,6 +125,10 @@ public class JobJavaScriptOSGIForESBManager extends JobJavaScriptsManager {
     private static final String JAVA = "java"; //$NON-NLS-1$
 
     private static final String JAVA_VERSION = "java.version";
+
+    private static File routineClassRootFolder = null;
+
+    private static File beanClassRootFolder = null;
 
     private MultiKeyMap requireBundleModules = new MultiKeyMap();
 
@@ -386,16 +391,21 @@ public class JobJavaScriptOSGIForESBManager extends JobJavaScriptsManager {
     protected void addRoutinesResources(ExportFileResource[] processes, ExportFileResource libResource) {
         File jarFile = new File(getTmpFolder() + File.separatorChar + JavaUtils.ROUTINES_JAR);
 
+        if (routineClassRootFolder == null) {
+            routineClassRootFolder = getCodeClassRootFileLocation(ERepositoryObjectType.ROUTINES);
+            if (routineClassRootFolder == null) {
+                return;
+            }
+            beanClassRootFolder = getCodeClassRootFileLocation(ERepositoryObjectType.BEANS);
+            RepositoryPlugin.getDefault().getRunProcessService().buildCodesJavaProject(new NullProgressMonitor());
+            if (beanClassRootFolder != null) {
+                FileCopyUtils.copyFolder(beanClassRootFolder, routineClassRootFolder);
+            }
+        }
+
         // make a jar file of system routine classes
-        File classRootFileLocation = getCodeClassRootFileLocation(ERepositoryObjectType.ROUTINES);
-        if (classRootFileLocation == null) {
-            return;
-        }
-        if (ERepositoryObjectType.valueOf("BEANS") != null) {
-            FileCopyUtils.copyFolder(getCodeClassRootFileLocation(ERepositoryObjectType.valueOf("BEANS")), classRootFileLocation);
-        }
         try {
-            JarBuilder jarbuilder = new JarBuilder(classRootFileLocation, jarFile);
+            JarBuilder jarbuilder = new JarBuilder(routineClassRootFolder, jarFile);
             jarbuilder.setIncludeDir(getRoutinesPaths());
             Collection<File> includeRoutines = new ArrayList<File>(getRoutineDependince(processes, true, USER_ROUTINES_PATH));
             includeRoutines.addAll(getRoutineDependince(processes, false, getIncludeRoutinesPath()));


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TESB-30623 - Data service job bundles built via CI contain empty routines library jar.

**What is the new behavior?**
The internal jar "lib/routines.jar" contains the expected routine classes.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


