### PR TITLE
feat(TUP-28342):Save maven url for components with parameter MODULE_L…

### DIFF
--- a/main/plugins/org.talend.designer.core.generic/src/main/java/org/talend/designer/core/generic/model/GenericTableUtils.java
+++ b/main/plugins/org.talend.designer.core.generic/src/main/java/org/talend/designer/core/generic/model/GenericTableUtils.java
@@ -162,16 +162,6 @@ public class GenericTableUtils {
 
     public static String getDriverJarPath(String mvnPath){
         String mvnUrl = TalendQuoteUtils.removeQuotesIfExist(mvnPath);
-        if (MavenUrlHelper.isMvnUrl(mvnUrl)) {
-            for(String key : CustomUriManager.getInstance().keySet()){
-                String value = CustomUriManager.getInstance().get(key);
-                if(mvnUrl.equals(value)){
-                    mvnUrl = key;
-                    break;
-                }
-            }
-            return MavenUrlHelper.generateModuleNameByMavenURI(mvnUrl);
-        }
-        return mvnPath;
+        return mvnUrl;
     }
 }

--- a/main/plugins/org.talend.designer.core/plugin.xml
+++ b/main/plugins/org.talend.designer.core/plugin.xml
@@ -782,6 +782,15 @@
              name="Fix empty process id parameters for tRunjob node"
              version="7.1.1">
        </projecttask>
+       <!--projecttask
+             beforeLogon="false"
+             breaks="7.3.0"
+             class="org.talend.designer.core.utils.UpdateModuleListInComponentsMigrationTask"
+             description="Replace jar name by maven uri."
+             id="org.talend.designer.core.utils.UpdateModuleListInComponentsMigrationTask"
+             name="UpdateModuleListInComponentsMigrationTask"
+             version="7.3.1">
+       </projecttask-->
     </extension>
     <extension
           point="org.talend.repository.projectsetting_page">

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/model/process/jobsettings/JobSettingsManager.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/model/process/jobsettings/JobSettingsManager.java
@@ -562,7 +562,7 @@ public class JobSettingsManager {
                     if (!moduleNameList.contains(moduleName)) {
                         moduleNameList.add(moduleName);
                     }
-                    String moduleValue = TalendTextUtils.addQuotes(moduleName);
+                    String moduleValue = TalendTextUtils.addQuotes(module.getMavenUri());
                     if (!moduleValueList.contains(moduleValue)) {
                         moduleValueList.add(moduleValue);
                     }

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/model/process/statsandlogs/StatsAndLogsManager.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/model/process/statsandlogs/StatsAndLogsManager.java
@@ -1476,7 +1476,7 @@ public class StatsAndLogsManager {
                     if (!moduleNameList.contains(moduleName)) {
                         moduleNameList.add(moduleName);
                     }
-                    String moduleValue = TalendTextUtils.addQuotes(moduleName);
+                    String moduleValue = TalendTextUtils.addQuotes(module.getMavenUri());
                     if (!moduleValueList.contains(moduleValue)) {
                         moduleValueList.add(moduleValue);
                     }

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/process/Process.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/process/Process.java
@@ -181,7 +181,6 @@ import org.talend.designer.core.ui.preferences.TalendDesignerPrefConstants;
 import org.talend.designer.core.ui.projectsetting.ProjectSettingManager;
 import org.talend.designer.core.ui.views.contexts.ContextsView;
 import org.talend.designer.core.ui.views.problems.Problems;
-import org.talend.designer.core.utils.ConnectionUtil;
 import org.talend.designer.core.utils.DesignerUtilities;
 import org.talend.designer.core.utils.DetectContextVarsUtils;
 import org.talend.designer.core.utils.JavaProcessUtil;
@@ -3730,9 +3729,6 @@ public class Process extends Element implements IProcess2, IGEFProcess, ILastVer
             updataComponentParamName = EParameterName.UPDATE_COMPONENTS.getName();
             // }
             setPropertyValue(updataComponentParamName, Boolean.TRUE);
-        }
-        if (id.equals(EParameterName.DRIVER_JAR.getName()) || id.equals("DRIVER_JAR_IMPLICIT_CONTEXT")) {
-            ConnectionUtil.getDriverJar(value);
         }
         super.setPropertyValue(id, value);
     }

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/process/ProcessUpdateManager.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/process/ProcessUpdateManager.java
@@ -2377,14 +2377,18 @@ public class ProcessUpdateManager extends AbstractUpdateManager {
             for (int i = 0; i < oldList.size(); i++) {
                 Map<String, Object> oldMap = oldList.get(i);
                 Map<String, Object> objectMap = (Map<String, Object>) objectList.get(i);
+                String oldDriver = String.valueOf(oldMap.get(nodeParamDriverKey));
                 String driver = String.valueOf(objectMap.get("drivers"));
                 if (driver != null) {
-                    MavenArtifact artifact = MavenUrlHelper.parseMvnUrl(TalendTextUtils.removeQuotes(driver));
-                    if (artifact != null) {
-                        driver = artifact.getFileName();
+                    driver = TalendTextUtils.removeQuotes(driver);
+                    if (!oldDriver.startsWith(MavenUrlHelper.MVN_PROTOCOL)) {
+                        MavenArtifact artifact = MavenUrlHelper.parseMvnUrl(driver);
+                        if (artifact != null) {
+                            driver = artifact.getFileName();
+                        }
                     }
                 }
-                if (oldMap.get(nodeParamDriverKey).equals(driver)) {
+                if (oldDriver.equals(driver)) {
                     sameValues = true;
                 } else {
                     sameValues = false;

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/properties/macrowidgets/tableeditor/PropertiesTableEditorView.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/properties/macrowidgets/tableeditor/PropertiesTableEditorView.java
@@ -65,6 +65,8 @@ import org.talend.core.model.process.INode;
 import org.talend.core.model.process.IProcess;
 import org.talend.core.model.process.IProcess2;
 import org.talend.core.model.properties.EbcdicConnectionItem;
+import org.talend.core.runtime.maven.MavenArtifact;
+import org.talend.core.runtime.maven.MavenUrlHelper;
 import org.talend.core.service.IEBCDICProviderService;
 import org.talend.core.service.ISAPProviderService;
 import org.talend.core.ui.metadata.celleditor.ModuleListCellEditor;
@@ -73,6 +75,7 @@ import org.talend.core.ui.metadata.celleditor.SchemaCellEditor;
 import org.talend.core.ui.metadata.celleditor.SchemaXPathQuerysCellEditor;
 import org.talend.core.ui.metadata.editor.AbstractMetadataTableEditorView;
 import org.talend.core.ui.proposal.TalendProposalProvider;
+import org.talend.core.utils.TalendQuoteUtils;
 import org.talend.designer.core.model.FakeElement;
 import org.talend.designer.core.model.components.EParameterName;
 import org.talend.designer.core.model.components.ElementParameter;
@@ -323,6 +326,7 @@ public class PropertiesTableEditorView<B> extends AbstractDataTableEditorView<B>
                     ModuleListCellEditor moduleEditor = new ModuleListCellEditor(table, currentParam, param);
                     moduleEditor.setTableEditorView(this);
                     column.setCellEditor(moduleEditor);
+                    column.setLabelProvider(new ModuleTableLabelProvider());
                     break;
                 case COLOR:
                     column.setModifiable((!param.isRepositoryValueUsed()) && (!param.isReadOnly())
@@ -1053,6 +1057,30 @@ public class PropertiesTableEditorView<B> extends AbstractDataTableEditorView<B>
         }
         String[] listToDisplay = stringToDisplay.toArray(new String[0]);
         return listToDisplay;
+    }
+
+    class ModuleTableLabelProvider implements IColumnLabelProvider {
+
+        @Override
+        public String getLabel(Object bean) {
+            if (bean instanceof Map) {
+                Map<String, String> valueMap = (Map<String, String>) bean;
+                String value = valueMap.get("drivers");
+                return getModuleName(value);
+            }
+            return "newLine";
+        }
+    }
+
+    private static String getModuleName(String jarPath) {
+        if (jarPath != null) {
+            jarPath = TalendQuoteUtils.removeQuotes(jarPath);
+            if (jarPath.startsWith(MavenUrlHelper.MVN_PROTOCOL)) {
+                MavenArtifact art = MavenUrlHelper.parseMvnUrl(jarPath);
+                return art.getFileName();
+            }
+        }
+        return jarPath;
     }
 
 }

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/projectsetting/ImplicitContextLoadElement.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/projectsetting/ImplicitContextLoadElement.java
@@ -14,7 +14,6 @@ package org.talend.designer.core.ui.projectsetting;
 
 
 import org.talend.core.model.process.Element;
-import org.talend.designer.core.utils.ConnectionUtil;
 
 /**
  * this class is only used in projectsetting to contains project's ImplicitContextLoadSettings
@@ -54,11 +53,4 @@ public class ImplicitContextLoadElement extends Element {
 
     }
 
-    @Override
-    public void setPropertyValue(String id, Object value) {
-        super.setPropertyValue(id, value);
-        if(id.equals("DRIVER_JAR_IMPLICIT_CONTEXT")){
-            ConnectionUtil.getDriverJar(value);
-        }
-    }
 }

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/projectsetting/ProjectSettingManager.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/projectsetting/ProjectSettingManager.java
@@ -621,7 +621,10 @@ public class ProjectSettingManager extends Utils {
             String moduleName = module.getModuleName();
             if (moduleName != null) {
                 moduleNameList.add(moduleName);
-                moduleValueList.add(TalendTextUtils.addQuotes(moduleName));
+                String moduleValue = TalendTextUtils.addQuotes(module.getMavenUri());
+                if (!moduleValueList.contains(moduleValue)) {
+                    moduleValueList.add(moduleValue);
+                }
             }
         }
         Comparator<String> comprarator = new IgnoreCaseComparator();

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/projectsetting/StatsAndLogsElement.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/projectsetting/StatsAndLogsElement.java
@@ -58,8 +58,5 @@ public class StatsAndLogsElement extends Element {
     @Override
     public void setPropertyValue(String id, Object value) {
         super.setPropertyValue(id, value);
-        if(id.equals(EParameterName.DRIVER_JAR.getName())){
-            ConnectionUtil.getDriverJar(value);
-        }
     }
 }

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/projectsetting/StatsAndLogsHelper.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/projectsetting/StatsAndLogsHelper.java
@@ -432,7 +432,10 @@ public class StatsAndLogsHelper extends Utils {
             String moduleName = module.getModuleName();
             if (moduleName != null) {
                 moduleNameList.add(moduleName);
-                moduleValueList.add(TalendTextUtils.addQuotes(moduleName));
+                String moduleValue = TalendTextUtils.addQuotes(module.getMavenUri());
+                if (!moduleValueList.contains(moduleValue)) {
+                    moduleValueList.add(moduleValue);
+                }
             }
         }
         Comparator<String> comprarator = new IgnoreCaseComparator();

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/JavaProcessUtil.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/JavaProcessUtil.java
@@ -27,10 +27,9 @@ import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang.StringUtils;
-import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.emf.common.util.EList;
 import org.talend.commons.exception.ExceptionHandler;
 import org.talend.commons.runtime.service.ITaCoKitService;
@@ -52,6 +51,8 @@ import org.talend.core.model.properties.Item;
 import org.talend.core.model.properties.ProcessItem;
 import org.talend.core.model.utils.ContextParameterUtils;
 import org.talend.core.model.utils.TalendTextUtils;
+import org.talend.core.runtime.maven.MavenConstants;
+import org.talend.core.runtime.maven.MavenUrlHelper;
 import org.talend.core.runtime.process.LastGenerationInfo;
 import org.talend.core.runtime.process.TalendProcessOptionConstants;
 import org.talend.core.utils.BitwiseOptionUtils;
@@ -519,104 +520,85 @@ public class JavaProcessUtil {
         }
     }
 
-    private static void getModulesInTable(final IProcess process, IElementParameter curParam,
-            List<ModuleNeeded> modulesNeeded) {
-
+    private static void getModulesInTable(final IProcess process, IElementParameter curParam, List<ModuleNeeded> modulesNeeded) {
         if (!(curParam.getValue() instanceof List)) {
             return;
         }
         List<Map<String, Object>> values = (List<Map<String, Object>>) curParam.getValue();
-        if (values != null && !values.isEmpty()) {
-            boolean updateCustomMavenUri = false;
-            Object[] listItemsValue = curParam.getListItemsValue();
-            if (listItemsValue != null && listItemsValue.length > 0 && listItemsValue[0] instanceof IElementParameter) {
-                for (Object o : listItemsValue) {
-                    IElementParameter param = (IElementParameter) o;
-                    if (param.getFieldType() == EParameterFieldType.MODULE_LIST) {
-                        for (Map<String, Object> line : values) {
-                            String moduleName = (String) line.get(param.getName());
-                            if (moduleName != null && !"".equals(moduleName)) { //$NON-NLS-1$
-
-                                boolean isContextMode = ContextParameterUtils.containContextVariables(moduleName);
-                                if (isContextMode) {
-                                    List<IContext> listContext = process.getContextManager().getListContext();
-                                    for (IContext context : listContext) {
-                                        List<IContextParameter> contextParameterList =
-                                                context.getContextParameterList();
-                                        for (IContextParameter contextPara : contextParameterList) {
-                                            String var = ContextParameterUtils.getVariableFromCode(moduleName);
-                                            if (var.equals(contextPara.getName())) {
-                                                String value =
-                                                        context.getContextParameter(contextPara.getName()).getValue();
-                                                if (StringUtils.isBlank(value)) {
-                                                    continue;
-                                                }
-                                                if (curParam.getName().equals(EParameterName.DRIVER_JAR.getName())
-                                                        && value.contains(";")) { //$NON-NLS-1$
-                                                    String[] jars = value.split(";"); //$NON-NLS-1$
-                                                    for (String jar2 : jars) {
-                                                        String jar = jar2;
-                                                        jar = jar.substring(jar.lastIndexOf("\\") + 1); //$NON-NLS-1$
-                                                        ModuleNeeded module = null;
-                                                        String jarName = TalendTextUtils.removeQuotes(jar);
-                                                        if (!jarName.toLowerCase().endsWith(".jar")) {
-                                                            module = ModulesNeededProvider
-                                                                    .getModuleNeededById(jarName);
-                                                            if (module == null) {
-                                                                module = new ModuleNeeded(null, jarName, null, true);
-                                                            }
-                                                        } else {
-                                                            module = new ModuleNeeded(null, jarName, null, true);
-                                                        }
-                                                        modulesNeeded.add(module);
-                                                    }
-                                                } else if (curParam.getName().equals("connection.driverTable") //$NON-NLS-1$
-                                                        && value.contains(";")) { //$NON-NLS-1$
-                                                    String[] jars = value.split(";"); //$NON-NLS-1$
-                                                    for (String jar2 : jars) {
-                                                        String jar = jar2;
-                                                        jar = jar.substring(jar.lastIndexOf("\\") + 1); //$NON-NLS-1$
-                                                        ModuleNeeded module = new ModuleNeeded(null,
-                                                                TalendTextUtils.removeQuotes(jar), null, true);
-                                                        modulesNeeded.add(module);
-                                                    }
-                                                } else {
-                                                    value = value.substring(value.lastIndexOf("\\") + 1); //$NON-NLS-1$
-
-                                                    ModuleNeeded module = new ModuleNeeded(null,
-                                                            TalendTextUtils.removeQuotes(value), null, true);
-                                                    modulesNeeded.add(module);
-                                                }
-                                            }
-                                        }
+        if (values == null || values.isEmpty()) {
+            return;
+        }
+        Object[] listItemsValue = curParam.getListItemsValue();
+        if (listItemsValue == null || listItemsValue.length == 0 && !(listItemsValue[0] instanceof IElementParameter)) {
+            return;
+        }
+        for (Object o : listItemsValue) {
+            IElementParameter param = (IElementParameter) o;
+            if (param.getFieldType() != EParameterFieldType.MODULE_LIST) {
+                continue;
+            }
+            for (Map<String, Object> line : values) {
+                String moduleName = (String) line.get(param.getName());
+                if (StringUtils.isBlank(moduleName)) {
+                    continue;
+                }
+                boolean isContextMode = ContextParameterUtils.containContextVariables(moduleName);
+                if (isContextMode) {
+                    List<IContext> listContext = process.getContextManager().getListContext();
+                    for (IContext context : listContext) {
+                        List<IContextParameter> contextParameterList = context.getContextParameterList();
+                        for (IContextParameter contextPara : contextParameterList) {
+                            String var = ContextParameterUtils.getVariableFromCode(moduleName);
+                            if (!var.equals(contextPara.getName())) {
+                                continue;
+                            }
+                            String value = context.getContextParameter(contextPara.getName()).getValue();
+                            if (StringUtils.isBlank(value)) {
+                                continue;
+                            }
+                            if (!value.contains(";")) { //$NON-NLS-1$
+                                modulesNeeded
+                                        .add(ModuleNeeded.newInstance(null, TalendTextUtils.removeQuotes(value), null, true));
+                                continue;
+                            }
+                            if (curParam.getName().equals(EParameterName.DRIVER_JAR.getName())) {
+                                Stream.of(value.split(";")).forEach(s -> { //$NON-NLS-1$
+                                    ModuleNeeded module = null;
+                                    String jarName = TalendTextUtils.removeQuotes(s);
+                                    if (!jarName.toLowerCase().endsWith(".jar")) { //$NON-NLS-1$
+                                        module = ModulesNeededProvider.getModuleNeededById(jarName);
                                     }
-
-                                } else {
-                                    ModuleNeeded mn = null;
-                                    if (!moduleName.toLowerCase().endsWith(".jar")) {
-                                        mn = ModulesNeededProvider.getModuleNeededById(moduleName);
-                                        if (mn == null) {
-                                            mn = getModuleValue(process, moduleName);
-                                        }
-                                    } else {
-                                        mn = getModuleValue(process, moduleName);
+                                    if (module == null) {
+                                        module = ModuleNeeded.newInstance(null, TalendTextUtils.removeQuotes(s), null, true);
                                     }
-
-                                    if (line.get("JAR_NEXUS_VERSION") != null) {
-                                        String a = moduleName.replaceFirst("[.][^.]+$", "");
-                                        mn.setMavenUri("mvn:org.talend.libraries/" + a + "/"
-                                                + line.get("JAR_NEXUS_VERSION") + "/jar");
-
-                                    }
-                                    modulesNeeded.add(mn);
-                                }
+                                    modulesNeeded.add(module);
+                                });
+                                continue;
+                            }
+                            if (curParam.getName().equals("connection.driverTable")) { //$NON-NLS-1$
+                                Stream.of(value.split(";")).forEach(s -> modulesNeeded //$NON-NLS-1$
+                                        .add(ModuleNeeded.newInstance(null, TalendTextUtils.removeQuotes(s), null, true)));
                             }
                         }
                     }
+                } else {
+                    ModuleNeeded module = null;
+                    if (!moduleName.toLowerCase().endsWith(".jar")) { //$NON-NLS-1$
+                        module = ModulesNeededProvider.getModuleNeededById(moduleName);
+                    }
+                    if (module == null) {
+                        module = getModuleValue(process, moduleName);
+                    }
+                    String nexusJarVersion = (String) line.get("JAR_NEXUS_VERSION"); //$NON-NLS-1$
+                    if (nexusJarVersion != null) {
+                        String mvnUrl = MavenUrlHelper.generateMvnUrl(MavenConstants.DEFAULT_LIB_GROUP_ID,
+                                moduleName.replaceFirst("[.][^.]+$", ""), nexusJarVersion, MavenConstants.TYPE_JAR, null);
+                        module.setMavenUri(mvnUrl);
+                    }
+                    modulesNeeded.add(module);
                 }
             }
         }
-
     }
 
     private static ModuleNeeded getModuleValue(final IProcess process, String moduleValue) {
@@ -635,7 +617,7 @@ public class JavaProcessUtil {
                 }
             }
         }
-        return new ModuleNeeded(null, TalendTextUtils.removeQuotes(moduleValue), null, true);
+        return ModuleNeeded.newInstance(null, moduleValue, null, true);
     }
 
     /**
@@ -652,7 +634,6 @@ public class JavaProcessUtil {
             // added for bug 13592. new parameter DRIVER_JAR was used for jdbc connection
             if (value != null && value instanceof List) {
                 List list = (List) value;
-                boolean updateCustomMavenUri = false;
                 for (Object element : list) {
                     if (element instanceof HashMap) {
                         HashMap map = (HashMap) element; // JAR_NAME
@@ -670,23 +651,18 @@ public class JavaProcessUtil {
                                     getModulesInTable(process, curParam, modulesNeeded);
                                 } else {
                                     ModuleNeeded module = null;
-
+                                    String moduleName = TalendTextUtils.removeQuotes(driverName);
                                     if (StringUtils.isNotBlank((String) map.get("JAR_NEXUS_VERSION"))) {
-                                        module = new ModuleNeeded(null, null, true,
-                                                "mvn:org.talend.libraries/"
-                                                        + TalendTextUtils.removeQuotes(driverName).replaceFirst(
-                                                                "[.][^.]+$", "")
-                                                        + "/" + (String) map.get("JAR_NEXUS_VERSION") + "/jar");
-
+                                        String mvnUrl = MavenUrlHelper.generateMvnUrl(MavenConstants.DEFAULT_LIB_GROUP_ID,
+                                                moduleName.replaceFirst("[.][^.]+$", ""), (String) map.get("JAR_NEXUS_VERSION"),
+                                                MavenConstants.TYPE_JAR, null);
+                                        module = ModuleNeeded.newInstance(null, mvnUrl, null, true);
                                     } else {
-                                        String moduleName = TalendTextUtils.removeQuotes(driverName);
                                         if (!moduleName.toLowerCase().endsWith(".jar")) {
                                             module = ModulesNeededProvider.getModuleNeededById(moduleName);
-                                            if (module == null) {
-                                                module = new ModuleNeeded(null, moduleName, null, true);
-                                            }
-                                        } else {
-                                            module = new ModuleNeeded(null, moduleName, null, true);
+                                        }
+                                        if (module == null) {
+                                            module = ModuleNeeded.newInstance(null, moduleName, null, true);
                                         }
                                     }
                                     modulesNeeded.add(module);
@@ -779,10 +755,7 @@ public class JavaProcessUtil {
         if (contextParam != null) {
             String values = contextParam.getValue();
             if (StringUtils.isNotBlank(values)) {
-                IPath path = new Path(values); // if it's path
-                String fileName = path.lastSegment(); // get the file name only.
-                ModuleNeeded module = new ModuleNeeded(null, fileName, null, true);
-                return module;
+                return ModuleNeeded.newInstance(null, values, null, true);
             }
         }
         return null;

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/UpdateModuleListInComponentsMigrationTask.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/UpdateModuleListInComponentsMigrationTask.java
@@ -1,0 +1,273 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.designer.core.utils;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.emf.common.util.EList;
+import org.talend.commons.exception.ExceptionHandler;
+import org.talend.commons.runtime.model.emf.EmfHelper;
+import org.talend.core.CorePlugin;
+import org.talend.core.model.components.ComponentCategory;
+import org.talend.core.model.components.IComponent;
+import org.talend.core.model.general.ModuleNeeded;
+import org.talend.core.model.metadata.builder.connection.Connection;
+import org.talend.core.model.metadata.builder.connection.DatabaseConnection;
+import org.talend.core.model.migration.AbstractItemMigrationTask;
+import org.talend.core.model.process.EParameterFieldType;
+import org.talend.core.model.process.IElementParameter;
+import org.talend.core.model.properties.ConnectionItem;
+import org.talend.core.model.properties.Item;
+import org.talend.core.model.properties.JobletProcessItem;
+import org.talend.core.model.properties.ProcessItem;
+import org.talend.core.model.repository.ERepositoryObjectType;
+import org.talend.core.model.utils.TalendTextUtils;
+import org.talend.core.repository.model.ProxyRepositoryFactory;
+import org.talend.core.runtime.maven.MavenUrlHelper;
+import org.talend.core.ui.component.ComponentsFactoryProvider;
+import org.talend.designer.core.model.utils.emf.talendfile.ElementParameterType;
+import org.talend.designer.core.model.utils.emf.talendfile.ElementValueType;
+import org.talend.designer.core.model.utils.emf.talendfile.NodeType;
+import org.talend.designer.core.model.utils.emf.talendfile.ParametersType;
+import org.talend.designer.core.model.utils.emf.talendfile.ProcessType;
+import org.talend.migration.IMigrationTask.ExecutionResult;
+import org.talend.repository.model.migration.EncryptPasswordInComponentsMigrationTask.FakeNode;
+
+/**
+ * created by bhe on Oct 13, 2020 Detailled comment
+ *
+ */
+public class UpdateModuleListInComponentsMigrationTask extends AbstractItemMigrationTask {
+
+    protected ProxyRepositoryFactory factory = ProxyRepositoryFactory.getInstance();
+
+    @Override
+    public List<ERepositoryObjectType> getTypes() {
+        List<ERepositoryObjectType> toReturn = new ArrayList<ERepositoryObjectType>();
+        toReturn.addAll(getAllMetaDataType());
+        toReturn.addAll(ERepositoryObjectType.getAllTypesOfProcess());
+        toReturn.addAll(ERepositoryObjectType.getAllTypesOfProcess2());
+        toReturn.addAll(ERepositoryObjectType.getAllTypesOfTestContainer());
+        toReturn.add(ERepositoryObjectType.JDBC);
+        return toReturn;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.talend.core.model.migration.AbstractItemMigrationTask#execute(org .talend.core.model.properties.Item)
+     */
+    @Override
+    public ExecutionResult execute(Item item) {
+        boolean modified = false;
+        try {
+            if (item instanceof ConnectionItem) {
+                modified = modified || updateConnectionItem((ConnectionItem) item);
+            } else if (item instanceof ProcessItem) {
+                ProcessItem processItem = (ProcessItem) item;
+                modified = modified || updateProcessItem(item, processItem.getProcess());
+            } else if (item instanceof JobletProcessItem) {
+                JobletProcessItem jobletItem = (JobletProcessItem) item;
+                modified = modified || updateProcessItem(item, jobletItem.getJobletProcess());
+            }
+        } catch (Exception ex) {
+            ExceptionHandler.process(ex);
+            return ExecutionResult.FAILURE;
+        }
+
+        if (modified) {
+            try {
+                factory.save(item, true);
+                // regenerate poms for affected job
+                CorePlugin.getDefault().getRunProcessService().generatePom(item);
+                return ExecutionResult.SUCCESS_NO_ALERT;
+            } catch (Exception ex) {
+                ExceptionHandler.process(ex);
+                return ExecutionResult.FAILURE;
+            }
+        }
+        return ExecutionResult.NOTHING_TO_DO;
+    }
+
+    private boolean updateConnectionItem(ConnectionItem connectionItem) throws Exception {
+        boolean modified = false;
+        if (connectionItem != null && connectionItem.getConnection() != null && !connectionItem.getConnection().isContextMode()) {
+            Connection connection = connectionItem.getConnection();
+            if (connection instanceof DatabaseConnection) {
+                modified = updateDatabaseConnection((DatabaseConnection) connection);
+            }
+        }
+        return modified;
+    }
+
+    protected boolean updateDatabaseConnection(DatabaseConnection dbConnection) throws Exception {
+        String driverJar = dbConnection.getDriverJarPath();
+        if (driverJar != null) {
+            String[] jars = driverJar.split(";");
+            StringBuffer sb = new StringBuffer();
+            for (String jar : jars) {
+                String uri = getMavenUriForJar(jar);
+                if (sb.length() > 0) {
+                    sb.append(";");
+                }
+                sb.append(uri);
+            }
+
+            dbConnection.setDriverJarPath(sb.toString());
+            return true;
+        }
+        return false;
+    }
+
+    private boolean updateProcessItem(Item item, ProcessType processType) throws Exception {
+        EmfHelper.visitChilds(processType);
+
+        boolean modified = false;
+
+        // job settings
+        if (checkJobsettintsParameter(item, processType)) {
+            modified = true;
+        }
+
+        // nodes parameters
+        if (checkNodes(item, processType)) {
+            modified = true;
+        }
+        return modified;
+    }
+
+    protected boolean checkJobsettintsParameter(Item item, ProcessType processType) throws Exception {
+        boolean modified = false;
+
+        ParametersType parameters = processType.getParameters();
+        if (parameters != null) {
+            for (Object p : parameters.getElementParameter()) {
+                if (p instanceof ElementParameterType) {
+                    ElementParameterType param = (ElementParameterType) p;
+                    // variable name used for Stat&Logs
+                    modified = updateParam(param);
+                }
+            }
+        }
+        return modified;
+    }
+
+    protected boolean checkNodesFromEmf(Item item, ProcessType processType) throws Exception {
+        boolean modified = false;
+        for (Object nodeObject : processType.getNode()) {
+            NodeType nodeType = (NodeType) nodeObject;
+            if (nodeType.getComponentName().equals("cConfig")) {
+                return false;
+            }
+            for (Object paramObjectType : nodeType.getElementParameter()) {
+                ElementParameterType param = (ElementParameterType) paramObjectType;
+                modified = modified || updateParam(param);
+            }
+        }
+        return modified;
+    }
+
+    protected boolean checkNodes(Item item, ProcessType processType) throws Exception {
+        boolean modified = checkNodesFromEmf(item, processType);
+
+        if (!modified) {
+            // some versions of the job doesn't have any field type saved in the job, so we will check from the existing
+            // component field type
+            ComponentCategory category = ComponentCategory.getComponentCategoryFromItem(item);
+            for (Object nodeObjectType : processType.getNode()) {
+                NodeType nodeType = (NodeType) nodeObjectType;
+                if (nodeType.getComponentName().equals("cConfig")) {
+                    return false;
+                }
+                IComponent component = ComponentsFactoryProvider.getInstance().get(nodeType.getComponentName(),
+                        category.getName());
+                if (component == null) {
+                    continue;
+                }
+                FakeNode fNode = new FakeNode(component);
+                for (Object paramObjectType : nodeType.getElementParameter()) {
+                    ElementParameterType param = (ElementParameterType) paramObjectType;
+                    IElementParameter paramFromEmf = fNode.getElementParameter(param.getName());
+                    if (paramFromEmf != null) {
+                        modified = modified || updateParam(param);
+                    }
+                }
+            }
+        }
+        return modified;
+    }
+
+    private List<ERepositoryObjectType> getAllMetaDataType() {
+        List<ERepositoryObjectType> list = new ArrayList<ERepositoryObjectType>();
+        list.add(ERepositoryObjectType.METADATA_CONNECTIONS);
+        return list;
+    }
+
+    private static boolean updateParam(ElementParameterType param) {
+        boolean modified = false;
+        if (param.getField() != null) {
+            if (param.getField().equals(EParameterFieldType.MODULE_LIST.name()) && param.getValue() != null) {
+                String jarUri = getMavenUriForJar(param.getValue());
+                param.setValue(jarUri);
+                modified = true;
+            }
+
+            if ("DRIVER_JAR".equals(param.getName()) && param.getField().equals(EParameterFieldType.TABLE.name())
+                    && param.getElementValue() != null) {
+
+                List<ElementValueType> newListValue = new ArrayList();
+                EList<?> elementValues = param.getElementValue();
+                for (Object ev : elementValues) {
+                    ElementValueType evt = (ElementValueType) ev;
+                    String jarUri = getMavenUriForJar(evt.getValue());
+                    evt.setValue(jarUri);
+                    newListValue.add(evt);
+                    modified = true;
+                }
+
+                if (modified) {
+                    param.getElementValue().clear();
+                    param.getElementValue().addAll(newListValue);
+                }
+            }
+        }
+        return modified;
+    }
+
+    public static String getMavenUriForJar(String jarName) {
+        jarName = TalendTextUtils.removeQuotes(jarName);
+        if (!StringUtils.isEmpty(jarName) && !jarName.startsWith(MavenUrlHelper.MVN_PROTOCOL)) {
+            ModuleNeeded mod = new ModuleNeeded(null, jarName, null, true);
+            if (!StringUtils.isEmpty(mod.getCustomMavenUri())) {
+                return mod.getCustomMavenUri();
+            }
+            return mod.getMavenUri();
+        }
+        return jarName;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.talend.core.model.migration.IProjectMigrationTask#getOrder()
+     */
+    @Override
+    public Date getOrder() {
+        GregorianCalendar gc = new GregorianCalendar(2020, 10, 13, 12, 0, 0);
+        return gc.getTime();
+    }
+}

--- a/main/plugins/org.talend.repository.generic/src/main/java/org/talend/repository/generic/ui/DBDynamicComposite.java
+++ b/main/plugins/org.talend.repository.generic/src/main/java/org/talend/repository/generic/ui/DBDynamicComposite.java
@@ -77,7 +77,27 @@ public class DBDynamicComposite extends DynamicComposite{
                         }
 
                     }
-                    genericElementParameter.setValue(list);
+                    boolean setVal = false;
+                    if (genericElementParameter.getValue() == null) {
+                        setVal = true;
+                    } else {
+                        List<Map<String, String>> oldValueList = (List<Map<String, String>>) genericElementParameter.getValue();
+                        if (oldValueList.isEmpty()) {
+                            setVal = true;
+                        } else {
+                            boolean allEmpty = true;
+                            for (Map<String, String> val : oldValueList) {
+                                if (!val.isEmpty()) {
+                                    allEmpty = false;
+                                    break;
+                                }
+                            }
+                            setVal = allEmpty;
+                        }
+                    }
+                    if (setVal) {
+                        genericElementParameter.setValue(list);
+                    }
                 }
             }
             if (genericElementParameter.getName()

--- a/test/plugins/org.talend.designer.core.generic.test/src/main/java/org/talend/designer/core/generic/model/GenericTableUtilsTest.java
+++ b/test/plugins/org.talend.designer.core.generic.test/src/main/java/org/talend/designer/core/generic/model/GenericTableUtilsTest.java
@@ -184,7 +184,8 @@ public class GenericTableUtilsTest {
         listString.add("mvn:org.talend.libraries/mysql-connector-java-5.1.30-bin/6.0.0");
         listString.add("mvn:org.talend.libraries/mysql-connector-java-5.1.40-bin/6.0.0");
         String jars = GenericTableUtils.getDriverJarPaths(listString);
-        assertEquals(jars, "mysql-connector-java-5.1.30-bin.jar;mysql-connector-java-5.1.40-bin.jar");
+        assertEquals(jars,
+                "mvn:org.talend.libraries/mysql-connector-java-5.1.30-bin/6.0.0;mvn:org.talend.libraries/mysql-connector-java-5.1.40-bin/6.0.0");
 
         listString = new ArrayList<String>();
         listString.add("mysql-connector-java-5.1.30-bin.jar");


### PR DESCRIPTION
…IST (#5278)

* feat(TUP-25246): support custom maven uri for components and dbwizard

* feat(TUP-28342):Save maven url for components with parameter MODULE_LIST

* feat(TUP-28342): Save driver jar as mvnurl for implicit context.

* feat(TUP-25246): Fix necessary UI updates

* feat(TUP-25246): add migration to replace jar name by uri

* feat(TUP-25246): add migration

* feat(TUP-25246): generate poms after migration

* feat(TUP-25246): fix migrate driver jar path

* feat(TUP-25246): Fix context jar path and disable migration and show jar name instead of uri for modulelist

* feat(TUP-25246): fix stats and logs

* feat(TUP-25246): show jar name instead of uri for module table

* feat(TUP-25246): remove quotes

* feat(TUP-25246): fix parse maven uri from context

* feat(TUP-25246): use maven uri of component instead of driver jar path

* feat(TUP-25246): add workaround for components

Co-authored-by: Zhiwei Xue <zwxue@talend.com>

**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TUP-25246

**What is the new behavior?**
Automatically detect maven uri for jar

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


