### PR TITLE
fix(TDI-44935): reuse custom query expression

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tAmazonOracleRow/tAmazonOracleRow_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tAmazonOracleRow/tAmazonOracleRow_main.javajet
@@ -54,11 +54,11 @@ for(IConnection conn : outgoingConns) {
 		<%
 	}
 }
-log4jCodeGenerateUtil.query(node);
 %>
 query_<%=cid %> = <%=dbquery%>;
 whetherReject_<%=cid%> = false;
 <%
+log4jCodeGenerateUtil.query(node, "query_" + cid);
 List<IMetadataTable> metadatas = node.getMetadataList();
 if ((metadatas!=null)&&(metadatas.size()>0)) {
 	IMetadataTable metadata = metadatas.get(0);
@@ -131,7 +131,7 @@ try {
 		<%
 		}
 	}
-	log4jCodeGenerateUtil.logInfo(node,"info",cid+" - Execute the query: '\" + "+dbquery +" + \"' has finished.");
+	log4jCodeGenerateUtil.logInfo(node,"info",cid+" - Execute the query: '\" + query_" + cid  + " + \"' has finished.");
 %>
 <%	//feature 0010425
 	if(usePrepareStatement){

--- a/main/plugins/org.talend.designer.components.localprovider/components/tOracleRow/tOracleRow_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tOracleRow/tOracleRow_main.javajet
@@ -54,11 +54,11 @@ for(IConnection conn : outgoingConns) {
 		<%
 	}
 }
-log4jCodeGenerateUtil.query(node);
 %>
 query_<%=cid %> = <%=dbquery%>;
 whetherReject_<%=cid%> = false;
 <%
+log4jCodeGenerateUtil.query(node, "query_" + cid);
 List<IMetadataTable> metadatas = node.getMetadataList();
 if ((metadatas!=null)&&(metadatas.size()>0)) {
 	IMetadataTable metadata = metadatas.get(0);
@@ -131,7 +131,7 @@ try {
 		<%
 		}
 	}
-	log4jCodeGenerateUtil.logInfo(node,"info",cid+" - Execute the query: '\" + "+dbquery +" + \"' has finished.");
+	log4jCodeGenerateUtil.logInfo(node,"info",cid+" - Execute the query: '\" + query_" + cid  + " + \"' has finished.");
 %>
 <%	//feature 0010425
 	if(usePrepareStatement){

--- a/main/plugins/org.talend.designer.components.localprovider/components/templates/DB/Input/AbstractDBInputBegin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/templates/DB/Input/AbstractDBInputBegin.javajet
@@ -93,9 +93,7 @@ imports="
 		    <%dbInputBeginUtil.createStatement(node);%>
 
 		    String dbquery_<%=cid%> = <%=dbInputBeginUtil.getQueryString(node)%>;
-			<%if(isLog4jEnabled){%>
-                log.debug("<%=cid%> - Executing the query: '"+dbquery_<%=cid%>+"'.");
-			<%}%>
+		    <% log4jCodeGenerateUtil.query(node, "dbquery_" + cid); %>
 
             <% 
             if(isAmazonAurora){

--- a/main/plugins/org.talend.designer.components.localprovider/components/templates/DB/Row/AbstractDBRowMain.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/templates/DB/Row/AbstractDBRowMain.javajet
@@ -55,11 +55,11 @@ for(IConnection conn : outgoingConns) {
 		<%
 	}
 }
-log4jCodeGenerateUtil.query(node);
 %>
 query_<%=cid %> = <%=dbquery%>;
 whetherReject_<%=cid%> = false;
 <%
+log4jCodeGenerateUtil.query(node, "query_" + cid);
 List<IMetadataTable> metadatas = node.getMetadataList();
 if ((metadatas!=null)&&(metadatas.size()>0)) {
 	IMetadataTable metadata = metadatas.get(0);
@@ -128,7 +128,7 @@ try {
 		<%
 		}
 	}
-	log4jCodeGenerateUtil.logInfo(node,"debug",cid+" - Execute the query: '\" + "+dbquery +" + \"' has finished.");
+	log4jCodeGenerateUtil.logInfo(node,"debug",cid+" - Execute the query: '\" + query_" + cid  + " + \"' has finished.");
 %>
 <%
 	if(usePrepareStatement){

--- a/main/plugins/org.talend.designer.components.localprovider/components/templates/Log4j/Log4jDBConnUtil.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/templates/Log4j/Log4jDBConnUtil.javajet
@@ -190,6 +190,16 @@ imports="
 			<%
 		}
 
+		public void query(INode node, String dbQueryVariableName){
+			beforeComponentProcess(node);
+			//for input
+			logInfo(node,"debug",cid+" - Executing the query: '\" + "+dbQueryVariableName +" + \"'.");
+		}
+
+		/**
+		* @deprecated please use another method instead: query(INode node, String dbQueryVariableName) because execution of the query expression can be not idempotent
+		*/
+		@Deprecated
 		public void query(INode node){
 			beforeComponentProcess(node);
 			//for input


### PR DESCRIPTION
* make query expression idempotent in the generated code
* use instead of duplication of custom query expression a variable

**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-44935

**What is the new behavior?**
logger used idempotent query

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard

**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
It's a backport from maintenenance/7.3

