### PR TITLE
chore(TDI-42384): remove old neo4j repo from pom

### DIFF
--- a/main/plugins/org.talend.designer.components.libs/libs_src/neo4j-talend-component/pom.xml
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/neo4j-talend-component/pom.xml
@@ -336,14 +336,6 @@
 	<!-- ================ -->
 	<!-- = Repositories = -->
 	<!-- ================ -->
-	<repositories>
-		<!-- Neo4j repository -->
-		<repository>
-			<id>neo4j-releases</id>
-			<name>Neo4j</name>
-			<url>http://m2.neo4j.org/content/repositories/public/</url>
-		</repository>
-	</repositories>
 
 
 	<distributionManagement>


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Fixing ticket https://jira.talendforge.org/browse/TDI-42384. We don't need neo4j repo as all the required deps can be downloaded from central.

