### PR TITLE
bugfix(TUP-29131) Replace jar name by maven uri for spark jobs (#5444)

### DIFF
--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/cmd/ChangeValuesFromRepository.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/cmd/ChangeValuesFromRepository.java
@@ -616,12 +616,7 @@ public class ChangeValuesFromRepository extends ChangeMetadataCommand {
                                         Map map = new HashMap();
                                         String driver = String.valueOf(((Map) value).get("drivers"));
                                         if (driver != null) {
-                                            MavenArtifact artifact = MavenUrlHelper
-                                                    .parseMvnUrl(TalendTextUtils.removeQuotes(driver));
-                                            if (artifact != null) {
-                                                driver = artifact.getFileName();
-                                            }
-                                            map.put("JAR_NAME", driver);
+                                            map.put("JAR_NAME", TalendTextUtils.removeQuotes(driver));
                                             newValue.add(map);
                                         }
                                     }

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/cmd/RepositoryChangeMetadataCommand.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/cmd/RepositoryChangeMetadataCommand.java
@@ -368,11 +368,7 @@ public class RepositoryChangeMetadataCommand extends ChangeMetadataCommand {
                             if (value instanceof Map) {
                                 Map map = new HashMap();
                                 String driver = String.valueOf(((Map) value).get("drivers"));
-                                MavenArtifact artifact = MavenUrlHelper.parseMvnUrl(TalendTextUtils.removeQuotes(driver));
-                                if (artifact != null) {
-                                    driver = artifact.getFileName();
-                                }
-                                map.put("JAR_NAME", driver);
+                                map.put("JAR_NAME", TalendTextUtils.removeQuotes(driver));
                                 newValue.add(map);
                             }
                         }


### PR DESCRIPTION
* fix(TUP-29131): Replace jar name by uri for spark job

* fix(TUP-29131): Replace jar name by maven uri for spark jobs

**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TUP-29131

**What is the new behavior?**
Replace jar name by maven uri for spark jobs

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


