### PR TITLE
fix(TUP-29224) auto increment the index according to the drag/drop column numbers.

### DIFF
--- a/main/plugins/org.talend.designer.dbmap/src/main/java/org/talend/designer/dbmap/managers/UIManager.java
+++ b/main/plugins/org.talend.designer.dbmap/src/main/java/org/talend/designer/dbmap/managers/UIManager.java
@@ -242,7 +242,7 @@ public class UIManager extends AbstractUIManager {
                         if (event.index != null) {
                             int index = event.index;
                             for (IMetadataColumn metadataColumn : metadataColumns) {
-                                addColumn(metadataColumn, dataMapTableView, index);
+                                addColumn(metadataColumn, dataMapTableView, index++);
                             }
                         } else if (event.indicesTarget != null) {
                             List<Integer> indicesTarget = event.indicesTarget;


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TUP-29224
ELTMAP generate wrong SQL When dragging multiple columns at the same time, because the column was always added into same index, so the order is opposite.

**What is the new behavior?**
auto increment the index according to the drag/drop column numbers.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


