### PR TITLE
fix(TDI-45260): fix cr issue, improve crlf row separator performance

### DIFF
--- a/main/plugins/org.talend.designer.components.libs/libs_src/talend_file_enhanced/pom.xml
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/talend_file_enhanced/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>org.talend.components.lib</groupId>
 	<artifactId>talend_file_enhanced</artifactId>
 	<name>talend_file_enhanced</name>
-	<version>1.0</version>
+	<version>1.1</version>
 
 	<properties>
 		<talend.nexus.url>https://artifacts-oss.talend.com</talend.nexus.url>


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-45260
CR issue, CRLF row separator low performance with Scanner

**What is the new behavior?**
Fixed problem with CR for LF row separator, increased performance for CRLF.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


