### PR TITLE
fix(TUP-29693): Do not replace maven uri for context inside jarname

### DIFF
--- a/main/plugins/org.talend.designer.core/plugin.xml
+++ b/main/plugins/org.talend.designer.core/plugin.xml
@@ -791,6 +791,15 @@
              name="UpdateModuleListInComponentsMigrationTask"
              version="7.3.1">
        </projecttask>
+       <projecttask
+             beforeLogon="false"
+             breaks="7.3.0"
+             class="org.talend.designer.core.utils.FixModuleListInBDJDBCMigrationTask"
+             description="Fix context used inside module list."
+             id="org.talend.designer.core.utils.FixModuleListInBDJDBCMigrationTask"
+             name="FixModuleListInBDJDBCMigrationTask"
+             version="7.3.1">
+       </projecttask>
     </extension>
     <extension
           point="org.talend.repository.projectsetting_page">

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/FixModuleListInBDJDBCMigrationTask.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/FixModuleListInBDJDBCMigrationTask.java
@@ -14,6 +14,7 @@ package org.talend.designer.core.utils;
 
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.talend.core.model.utils.TalendTextUtils;
@@ -29,7 +30,7 @@ public class FixModuleListInBDJDBCMigrationTask extends UpdateModuleListInCompon
     protected ProxyRepositoryFactory factory = ProxyRepositoryFactory.getInstance();
 
 
-    public String getMavenUriForJar(String jarName) {
+    public String getMavenUriForJar(String jarName, List ctxs) {
         jarName = TalendTextUtils.removeQuotes(jarName);
 
         if (StringUtils.isEmpty(jarName) || !jarName.startsWith(MavenUrlHelper.MVN_PROTOCOL)) {
@@ -40,7 +41,7 @@ public class FixModuleListInBDJDBCMigrationTask extends UpdateModuleListInCompon
         if (vals.length > 3 && vals[0].equals("mvn:org.talend.libraries") && vals[2].equals("6.0.0-SNAPSHOT")
                 && (vals[1].equals("context") || vals[1].startsWith("((String)context"))) {
             String ctx = vals[1] + "." + vals[vals.length - 1];
-            boolean containContext = containContext(ctx);
+            boolean containContext = containContext(ctx, ctxs);
             if (containContext) {
                 return ctx;
             }

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/FixModuleListInBDJDBCMigrationTask.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/FixModuleListInBDJDBCMigrationTask.java
@@ -206,8 +206,7 @@ public class FixModuleListInBDJDBCMigrationTask extends AbstractItemMigrationTas
 
         String[] vals = val.split("/");
         if (vals.length > 3 && vals[0].equals("mvn:org.talend.libraries") && vals[2].equals("6.0.0-SNAPSHOT")
-                && (vals[1].equals("context") || vals[1].startsWith("((String)context"))
-                && !vals[vals.length - 1].equals("jar")) {
+                && (vals[1].equals("context") || vals[1].startsWith("((String)context"))) {
             return vals[1] + "." + vals[vals.length - 1];
         }
         return null;

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/FixModuleListInBDJDBCMigrationTask.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/FixModuleListInBDJDBCMigrationTask.java
@@ -1,0 +1,226 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.designer.core.utils;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.emf.common.util.EList;
+import org.talend.commons.exception.ExceptionHandler;
+import org.talend.commons.runtime.model.emf.EmfHelper;
+import org.talend.core.CorePlugin;
+import org.talend.core.model.components.ComponentCategory;
+import org.talend.core.model.components.IComponent;
+import org.talend.core.model.migration.AbstractItemMigrationTask;
+import org.talend.core.model.process.EParameterFieldType;
+import org.talend.core.model.process.IElementParameter;
+import org.talend.core.model.properties.Item;
+import org.talend.core.model.properties.JobletProcessItem;
+import org.talend.core.model.properties.ProcessItem;
+import org.talend.core.model.repository.ERepositoryObjectType;
+import org.talend.core.model.utils.TalendTextUtils;
+import org.talend.core.repository.model.ProxyRepositoryFactory;
+import org.talend.core.runtime.maven.MavenUrlHelper;
+import org.talend.core.ui.component.ComponentsFactoryProvider;
+import org.talend.designer.core.model.utils.emf.talendfile.ElementParameterType;
+import org.talend.designer.core.model.utils.emf.talendfile.ElementValueType;
+import org.talend.designer.core.model.utils.emf.talendfile.NodeType;
+import org.talend.designer.core.model.utils.emf.talendfile.ProcessType;
+import org.talend.repository.model.migration.EncryptPasswordInComponentsMigrationTask.FakeNode;
+
+/**
+ * created by bhe on Dec 12, 2020 Detailled comment
+ *
+ */
+public class FixModuleListInBDJDBCMigrationTask extends AbstractItemMigrationTask {
+
+    protected ProxyRepositoryFactory factory = ProxyRepositoryFactory.getInstance();
+
+    private static final Set<String> COMPONENT_NAMES = new HashSet<String>();
+
+    static {
+        COMPONENT_NAMES.add("tJDBCConfiguration");
+        COMPONENT_NAMES.add("tJDBCInput");
+        COMPONENT_NAMES.add("tJDBCOutput");
+    }
+
+    @Override
+    public List<ERepositoryObjectType> getTypes() {
+        List<ERepositoryObjectType> toReturn = new ArrayList<ERepositoryObjectType>();
+        toReturn.addAll(ERepositoryObjectType.getAllTypesOfProcess());
+        toReturn.addAll(ERepositoryObjectType.getAllTypesOfProcess2());
+        toReturn.addAll(ERepositoryObjectType.getAllTypesOfTestContainer());
+        toReturn.add(ERepositoryObjectType.JDBC);
+        return toReturn;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.talend.core.model.migration.AbstractItemMigrationTask#execute(org .talend.core.model.properties.Item)
+     */
+    @Override
+    public ExecutionResult execute(Item item) {
+        boolean modified = false;
+        try {
+            if (item instanceof ProcessItem) {
+                ProcessItem processItem = (ProcessItem) item;
+                if (updateProcessItem(item, processItem.getProcess())) {
+                    modified = true;
+                }
+            } else if (item instanceof JobletProcessItem) {
+                JobletProcessItem jobletItem = (JobletProcessItem) item;
+                if (updateProcessItem(item, jobletItem.getJobletProcess())) {
+                    modified = true;
+                }
+            }
+        } catch (Exception ex) {
+            ExceptionHandler.process(ex);
+            return ExecutionResult.FAILURE;
+        }
+
+        if (modified) {
+            try {
+                factory.save(item, true);
+                // regenerate poms for affected job
+                CorePlugin.getDefault().getRunProcessService().generatePom(item);
+                return ExecutionResult.SUCCESS_NO_ALERT;
+            } catch (Exception ex) {
+                ExceptionHandler.process(ex);
+                return ExecutionResult.FAILURE;
+            }
+        }
+        return ExecutionResult.NOTHING_TO_DO;
+    }
+
+    private boolean updateProcessItem(Item item, ProcessType processType) throws Exception {
+        EmfHelper.visitChilds(processType);
+
+        boolean modified = false;
+
+        // nodes parameters
+        if (checkNodes(item, processType)) {
+            modified = true;
+        }
+        return modified;
+    }
+
+    protected boolean checkNodesFromEmf(Item item, ProcessType processType) throws Exception {
+        boolean modified = false;
+        for (Object nodeObject : processType.getNode()) {
+            NodeType nodeType = (NodeType) nodeObject;
+            boolean needFix = needFix(nodeType.getComponentName());
+            for (Object paramObjectType : nodeType.getElementParameter()) {
+                ElementParameterType param = (ElementParameterType) paramObjectType;
+                if (needFix && updateParam(param)) {
+                    modified = true;
+                }
+            }
+        }
+        return modified;
+    }
+
+    protected boolean checkNodes(Item item, ProcessType processType) throws Exception {
+        boolean modified = checkNodesFromEmf(item, processType);
+
+        if (!modified) {
+            // some versions of the job doesn't have any field type saved in the job, so we will check from the existing
+            // component field type
+            ComponentCategory category = ComponentCategory.getComponentCategoryFromItem(item);
+            for (Object nodeObjectType : processType.getNode()) {
+                NodeType nodeType = (NodeType) nodeObjectType;
+                boolean needFix = needFix(nodeType.getComponentName());
+                IComponent component = ComponentsFactoryProvider.getInstance().get(nodeType.getComponentName(),
+                        category.getName());
+                if (component == null) {
+                    continue;
+                }
+                FakeNode fNode = new FakeNode(component);
+                for (Object paramObjectType : nodeType.getElementParameter()) {
+                    ElementParameterType param = (ElementParameterType) paramObjectType;
+                    IElementParameter paramFromEmf = fNode.getElementParameter(param.getName());
+                    if (paramFromEmf != null) {
+                        if (needFix && updateParam(param)) {
+                            modified = true;
+                        }
+                    }
+                }
+            }
+        }
+        return modified;
+    }
+
+    private static boolean updateParam(ElementParameterType param) {
+        boolean modified = false;
+        if (param.getField() != null) {
+            if (param.getField().equals(EParameterFieldType.MODULE_LIST.name()) && param.getValue() != null) {
+                String context = getFixedValue(param.getValue());
+                if (context != null) {
+                    param.setValue(context);
+                    modified = true;
+                }
+            } else if (("DRIVER_JAR".equals(param.getName()) || "DRIVER_JAR_IMPLICIT_CONTEXT".equals(param.getName()))
+                    && param.getElementValue() != null) {
+
+                EList<?> elementValues = param.getElementValue();
+                for (Object ev : elementValues) {
+                    ElementValueType evt = (ElementValueType) ev;
+                    String context = getFixedValue(evt.getValue());
+                    if (context != null) {
+                        evt.setValue(context);
+                        modified = true;
+                    }
+                }
+            }
+        }
+        return modified;
+    }
+
+    private static boolean needFix(String componentName) {
+        return COMPONENT_NAMES.contains(componentName);
+    }
+
+    private static String getFixedValue(String paramVal) {
+        if (paramVal == null || StringUtils.isEmpty(paramVal)) {
+            return null;
+        }
+        String val = TalendTextUtils.removeQuotes(paramVal);
+        if (StringUtils.isEmpty(val) || !val.startsWith(MavenUrlHelper.MVN_PROTOCOL)) {
+            return null;
+        }
+
+        String[] vals = val.split("/");
+        if (vals.length > 3 && vals[0].equals("mvn:org.talend.libraries") && vals[2].equals("6.0.0-SNAPSHOT")
+                && (vals[1].equals("context") || vals[1].startsWith("((String)context"))
+                && !vals[vals.length - 1].equals("jar")) {
+            return vals[1] + "." + vals[vals.length - 1];
+        }
+        return null;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.talend.core.model.migration.IProjectMigrationTask#getOrder()
+     */
+    @Override
+    public Date getOrder() {
+        GregorianCalendar gc = new GregorianCalendar(2020, 12, 12, 12, 0, 0);
+        return gc.getTime();
+    }
+}

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/FixModuleListInBDJDBCMigrationTask.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/FixModuleListInBDJDBCMigrationTask.java
@@ -12,204 +12,41 @@
 // ============================================================================
 package org.talend.designer.core.utils;
 
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.GregorianCalendar;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
-import org.eclipse.emf.common.util.EList;
-import org.talend.commons.exception.ExceptionHandler;
-import org.talend.commons.runtime.model.emf.EmfHelper;
-import org.talend.core.CorePlugin;
-import org.talend.core.model.components.ComponentCategory;
-import org.talend.core.model.components.IComponent;
-import org.talend.core.model.migration.AbstractItemMigrationTask;
-import org.talend.core.model.process.EParameterFieldType;
-import org.talend.core.model.process.IElementParameter;
-import org.talend.core.model.properties.Item;
-import org.talend.core.model.properties.JobletProcessItem;
-import org.talend.core.model.properties.ProcessItem;
-import org.talend.core.model.repository.ERepositoryObjectType;
 import org.talend.core.model.utils.TalendTextUtils;
 import org.talend.core.repository.model.ProxyRepositoryFactory;
 import org.talend.core.runtime.maven.MavenUrlHelper;
-import org.talend.core.ui.component.ComponentsFactoryProvider;
-import org.talend.designer.core.model.utils.emf.talendfile.ElementParameterType;
-import org.talend.designer.core.model.utils.emf.talendfile.ElementValueType;
-import org.talend.designer.core.model.utils.emf.talendfile.NodeType;
-import org.talend.designer.core.model.utils.emf.talendfile.ProcessType;
-import org.talend.repository.model.migration.EncryptPasswordInComponentsMigrationTask.FakeNode;
 
 /**
  * created by bhe on Dec 12, 2020 Detailled comment
  *
  */
-public class FixModuleListInBDJDBCMigrationTask extends AbstractItemMigrationTask {
+public class FixModuleListInBDJDBCMigrationTask extends UpdateModuleListInComponentsMigrationTask {
 
     protected ProxyRepositoryFactory factory = ProxyRepositoryFactory.getInstance();
 
-    private static final Set<String> COMPONENT_NAMES = new HashSet<String>();
 
-    static {
-        COMPONENT_NAMES.add("tJDBCConfiguration");
-        COMPONENT_NAMES.add("tJDBCInput");
-        COMPONENT_NAMES.add("tJDBCOutput");
-    }
+    public String getMavenUriForJar(String jarName) {
+        jarName = TalendTextUtils.removeQuotes(jarName);
 
-    @Override
-    public List<ERepositoryObjectType> getTypes() {
-        List<ERepositoryObjectType> toReturn = new ArrayList<ERepositoryObjectType>();
-        toReturn.addAll(ERepositoryObjectType.getAllTypesOfProcess());
-        toReturn.addAll(ERepositoryObjectType.getAllTypesOfProcess2());
-        toReturn.addAll(ERepositoryObjectType.getAllTypesOfTestContainer());
-        toReturn.add(ERepositoryObjectType.JDBC);
-        return toReturn;
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.talend.core.model.migration.AbstractItemMigrationTask#execute(org .talend.core.model.properties.Item)
-     */
-    @Override
-    public ExecutionResult execute(Item item) {
-        boolean modified = false;
-        try {
-            if (item instanceof ProcessItem) {
-                ProcessItem processItem = (ProcessItem) item;
-                if (updateProcessItem(item, processItem.getProcess())) {
-                    modified = true;
-                }
-            } else if (item instanceof JobletProcessItem) {
-                JobletProcessItem jobletItem = (JobletProcessItem) item;
-                if (updateProcessItem(item, jobletItem.getJobletProcess())) {
-                    modified = true;
-                }
-            }
-        } catch (Exception ex) {
-            ExceptionHandler.process(ex);
-            return ExecutionResult.FAILURE;
+        if (StringUtils.isEmpty(jarName) || !jarName.startsWith(MavenUrlHelper.MVN_PROTOCOL)) {
+            return jarName;
         }
 
-        if (modified) {
-            try {
-                factory.save(item, true);
-                // regenerate poms for affected job
-                CorePlugin.getDefault().getRunProcessService().generatePom(item);
-                return ExecutionResult.SUCCESS_NO_ALERT;
-            } catch (Exception ex) {
-                ExceptionHandler.process(ex);
-                return ExecutionResult.FAILURE;
-            }
-        }
-        return ExecutionResult.NOTHING_TO_DO;
-    }
-
-    private boolean updateProcessItem(Item item, ProcessType processType) throws Exception {
-        EmfHelper.visitChilds(processType);
-
-        boolean modified = false;
-
-        // nodes parameters
-        if (checkNodes(item, processType)) {
-            modified = true;
-        }
-        return modified;
-    }
-
-    protected boolean checkNodesFromEmf(Item item, ProcessType processType) throws Exception {
-        boolean modified = false;
-        for (Object nodeObject : processType.getNode()) {
-            NodeType nodeType = (NodeType) nodeObject;
-            boolean needFix = needFix(nodeType.getComponentName());
-            for (Object paramObjectType : nodeType.getElementParameter()) {
-                ElementParameterType param = (ElementParameterType) paramObjectType;
-                if (needFix && updateParam(param)) {
-                    modified = true;
-                }
-            }
-        }
-        return modified;
-    }
-
-    protected boolean checkNodes(Item item, ProcessType processType) throws Exception {
-        boolean modified = checkNodesFromEmf(item, processType);
-
-        if (!modified) {
-            // some versions of the job doesn't have any field type saved in the job, so we will check from the existing
-            // component field type
-            ComponentCategory category = ComponentCategory.getComponentCategoryFromItem(item);
-            for (Object nodeObjectType : processType.getNode()) {
-                NodeType nodeType = (NodeType) nodeObjectType;
-                boolean needFix = needFix(nodeType.getComponentName());
-                IComponent component = ComponentsFactoryProvider.getInstance().get(nodeType.getComponentName(),
-                        category.getName());
-                if (component == null) {
-                    continue;
-                }
-                FakeNode fNode = new FakeNode(component);
-                for (Object paramObjectType : nodeType.getElementParameter()) {
-                    ElementParameterType param = (ElementParameterType) paramObjectType;
-                    IElementParameter paramFromEmf = fNode.getElementParameter(param.getName());
-                    if (paramFromEmf != null) {
-                        if (needFix && updateParam(param)) {
-                            modified = true;
-                        }
-                    }
-                }
-            }
-        }
-        return modified;
-    }
-
-    private static boolean updateParam(ElementParameterType param) {
-        boolean modified = false;
-        if (param.getField() != null) {
-            if (param.getField().equals(EParameterFieldType.MODULE_LIST.name()) && param.getValue() != null) {
-                String context = getFixedValue(param.getValue());
-                if (context != null) {
-                    param.setValue(context);
-                    modified = true;
-                }
-            } else if (("DRIVER_JAR".equals(param.getName()) || "DRIVER_JAR_IMPLICIT_CONTEXT".equals(param.getName()))
-                    && param.getElementValue() != null) {
-
-                EList<?> elementValues = param.getElementValue();
-                for (Object ev : elementValues) {
-                    ElementValueType evt = (ElementValueType) ev;
-                    String context = getFixedValue(evt.getValue());
-                    if (context != null) {
-                        evt.setValue(context);
-                        modified = true;
-                    }
-                }
-            }
-        }
-        return modified;
-    }
-
-    private static boolean needFix(String componentName) {
-        return COMPONENT_NAMES.contains(componentName);
-    }
-
-    private static String getFixedValue(String paramVal) {
-        if (paramVal == null || StringUtils.isEmpty(paramVal)) {
-            return null;
-        }
-        String val = TalendTextUtils.removeQuotes(paramVal);
-        if (StringUtils.isEmpty(val) || !val.startsWith(MavenUrlHelper.MVN_PROTOCOL)) {
-            return null;
-        }
-
-        String[] vals = val.split("/");
+        String[] vals = jarName.split("/");
         if (vals.length > 3 && vals[0].equals("mvn:org.talend.libraries") && vals[2].equals("6.0.0-SNAPSHOT")
                 && (vals[1].equals("context") || vals[1].startsWith("((String)context"))) {
-            return vals[1] + "." + vals[vals.length - 1];
+            String ctx = vals[1] + "." + vals[vals.length - 1];
+            boolean containContext = containContext(ctx);
+            if (containContext) {
+                return ctx;
+            }
         }
-        return null;
+
+        return jarName;
     }
 
     /*

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/FixModuleListInBDJDBCMigrationTask.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/FixModuleListInBDJDBCMigrationTask.java
@@ -18,7 +18,6 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.talend.core.model.utils.TalendTextUtils;
-import org.talend.core.repository.model.ProxyRepositoryFactory;
 import org.talend.core.runtime.maven.MavenUrlHelper;
 
 /**
@@ -26,8 +25,6 @@ import org.talend.core.runtime.maven.MavenUrlHelper;
  *
  */
 public class FixModuleListInBDJDBCMigrationTask extends UpdateModuleListInComponentsMigrationTask {
-
-    protected ProxyRepositoryFactory factory = ProxyRepositoryFactory.getInstance();
 
 
     public String getMavenUriForJar(String jarName, List ctxs) {

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/UpdateModuleListInComponentsMigrationTask.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/UpdateModuleListInComponentsMigrationTask.java
@@ -39,6 +39,7 @@ import org.talend.core.model.properties.JobletProcessItem;
 import org.talend.core.model.properties.ProcessItem;
 import org.talend.core.model.properties.StatAndLogsSettings;
 import org.talend.core.model.repository.ERepositoryObjectType;
+import org.talend.core.model.utils.ContextParameterUtils;
 import org.talend.core.model.utils.TalendTextUtils;
 import org.talend.core.repository.model.ProxyRepositoryFactory;
 import org.talend.core.runtime.maven.MavenUrlHelper;
@@ -376,7 +377,8 @@ public class UpdateModuleListInComponentsMigrationTask extends AbstractItemMigra
 
     public static String getMavenUriForJar(String jarName) {
         jarName = TalendTextUtils.removeQuotes(jarName);
-        if (!StringUtils.isEmpty(jarName) && !MavenUrlHelper.isMvnUrl(jarName)) {
+        boolean containContext = ContextParameterUtils.isContainContextParam(jarName);
+        if (!StringUtils.isEmpty(jarName) && !MavenUrlHelper.isMvnUrl(jarName) && !containContext) {
             ModuleNeeded mod = new ModuleNeeded(null, jarName, null, true);
             if (!StringUtils.isEmpty(mod.getCustomMavenUri())) {
                 return mod.getCustomMavenUri();

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/UpdateModuleListInComponentsMigrationTask.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/UpdateModuleListInComponentsMigrationTask.java
@@ -15,14 +15,18 @@ package org.talend.designer.core.utils;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.emf.common.util.EList;
 import org.talend.commons.exception.ExceptionHandler;
+import org.talend.commons.exception.PersistenceException;
 import org.talend.commons.runtime.model.emf.EmfHelper;
 import org.talend.core.CorePlugin;
+import org.talend.core.GlobalServiceRegister;
 import org.talend.core.model.components.ComponentCategory;
 import org.talend.core.model.components.IComponent;
 import org.talend.core.model.general.ModuleNeeded;
@@ -33,22 +37,30 @@ import org.talend.core.model.migration.AbstractItemMigrationTask;
 import org.talend.core.model.process.EParameterFieldType;
 import org.talend.core.model.process.IElementParameter;
 import org.talend.core.model.properties.ConnectionItem;
+import org.talend.core.model.properties.ContextItem;
 import org.talend.core.model.properties.ImplicitContextSettings;
 import org.talend.core.model.properties.Item;
 import org.talend.core.model.properties.JobletProcessItem;
 import org.talend.core.model.properties.ProcessItem;
+import org.talend.core.model.properties.Property;
 import org.talend.core.model.properties.StatAndLogsSettings;
 import org.talend.core.model.repository.ERepositoryObjectType;
+import org.talend.core.model.repository.IRepositoryViewObject;
+import org.talend.core.model.repository.RepositoryObject;
 import org.talend.core.model.utils.ContextParameterUtils;
 import org.talend.core.model.utils.TalendTextUtils;
 import org.talend.core.repository.model.ProxyRepositoryFactory;
 import org.talend.core.runtime.maven.MavenUrlHelper;
 import org.talend.core.ui.component.ComponentsFactoryProvider;
+import org.talend.designer.core.model.utils.emf.talendfile.ContextType;
 import org.talend.designer.core.model.utils.emf.talendfile.ElementParameterType;
 import org.talend.designer.core.model.utils.emf.talendfile.ElementValueType;
 import org.talend.designer.core.model.utils.emf.talendfile.NodeType;
 import org.talend.designer.core.model.utils.emf.talendfile.ParametersType;
 import org.talend.designer.core.model.utils.emf.talendfile.ProcessType;
+import org.talend.migration.IMigrationTask.ExecutionResult;
+import org.talend.repository.model.IProxyRepositoryFactory;
+import org.talend.repository.model.IRepositoryService;
 import org.talend.repository.model.migration.EncryptPasswordInComponentsMigrationTask.FakeNode;
 
 /**
@@ -58,6 +70,8 @@ import org.talend.repository.model.migration.EncryptPasswordInComponentsMigratio
 public class UpdateModuleListInComponentsMigrationTask extends AbstractItemMigrationTask {
 
     protected ProxyRepositoryFactory factory = ProxyRepositoryFactory.getInstance();
+
+    protected Set<ContextItem> contextItems = new HashSet<ContextItem>();
 
     @Override
     public List<ERepositoryObjectType> getTypes() {
@@ -70,6 +84,93 @@ public class UpdateModuleListInComponentsMigrationTask extends AbstractItemMigra
         return toReturn;
     }
 
+    @Override
+    public ExecutionResult execute(Project project) {
+        setProject(project);
+        IRepositoryService service = (IRepositoryService) GlobalServiceRegister.getDefault().getService(IRepositoryService.class);
+        IProxyRepositoryFactory factory = service.getProxyRepositoryFactory();
+        ExecutionResult executeFinal = null;
+        List<IRepositoryViewObject> list = new ArrayList<IRepositoryViewObject>();
+
+        try {
+            loadContextItems();
+
+            for (ERepositoryObjectType curTyp : getAllTypes()) {
+                if (curTyp != null && curTyp.isResourceItem()) {
+                    /* specific project so that on svn model it will migrate all ref projects,bug 17295 */
+                    list.addAll(factory.getAll(project, curTyp, true, true));
+                }
+            }
+
+            if (list.isEmpty()) {
+                return ExecutionResult.NOTHING_TO_DO;
+            }
+
+            for (IRepositoryViewObject object : list) {
+                ExecutionResult execute = null;
+                // in case the resource has been modified (see MergeTosMetadataMigrationTask for example)
+                if ((object.getProperty().eResource() == null || object.getProperty().getItem().eResource() == null)
+                        && (object instanceof RepositoryObject)) {
+                    Property updatedProperty = factory.reload(object.getProperty());
+                    ((RepositoryObject) object).setProperty(updatedProperty);
+                }
+
+                Item item = object.getProperty().getItem();
+                execute = execute(item);
+
+                if (execute != ExecutionResult.FAILURE) {
+                    execute = this.migrateProjectSettings(project);
+                }
+
+                unloadObject(object);
+
+                if (execute == ExecutionResult.FAILURE) {
+                    executeFinal = ExecutionResult.FAILURE;
+                }
+                if (executeFinal != ExecutionResult.FAILURE) {
+                    executeFinal = execute;
+                }
+            }
+
+            return executeFinal;
+        } catch (PersistenceException e) {
+            ExceptionHandler.process(e);
+            return ExecutionResult.FAILURE;
+        }
+    }
+
+    private void loadContextItems() throws PersistenceException {
+        if (contextItems.isEmpty()) {
+            IRepositoryService service = (IRepositoryService) GlobalServiceRegister.getDefault()
+                    .getService(IRepositoryService.class);
+            IProxyRepositoryFactory factory = service.getProxyRepositoryFactory();
+            List<IRepositoryViewObject> contextObjs = factory.getAll(ERepositoryObjectType.CONTEXT);
+            for (IRepositoryViewObject ctxObj : contextObjs) {
+                if (ctxObj.getProperty() != null) {
+                    ContextItem ctxItem = (ContextItem) ctxObj.getProperty().getItem();
+                    if (ctxItem != null) {
+                        contextItems.add(ctxItem);
+                    }
+                }
+            }
+        }
+    }
+    
+    @Override
+    public ExecutionResult execute(Project project, Item item) {
+        if (!getAllTypes().contains(ERepositoryObjectType.getItemType(item))) {
+            return ExecutionResult.NOTHING_TO_DO;
+        }
+        setProject(project);
+        try {
+            loadContextItems();
+        } catch (PersistenceException e) {
+            ExceptionHandler.process(e);
+            return ExecutionResult.FAILURE;
+        }
+        return execute(item);
+    }
+    
     /*
      * (non-Javadoc)
      *
@@ -111,41 +212,6 @@ public class UpdateModuleListInComponentsMigrationTask extends AbstractItemMigra
             }
         }
         return ExecutionResult.NOTHING_TO_DO;
-    }
-
-    @Override
-    public ExecutionResult execute(Project project) {
-        ExecutionResult result = super.execute(project);
-        if (result == ExecutionResult.FAILURE) {
-            return result;
-        }
-
-        result = this.migrateProjectSettings(project);
-
-        return result;
-    }
-
-    @Override
-    public ExecutionResult execute(Project project, boolean doSave) {
-        ExecutionResult result = super.execute(project, doSave);
-        if (result == ExecutionResult.FAILURE) {
-            return result;
-        }
-
-        result = this.migrateProjectSettings(project);
-
-        return result;
-    }
-
-    @Override
-    public ExecutionResult execute(Project project, Item item) {
-
-        ExecutionResult result = super.execute(project, item);
-        if (result == ExecutionResult.FAILURE) {
-            return result;
-        }
-        result = migrateProjectSettings(project);
-        return result;
     }
 
     protected ExecutionResult migrateProjectSettings(Project project) {
@@ -309,7 +375,7 @@ public class UpdateModuleListInComponentsMigrationTask extends AbstractItemMigra
         return list;
     }
 
-    private static boolean updateParam(ElementParameterType param) {
+    private boolean updateParam(ElementParameterType param) {
         boolean modified = false;
         if (param.getField() != null) {
             if (param.getField().equals(EParameterFieldType.MODULE_LIST.name()) && param.getValue() != null) {
@@ -333,7 +399,7 @@ public class UpdateModuleListInComponentsMigrationTask extends AbstractItemMigra
         return modified;
     }
 
-    private static boolean updateParamForcConfig(ElementParameterType param) {
+    private boolean updateParamForcConfig(ElementParameterType param) {
         boolean modified = false;
         if (param.getField() != null) {
             if (param.getField().equals(EParameterFieldType.MODULE_LIST.name()) && param.getValue() != null) {
@@ -375,9 +441,9 @@ public class UpdateModuleListInComponentsMigrationTask extends AbstractItemMigra
         return modified;
     }
 
-    public static String getMavenUriForJar(String jarName) {
+    public String getMavenUriForJar(String jarName) {
         jarName = TalendTextUtils.removeQuotes(jarName);
-        boolean containContext = ContextParameterUtils.isContainContextParam(jarName);
+        boolean containContext = containContext(jarName);
         if (!StringUtils.isEmpty(jarName) && !MavenUrlHelper.isMvnUrl(jarName) && !containContext) {
             ModuleNeeded mod = new ModuleNeeded(null, jarName, null, true);
             if (!StringUtils.isEmpty(mod.getCustomMavenUri())) {
@@ -386,6 +452,18 @@ public class UpdateModuleListInComponentsMigrationTask extends AbstractItemMigra
             return mod.getMavenUri();
         }
         return jarName;
+    }
+
+    public boolean containContext(String jarName) {
+        for (ContextItem item : contextItems) {
+            List ctxs = item.getContext();
+            for (Object ct : ctxs) {
+                if (ContextParameterUtils.isContextParamOfContextType((ContextType) ct, jarName)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /*

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/UpdateModuleListInComponentsMigrationTask.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/UpdateModuleListInComponentsMigrationTask.java
@@ -438,9 +438,11 @@ public class UpdateModuleListInComponentsMigrationTask extends AbstractItemMigra
     }
 
     public boolean containContext(String jarName, List ctxs) {
-        if (ctxs == null || ctxs.isEmpty()) {
-            return false;
+        if (ctxs == null) {
+            // for project settings
+            return ContextParameterUtils.isContainContextParam(jarName);
         }
+        // check for job and connections
         for (Object ct : ctxs) {
             if (ContextParameterUtils.isContextParamOfContextType((ContextType) ct, jarName)) {
                 return true;


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TUP-29693

**What is the new behavior?**
When to migrate jarname to maven uri, do not replace jarname if jarname contains context.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


