### PR TITLE
fix(TUP-29693): Do not replace maven uri for context inside jarname (…

### DIFF
--- a/main/plugins/org.talend.designer.core/plugin.xml
+++ b/main/plugins/org.talend.designer.core/plugin.xml
@@ -791,6 +791,15 @@
              name="UpdateModuleListInComponentsMigrationTask"
              version="7.3.1">
        </projecttask>
+       <projecttask
+             beforeLogon="false"
+             breaks="7.3.0"
+             class="org.talend.designer.core.utils.FixModuleListInBDJDBCMigrationTask"
+             description="Fix context used inside module list."
+             id="org.talend.designer.core.utils.FixModuleListInBDJDBCMigrationTask"
+             name="FixModuleListInBDJDBCMigrationTask"
+             version="7.3.1">
+       </projecttask>
     </extension>
     <extension
           point="org.talend.repository.projectsetting_page">

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/FixModuleListInBDJDBCMigrationTask.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/FixModuleListInBDJDBCMigrationTask.java
@@ -1,0 +1,60 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2020 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.designer.core.utils;
+
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.talend.core.model.utils.TalendTextUtils;
+import org.talend.core.runtime.maven.MavenUrlHelper;
+
+/**
+ * created by bhe on Dec 12, 2020 Detailled comment
+ *
+ */
+public class FixModuleListInBDJDBCMigrationTask extends UpdateModuleListInComponentsMigrationTask {
+
+
+    public String getMavenUriForJar(String jarName, List ctxs) {
+        jarName = TalendTextUtils.removeQuotes(jarName);
+
+        if (StringUtils.isEmpty(jarName) || !jarName.startsWith(MavenUrlHelper.MVN_PROTOCOL)) {
+            return jarName;
+        }
+
+        String[] vals = jarName.split("/");
+        if (vals.length > 3 && vals[0].equals("mvn:org.talend.libraries") && vals[2].equals("6.0.0-SNAPSHOT")
+                && (vals[1].equals("context") || vals[1].startsWith("((String)context"))) {
+            String ctx = vals[1] + "." + vals[vals.length - 1];
+            boolean containContext = containContext(ctx, ctxs);
+            if (containContext) {
+                return ctx;
+            }
+        }
+
+        return jarName;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.talend.core.model.migration.IProjectMigrationTask#getOrder()
+     */
+    @Override
+    public Date getOrder() {
+        GregorianCalendar gc = new GregorianCalendar(2020, 12, 12, 12, 0, 0);
+        return gc.getTime();
+    }
+}

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/UpdateModuleListInComponentsMigrationTask.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/UpdateModuleListInComponentsMigrationTask.java
@@ -25,6 +25,7 @@ import org.talend.commons.runtime.model.emf.EmfHelper;
 import org.talend.core.CorePlugin;
 import org.talend.core.model.components.ComponentCategory;
 import org.talend.core.model.components.IComponent;
+import org.talend.core.model.context.ContextUtils;
 import org.talend.core.model.general.ModuleNeeded;
 import org.talend.core.model.general.Project;
 import org.talend.core.model.metadata.builder.connection.Connection;
@@ -33,16 +34,19 @@ import org.talend.core.model.migration.AbstractItemMigrationTask;
 import org.talend.core.model.process.EParameterFieldType;
 import org.talend.core.model.process.IElementParameter;
 import org.talend.core.model.properties.ConnectionItem;
+import org.talend.core.model.properties.ContextItem;
 import org.talend.core.model.properties.ImplicitContextSettings;
 import org.talend.core.model.properties.Item;
 import org.talend.core.model.properties.JobletProcessItem;
 import org.talend.core.model.properties.ProcessItem;
 import org.talend.core.model.properties.StatAndLogsSettings;
 import org.talend.core.model.repository.ERepositoryObjectType;
+import org.talend.core.model.utils.ContextParameterUtils;
 import org.talend.core.model.utils.TalendTextUtils;
 import org.talend.core.repository.model.ProxyRepositoryFactory;
 import org.talend.core.runtime.maven.MavenUrlHelper;
 import org.talend.core.ui.component.ComponentsFactoryProvider;
+import org.talend.designer.core.model.utils.emf.talendfile.ContextType;
 import org.talend.designer.core.model.utils.emf.talendfile.ElementParameterType;
 import org.talend.designer.core.model.utils.emf.talendfile.ElementValueType;
 import org.talend.designer.core.model.utils.emf.talendfile.NodeType;
@@ -158,7 +162,7 @@ public class UpdateModuleListInComponentsMigrationTask extends AbstractItemMigra
                 final Object object = elementParameter.get(i);
                 if (object instanceof ElementParameterType) {
                     ElementParameterType parameterType = (ElementParameterType) object;
-                    if (updateParam(parameterType)) {
+                    if (updateParam(parameterType, null)) {
                         modified = true;
                     }
                 }
@@ -173,7 +177,7 @@ public class UpdateModuleListInComponentsMigrationTask extends AbstractItemMigra
                 final Object object = elementParameter.get(i);
                 if (object instanceof ElementParameterType) {
                     ElementParameterType parameterType = (ElementParameterType) object;
-                    if (updateParam(parameterType)) {
+                    if (updateParam(parameterType, null)) {
                         modified = true;
                     }
                 }
@@ -206,10 +210,15 @@ public class UpdateModuleListInComponentsMigrationTask extends AbstractItemMigra
     protected boolean updateDatabaseConnection(DatabaseConnection dbConnection) throws Exception {
         String driverJar = dbConnection.getDriverJarPath();
         if (driverJar != null) {
+            List ctxs = null;
+            ContextItem contextItem = ContextUtils.getContextItemById2(dbConnection.getContextId());
+            if (contextItem != null) {
+                ctxs = contextItem.getContext();
+            }
             String[] jars = driverJar.split(";");
             StringBuffer sb = new StringBuffer();
             for (String jar : jars) {
-                String uri = getMavenUriForJar(jar);
+                String uri = getMavenUriForJar(jar, ctxs);
                 if (sb.length() > 0) {
                     sb.append(";");
                 }
@@ -248,7 +257,7 @@ public class UpdateModuleListInComponentsMigrationTask extends AbstractItemMigra
                 if (p instanceof ElementParameterType) {
                     ElementParameterType param = (ElementParameterType) p;
                     // variable name used for Stat&Logs
-                    if (updateParam(param)) {
+                    if (updateParam(param, processType)) {
                         modified = true;
                     }
                 }
@@ -264,7 +273,7 @@ public class UpdateModuleListInComponentsMigrationTask extends AbstractItemMigra
             boolean isConfig = nodeType.getComponentName().equals("cConfig");
             for (Object paramObjectType : nodeType.getElementParameter()) {
                 ElementParameterType param = (ElementParameterType) paramObjectType;
-                if (isConfig ? updateParamForcConfig(param) : updateParam(param)) {
+                if (isConfig ? updateParamForcConfig(param, processType) : updateParam(param, processType)) {
                     modified = true;
                 }
             }
@@ -292,7 +301,7 @@ public class UpdateModuleListInComponentsMigrationTask extends AbstractItemMigra
                     ElementParameterType param = (ElementParameterType) paramObjectType;
                     IElementParameter paramFromEmf = fNode.getElementParameter(param.getName());
                     if (paramFromEmf != null) {
-                        if (isConfig ? updateParamForcConfig(param) : updateParam(param)) {
+                        if (isConfig ? updateParamForcConfig(param, processType) : updateParam(param, processType)) {
                             modified = true;
                         }
                     }
@@ -308,11 +317,12 @@ public class UpdateModuleListInComponentsMigrationTask extends AbstractItemMigra
         return list;
     }
 
-    private static boolean updateParam(ElementParameterType param) {
+    private boolean updateParam(ElementParameterType param, ProcessType processType) {
         boolean modified = false;
+        List ctxs = processType == null ? null : processType.getContext();
         if (param.getField() != null) {
             if (param.getField().equals(EParameterFieldType.MODULE_LIST.name()) && param.getValue() != null) {
-                String jarUri = getMavenUriForJar(param.getValue());
+                String jarUri = getMavenUriForJar(param.getValue(), ctxs);
                 param.setValue(jarUri);
                 modified = true;
             } else if (("DRIVER_JAR".equals(param.getName()) || "DRIVER_JAR_IMPLICIT_CONTEXT".equals(param.getName()))
@@ -321,7 +331,7 @@ public class UpdateModuleListInComponentsMigrationTask extends AbstractItemMigra
                 EList<?> elementValues = param.getElementValue();
                 for (Object ev : elementValues) {
                     ElementValueType evt = (ElementValueType) ev;
-                    String jarUri = getMavenUriForJar(evt.getValue());
+                    String jarUri = getMavenUriForJar(evt.getValue(), ctxs);
                     if (!StringUtils.equals(jarUri, evt.getValue())) {
                         evt.setValue(jarUri);
                         modified = true;
@@ -332,11 +342,12 @@ public class UpdateModuleListInComponentsMigrationTask extends AbstractItemMigra
         return modified;
     }
 
-    private static boolean updateParamForcConfig(ElementParameterType param) {
+    private boolean updateParamForcConfig(ElementParameterType param, ProcessType processType) {
         boolean modified = false;
+        List ctxs = processType == null ? null : processType.getContext();
         if (param.getField() != null) {
             if (param.getField().equals(EParameterFieldType.MODULE_LIST.name()) && param.getValue() != null) {
-                String jarUri = getMavenUriForJar(param.getValue());
+                String jarUri = getMavenUriForJar(param.getValue(), ctxs);
                 param.setValue(jarUri);
                 modified = true;
             } else if (("DRIVER_JAR".equals(param.getName()) || "DRIVER_JAR_IMPLICIT_CONTEXT".equals(param.getName()))
@@ -350,7 +361,7 @@ public class UpdateModuleListInComponentsMigrationTask extends AbstractItemMigra
                     ElementValueType evt = (ElementValueType) ev;
                     switch (evt.getElementRef()) {
                         case "JAR_NAME": {
-                            String jarUri = getMavenUriForJar(evt.getValue());
+                            String jarUri = getMavenUriForJar(evt.getValue(), ctxs);
                             if (!StringUtils.equals(jarUri, evt.getValue())) {
                                 jn = evt;
                                 modified = true;
@@ -374,9 +385,10 @@ public class UpdateModuleListInComponentsMigrationTask extends AbstractItemMigra
         return modified;
     }
 
-    public static String getMavenUriForJar(String jarName) {
+    public String getMavenUriForJar(String jarName, List ctxs) {
         jarName = TalendTextUtils.removeQuotes(jarName);
-        if (!StringUtils.isEmpty(jarName) && !MavenUrlHelper.isMvnUrl(jarName)) {
+        boolean containContext = containContext(jarName, ctxs);
+        if (!StringUtils.isEmpty(jarName) && !MavenUrlHelper.isMvnUrl(jarName) && !containContext) {
             ModuleNeeded mod = new ModuleNeeded(null, jarName, null, true);
             if (!StringUtils.isEmpty(mod.getCustomMavenUri())) {
                 return mod.getCustomMavenUri();
@@ -384,6 +396,20 @@ public class UpdateModuleListInComponentsMigrationTask extends AbstractItemMigra
             return mod.getMavenUri();
         }
         return jarName;
+    }
+
+    public boolean containContext(String jarName, List ctxs) {
+        if (ctxs == null) {
+            // for project settings
+            return ContextParameterUtils.isContainContextParam(jarName);
+        }
+        // check for job and connections
+        for (Object ct : ctxs) {
+            if (ContextParameterUtils.isContextParamOfContextType((ContextType) ct, jarName)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /*


### PR DESCRIPTION
…#5625)

* fix(TUP-29693): Do not replace maven uri for context inside jarname

* fix(TUP-29693): fix context inside jar name

* fix(TUP-29693): fix context inside jar name

* fix(TUP-2969): fix migrate maven uri for javajet components

* fix(TUP-2969): fix migrate maven uri for javajet components

* fix(TUP-2969): add check for project settings as well

* fix(TUP-29693): Kepp main logic unchanged

**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TUP-29693

**What is the new behavior?**
1 - If jarname contains context, then migrate the value as it is, otherwise replace value with maven uri.
2 - If wrong maven uri was set because of R2020-11 patch, then reset the maven uri back to context.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


