### PR TITLE
fix(TUP-29641): fixed tAdvancedFileOutputXML display issues with MacO…

### DIFF
--- a/main/plugins/org.talend.designer.fileoutputxml/src/main/java/org/talend/designer/fileoutputxml/ui/edit/Schema2XMLLinker.java
+++ b/main/plugins/org.talend.designer.fileoutputxml/src/main/java/org/talend/designer/fileoutputxml/ui/edit/Schema2XMLLinker.java
@@ -44,6 +44,7 @@ import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.swt.widgets.Widget;
 import org.talend.commons.ui.runtime.exception.ExceptionHandler;
 import org.talend.commons.ui.runtime.utils.TableUtils;
+import org.talend.commons.ui.runtime.ws.WindowSystem;
 import org.talend.commons.ui.swt.dialogs.ProgressDialog;
 import org.talend.commons.ui.swt.drawing.link.ExtremityLink;
 import org.talend.commons.ui.swt.drawing.link.IExtremityLink;
@@ -75,6 +76,10 @@ public class Schema2XMLLinker extends TableToTreeLinker<Object, Object> {
     private Color selectedLoopLinkColor;
 
     private Color selectedRelativeLinkColor;
+
+    private Color transparentBgColor;
+
+    private Color originalBgColor;
 
     private FOXManager manager;
 
@@ -116,6 +121,11 @@ public class Schema2XMLLinker extends TableToTreeLinker<Object, Object> {
 
         initColors(display);
 
+        if (WindowSystem.isBigSurOrLater()) {
+            getBackgroundRefresher().setBackgroundColor(originalBgColor);
+            getBgDrawableComposite().setBackground(transparentBgColor);
+        }
+
         setUnselectedStyleLink(createStandardLink(display.getSystemColor(SWT.COLOR_BLUE)));
 
         getSelectedRelativeStyleLink();
@@ -134,12 +144,17 @@ public class Schema2XMLLinker extends TableToTreeLinker<Object, Object> {
         // selectedLoopLinkColor = new Color(display, 255, 131, 255);
         selectedLoopLinkColor = new Color(display, 110, 168, 255);// light blue
         selectedRelativeLinkColor = new Color(display, 110, 168, 0);
+        transparentBgColor = new Color(display, 0, 0, 0, 0);
+        originalBgColor = getBgDrawableComposite().getBackground();
+
         getSource().addDisposeListener(new DisposeListener() {
 
             @Override
             public void widgetDisposed(DisposeEvent e) {
                 selectedLoopLinkColor.dispose();
                 selectedRelativeLinkColor.dispose();
+                transparentBgColor.dispose();
+                originalBgColor.dispose();
                 getSource().removeDisposeListener(this);
             }
         });


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TUP-29641

**What is the new behavior?**
Fixed tAdvancedFileOutputXML display issues with MacOS BigSur. 
Set the main SashForm's background color to transparent color and draw the component with original background color.

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


