### PR TITLE
fix(TUP-29590) fix httpcore sometimes not included when parent job has tRunjob, child job has tHiveConnection , and routine has dependency to httpcore.

### DIFF
--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/JavaProcessUtil.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/JavaProcessUtil.java
@@ -115,7 +115,6 @@ public class JavaProcessUtil {
                     }
                     it.remove();
                 } else {
-//                    dedupModulesList.add(module.getModuleName());
                     dedupModulesList.add(coordinate);
                     
                     previousModule = module;

--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/JavaProcessUtil.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/utils/JavaProcessUtil.java
@@ -51,6 +51,7 @@ import org.talend.core.model.properties.Item;
 import org.talend.core.model.properties.ProcessItem;
 import org.talend.core.model.utils.ContextParameterUtils;
 import org.talend.core.model.utils.TalendTextUtils;
+import org.talend.core.runtime.maven.MavenArtifact;
 import org.talend.core.runtime.maven.MavenConstants;
 import org.talend.core.runtime.maven.MavenUrlHelper;
 import org.talend.core.runtime.process.LastGenerationInfo;
@@ -104,15 +105,21 @@ public class JavaProcessUtil {
             // in some case it's not a real library, but just a text.
             if (!module.getModuleName().contains(".")) { //$NON-NLS-1$
                 it.remove();
-            } else if (dedupModulesList.contains(module.getModuleName())) {
-                if (module.isMrRequired() && previousModule != null
-                        && previousModule.getModuleName().equals(module.getModuleName())) {
-                    previousModule.setMrRequired(Boolean.TRUE);
-                }
-                it.remove();
             } else {
-                dedupModulesList.add(module.getModuleName());
-                previousModule = module;
+                String coordinate = getCoordinate(module);
+                
+                if (dedupModulesList.contains(coordinate)) {
+                    if (module.isMrRequired() && previousModule != null
+                            && previousModule.getModuleName().equals(module.getModuleName())) {
+                        previousModule.setMrRequired(Boolean.TRUE);
+                    }
+                    it.remove();
+                } else {
+//                    dedupModulesList.add(module.getModuleName());
+                    dedupModulesList.add(coordinate);
+                    
+                    previousModule = module;
+                }
             }
         }
 
@@ -124,6 +131,33 @@ public class JavaProcessUtil {
         return new HashSet<ModuleNeeded>(modulesNeeded);
     }
 
+    public static String getCoordinate(ModuleNeeded module) {
+        String mavenUri = module.getMavenUri();
+        if (!MavenUrlHelper.isMvnUrl(mavenUri)) {
+            mavenUri = MavenUrlHelper.generateMvnUrlForJarName(mavenUri);
+        }
+        MavenArtifact artifact = MavenUrlHelper.parseMvnUrl(mavenUri);
+        
+        String groupId = artifact.getGroupId();
+        String artifactId = artifact.getArtifactId();
+        String type = artifact.getType();
+        String version = artifact.getVersion();
+        String classifier = artifact.getClassifier();
+        
+        String separator = ":"; //$NON-NLS-1$
+        String coordinate = groupId + separator + artifactId;
+        if (StringUtils.isNotBlank(type)) {
+            coordinate += separator + type;
+        }
+        if (StringUtils.isNotBlank(classifier)) {
+            coordinate += separator + classifier;
+        }
+        if (StringUtils.isNotBlank(version)) {
+            coordinate += separator + version;
+        }
+        return coordinate;
+    }
+    
     // for MapReduce job, if the jar on Xml don't set MRREQUIRED="true", shouldn't add it to
     // DistributedCache
     public static Set<String> getNeededLibraries(final IProcess process, int options) {

--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/java/JavaProcessorUtilities.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/java/JavaProcessorUtilities.java
@@ -157,7 +157,9 @@ public class JavaProcessorUtilities {
 
             @Override
             public int compare(ModuleNeeded m1, ModuleNeeded m2) {
-                return m1.toString().compareTo(m2.toString());
+                int compareResult = m1.toString().compareTo(m2.toString());
+                return compareResult != 0 ? compareResult
+                        : JavaProcessUtil.getCoordinate(m1).compareTo(JavaProcessUtil.getCoordinate(m2));
             }
         });
 

--- a/test/plugins/org.talend.designer.core.test/src/org/talend/designer/core/utils/JavaProcessUtilTest.java
+++ b/test/plugins/org.talend.designer.core.test/src/org/talend/designer/core/utils/JavaProcessUtilTest.java
@@ -221,4 +221,21 @@ public class JavaProcessUtilTest {
         return moduleNeededSet;
     }
 
+    @Test
+    public void testGetCoordinate() {
+        String context = "tHiveConnection";
+        String informationMsg = "Required for using this component.";
+        boolean required = false;
+        String[] mvnUris = { "mvn:org.talend.libraries/httpcore-4.4.6/6.3.0/jar", "mvn:org.apache.httpcomponents/httpcore/4.4.6",
+                "mvn:https://studio-dl-client:enc:system.encryption.key.v1:xgJc9IaLeJSt6UpaabOusZUBcK4bLUJipmAhuD6dHI8fBqoB7pm4UDWlWLk=@talend-update.talend.com/nexus/content/groups/dynamicdistribution/!org.apache.httpcomponents/httpcore/4.4.6/jar" };
+        String[] expectedCoordinates = { "org.talend.libraries:httpcore-4.4.6:jar:6.3.0",
+                "org.apache.httpcomponents:httpcore:jar:4.4.6", "org.apache.httpcomponents:httpcore:jar:4.4.6" };
+        for (int i = 0; i < mvnUris.length; i++) {
+            String mvnUri = mvnUris[i];
+            ModuleNeeded module = new ModuleNeeded(context,informationMsg,required,mvnUri);
+            String coordinate = JavaProcessUtil.getCoordinate(module);
+            assertEquals(expectedCoordinates[i], coordinate);
+        }
+        
+    }
 }


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TUP-29590

using 7.3.1, with a dynamic distribution , parent job is calling child job and childjob is using tHiveconnection component.
a custom routine requires : httpcore-4.4.6/6.0.0 (not necessarily in dependency for either of the job)
The lib httpcore-4.4.6 is sometime not included in the build.

**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


