### PR TITLE
fix(TUP-29550) fix problem that "rename" Job in property sheet page duplicates item in Pom file

### DIFF
--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/views/jobsettings/tabs/MainComposite.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/views/jobsettings/tabs/MainComposite.java
@@ -784,7 +784,7 @@ public class MainComposite extends AbstractTabComposite {
                                                         RelationshipItemBuilder.getInstance().addOrUpdateItem(repositoryObject.getProperty().getItem());
                                                     }
                                                     proxyRepositoryFactory.save(ProjectManager.getInstance().getCurrentProject(),
-                                                            repositoryObject.getProperty().getItem(), false);
+                                                            repositoryObject.getProperty(), oldName, oldVersion);
                                                     if (needjobletRelateUpdate && GlobalServiceRegister.getDefault()
                                                             .isServiceRegistered(IJobletProviderService.class)) {
                                                         IJobletProviderService jobletService = (IJobletProviderService) GlobalServiceRegister


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TUP-29550
after rename job name,version, old job items still in pom file.

**What is the new behavior?**
update pom file according job property change, align with edit job property.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


