### PR TITLE
feat(TDI-45530): bump component-runtime to 1.29.1 for bouncycastle CVE

### DIFF
--- a/main/plugins/org.talend.sdk.component.studio-integration/pom.xml
+++ b/main/plugins/org.talend.sdk.component.studio-integration/pom.xml
@@ -14,7 +14,7 @@
   <description>Studio integration of the Talend Component Kit framework.</description>
 
   <properties>
-    <component-runtime.version>1.29.0</component-runtime.version>
+    <component-runtime.version>1.29.1</component-runtime.version>
     <commons-lang3.version>3.11</commons-lang3.version>
     <mockito.version>2.23.0</mockito.version>
     <oro.version>2.0.8</oro.version>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TDI-45530

*Related PR*
- https://github.com/Talend/studio-full-master/pull/618
- https://github.com/Talend/tcommon-studio-se/pull/4036
- https://github.com/Talend/tcommon-studio-ee/pull/1742
- https://github.com/Talend/tdi-studio-se/pull/5803