### PR TITLE
feat(TCOMP-1877): clean cached libs studio-integration

### DIFF
--- a/main/plugins/org.talend.sdk.component.studio-integration/pom.xml
+++ b/main/plugins/org.talend.sdk.component.studio-integration/pom.xml
@@ -196,6 +196,24 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.1.0</version>
+        <configuration>
+          <filesets>
+            <fileset>
+              <!-- The same directory as in maven-dependency-plugin where the libraries will be copied-->
+              <directory>${project.basedir}/lib</directory>
+              <includes>
+                <include>**/*.jar</include>
+              </includes>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>3.0.2</version>
         <executions>


### PR DESCRIPTION
* clean cached libs during clean phase for studio-integration plugin
* help to avoid using the out-to-date version of jars in plugin

**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TCOMP-1877

**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard

**What kind of change does this PR introduce?**

- [x] Other... Please describe: port from maintenance/7.3

**Does this PR introduce a breaking change?**

- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

