### PR TITLE
fix(TUP-25417) JDK11: run a job call a child job use twebservice meet error.

### DIFF
--- a/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/java/JavaProcessor.java
+++ b/main/plugins/org.talend.designer.runprocess/src/main/java/org/talend/designer/runprocess/java/JavaProcessor.java
@@ -147,6 +147,7 @@ import org.talend.designer.core.DesignerPlugin;
 import org.talend.designer.core.IDesignerCoreService;
 import org.talend.designer.core.ISyntaxCheckableEditor;
 import org.talend.designer.core.model.components.EParameterName;
+import org.talend.designer.core.model.utils.emf.talendfile.NodeType;
 import org.talend.designer.core.model.utils.emf.talendfile.ProcessType;
 import org.talend.designer.core.model.utils.emf.talendfile.RoutinesParameterType;
 import org.talend.designer.core.runprocess.Processor;
@@ -1643,6 +1644,18 @@ public class JavaProcessor extends AbstractJavaProcessor implements IJavaBreakpo
                         if (BuildJobConstants.ESB_CXF_COMPONENTS.contains(node.getComponent().getName())) {
                             hasCXFComponent = true;
                             break out;
+                        }
+                    }
+                    
+                  //check child job
+                    Set<JobInfo> buildChildrenJobs = getBuildChildrenJobs();
+                    for(JobInfo jobInfo:buildChildrenJobs) {
+                        List<? extends NodeType> generatingNodes = jobInfo.getProcessItem().getProcess().getNode();
+                        for (NodeType inode : generatingNodes) {
+                            if (BuildJobConstants.ESB_CXF_COMPONENTS.contains(inode.getComponentName())) {
+                                hasCXFComponent = true;
+                                break out;
+                            }
                         }
                     }
                     break;


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TUP-25417

**What is the new behavior?**
generate classpath using relative path for building parent job(whose child job contains esb cxf components) on jdk11

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


