### PR TITLE
feat(TDI-45732): extend not dieoneerror area

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tMap/tMap_main.inc.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMap/tMap_main.inc.javajet
@@ -67,7 +67,8 @@
 		}
 	}
 	boolean isLog4jEnabled = ("true").equals(ElementParameterParser.getValue(node.getProcess(), "__LOG4J_ACTIVATE__"));
-	
+	boolean dieonerror = ("true").equals(ElementParameterParser.getValue(node, "__DIE_ON_ERROR__"));
+
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	
         ILanguage currentLanguage = LanguageProvider.getJavaLanguage();
@@ -426,6 +427,14 @@
 		} // T_TM_M_291
 		
 		
+		%>
+
+            <%
+            if (!dieonerror) {
+            %>
+                try { // anchor
+            <%
+            } // close dieonerror if check
 		%>
         // ###############################
         // # Input tables (lookups)
@@ -1358,13 +1367,7 @@
             
         } // for (ExternalMapperTable externalTable : inputTables) {  // T_TM_M_261
         boolean atLeastOneInputTableWithInnerJoin = !inputTablesWithInnerJoin.isEmpty();
-        boolean dieonerror = ("true").equals(ElementParameterParser.getValue(node, "__DIE_ON_ERROR__"));
 
-		if (!dieonerror) {
-		%>
-			try {
-		<%
-		}
         %>// ###############################
         <%
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tMap/tMap_main.inc.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tMap/tMap_main.inc.javajet
@@ -432,7 +432,7 @@
             <%
             if (!dieonerror) {
             %>
-                try { // anchor
+                try {
             <%
             } // close dieonerror if check
 		%>


### PR DESCRIPTION
* extend try-block that includes "Input tables (lookups)"

**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-45732

**What is the new behavior?**
covered with try-catch Table Input (lookups) area in tMap component

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


