### PR TITLE
fix(TDI-45859): tFileCopy with different fs

### DIFF
--- a/main/plugins/org.talend.designer.components.libs/libs_src/filecopy/pom.xml
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/filecopy/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.talend.components</groupId>
 	<artifactId>filecopy</artifactId>
-	<version>2.0.1</version>
+	<version>2.0.2</version>
 	<packaging>jar</packaging>
 
 	<name>talend-copy</name>

--- a/main/plugins/org.talend.designer.components.libs/libs_src/filecopy/src/main/java/org/talend/FileCopy.java
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/filecopy/src/main/java/org/talend/FileCopy.java
@@ -52,4 +52,21 @@ public class FileCopy {
         }
     }
 
+    /**
+     * Force Copy and Delete files.
+     *
+     * @param srcFileName : file name for source file.
+     * @param desFileName : file name for destination file.
+     * @throws IOException : if IO pb.
+     */
+    public static void forceCopyAndDelete(String srcFileName, String desFileName) throws IOException {
+        final Path source = Paths.get(srcFileName);
+        final Path destination =  Paths.get(desFileName);
+        final long lastModifiedTime = new File(srcFileName).lastModified();
+
+        Files.copy(source, destination, StandardCopyOption.REPLACE_EXISTING);
+        Files.delete(source);
+        new File(desFileName).setLastModified(lastModifiedTime);
+    }
+
 }

--- a/main/plugins/org.talend.designer.components.libs/libs_src/filecopy/src/main/java/org/talend/FileCopy.java
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/filecopy/src/main/java/org/talend/FileCopy.java
@@ -66,7 +66,7 @@ public class FileCopy {
 
         Files.copy(source, destination, StandardCopyOption.REPLACE_EXISTING);
         Files.delete(source);
-        new File(desFileName).setLastModified(lastModifiedTime);
+        destination.toFile().setLastModified(lastModifiedTime);
     }
 
 }

--- a/main/plugins/org.talend.designer.components.libs/libs_src/filecopy/src/test/java/org/talend/FileCopyTest.java
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/filecopy/src/test/java/org/talend/FileCopyTest.java
@@ -101,6 +101,26 @@ class FileCopyTest {
     }
 
     @Test
+    void testForceCopyWithDelete() throws Exception {
+        final URL repCopy = Thread.currentThread().getContextClassLoader().getResource("copy");
+
+        File file = this.buildFile("fileToDelete.txt", 10L * 1024L);
+        file.deleteOnExit();
+        File copy = new File(repCopy.getPath(), "fileToDelete.txt");
+        long referenceSize = file.length();
+        if (!copy.exists()) {
+            copy.createNewFile();
+        }
+        copy.deleteOnExit();
+
+        FileCopy.forceCopyAndDelete(file.getPath(), copy.getPath());
+
+        Assertions.assertFalse(file.exists(), "file not delete");
+        Assertions.assertTrue(copy.exists(), "small file : original file deleted");
+        Assertions.assertEquals(referenceSize, copy.length(), "Size error");
+    }
+
+    @Test
     void testLastModifiedTime() throws Exception {
         final URL repCopy = Thread.currentThread().getContextClassLoader().getResource("copy");
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileCopy/tFileCopy_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileCopy/tFileCopy_java.xml
@@ -141,11 +141,24 @@
     </PARAMETER>
   </PARAMETERS>
   
+  <ADVANCED_PARAMETERS>
+	<PARAMETER
+      NAME="FORCE_COPY_DELETE"
+      FIELD="CHECK"
+      REQUIRED="true"
+      NUM_ROW="10"
+      REPOSITORY_VALUE="FORCE_COPY_DELETE"
+      SHOW_IF="REMOVE_FILE=='true'"
+    >
+      <DEFAULT>false</DEFAULT>
+    </PARAMETER>
+  </ADVANCED_PARAMETERS>
+  
   <CODEGENERATION>
     <IMPORTS>
-      <IMPORT NAME="filecopy" MODULE="filecopy-2.0.1.jar" 
-              MVN="mvn:org.talend.components/filecopy/2.0.1"
-              UrlPath="platform:/plugin/org.talend.libraries.custom/lib/filecopy-2.0.1.jar"
+      <IMPORT NAME="filecopy-2.0.2" MODULE="filecopy-2.0.2.jar" 
+              MVN="mvn:org.talend.components/filecopy/2.0.2"
+              UrlPath="platform:/plugin/org.talend.libraries.custom/lib/filecopy-2.0.2.jar"
               REQUIRED="true" />
     </IMPORTS>
   </CODEGENERATION>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileCopy/tFileCopy_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileCopy/tFileCopy_java.xml
@@ -148,7 +148,7 @@
       REQUIRED="true"
       NUM_ROW="10"
       REPOSITORY_VALUE="FORCE_COPY_DELETE"
-      SHOW_IF="REMOVE_FILE=='true'"
+      SHOW_IF="(REMOVE_FILE=='true') AND (ENABLE_COPY_DIRECTORY=='false')"
     >
       <DEFAULT>false</DEFAULT>
     </PARAMETER>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileCopy/tFileCopy_main.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileCopy/tFileCopy_main.javajet
@@ -33,6 +33,8 @@
 	
 	boolean failOn = ("true").equals(ElementParameterParser.getValue(node,"__FAILON__"));
 	
+	boolean forceCopyAndDelete = ("true").equals(ElementParameterParser.getValue(node,"__FORCE_COPY_DELETE__")) && reFile;
+	
 	final boolean isLog4jEnabled = ("true").equals(ElementParameterParser.getValue(node.getProcess(), "__LOG4J_ACTIVATE__"));
 	
 	log4jFileUtil.componentStartInfo(node);
@@ -198,9 +200,15 @@
 				try {
 <%
 			}
+			if(!forceCopyAndDelete) {
 %>
 					org.talend.FileCopy.copyFile(srcFile_<%=cid %>.getPath(), desFile_<%=cid %>.getPath(), <%=reFile %>);
 <%
+			} else {
+%>
+					org.talend.FileCopy.forceCopyAndDelete(srcFile_<%=cid %>.getPath(), desFile_<%=cid %>.getPath());
+<%
+			}
 			if (!failOn) {
 %>
 				} catch (Exception e) {

--- a/main/plugins/org.talend.designer.components.localprovider/components/tFileCopy/tFileCopy_messages.properties
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tFileCopy/tFileCopy_messages.properties
@@ -19,3 +19,4 @@ DESTINATION_FILEPATH.NAME=Destination File Path
 DESTINATION_FILENAME.NAME=Destination File Name
 FAILON.NAME=Fail on error
 
+FORCE_COPY_DELETE.NAME=Force copy instead of move

--- a/main/plugins/org.talend.libraries.custom/pom.xml
+++ b/main/plugins/org.talend.libraries.custom/pom.xml
@@ -56,7 +56,7 @@
                 <artifactItem>
                   <groupId>org.talend.components</groupId>
                   <artifactId>filecopy</artifactId>
-                  <version>2.0.1</version>
+                  <version>2.0.2</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.talend.components.lib</groupId>

--- a/main/plugins/org.talend.repository/plugin.xml
+++ b/main/plugins/org.talend.repository/plugin.xml
@@ -3629,6 +3629,15 @@
               name="ReplaceInheritCredentialCheckBoxWithDropDownListTask"
               version="7.3.1">
      </projecttask>
+       <projecttask
+               beforeLogon="false"
+               breaks="7.3.0"
+               class="org.talend.repository.model.migration.SetForceCopyFortFileCopy"
+               description="Set force copy checkbox to true."
+               id="org.talend.repository.model.migration.SetForceCopyFortFileCopy"
+               name="SetForceCopyFortFileCopy"
+               version="7.3.1">
+       </projecttask>
    </extension>
 
    <extension

--- a/main/plugins/org.talend.repository/src/main/java/org/talend/repository/model/migration/SetForceCopyFortFileCopy.java
+++ b/main/plugins/org.talend.repository/src/main/java/org/talend/repository/model/migration/SetForceCopyFortFileCopy.java
@@ -1,0 +1,67 @@
+package org.talend.repository.model.migration;
+
+import org.talend.commons.exception.ExceptionHandler;
+import org.talend.commons.exception.PersistenceException;
+import org.talend.core.language.ECodeLanguage;
+import org.talend.core.model.components.ComponentUtilities;
+import org.talend.core.model.components.ModifyComponentsAction;
+import org.talend.core.model.components.conversions.IComponentConversion;
+import org.talend.core.model.components.filters.IComponentFilter;
+import org.talend.core.model.components.filters.NameComponentFilter;
+import org.talend.core.model.migration.AbstractJobMigrationTask;
+import org.talend.core.model.properties.Item;
+import org.talend.designer.core.model.utils.emf.talendfile.NodeType;
+import org.talend.designer.core.model.utils.emf.talendfile.ProcessType;
+
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+public class SetForceCopyFortFileCopy extends AbstractJobMigrationTask {
+
+    @Override
+    public ExecutionResult execute(final Item item) {
+        final ProcessType processType = getProcessType(item);
+        if (getProject().getLanguage() != ECodeLanguage.JAVA || processType == null) {
+            return ExecutionResult.NOTHING_TO_DO;
+        }
+        String[] compNames = {"tFileCopy"}; //$NON-NLS-1$
+
+        IComponentConversion action = new IComponentConversion() {
+
+            public void transform(NodeType node) {
+                if(node == null) {
+                    return;
+                }
+
+                if (ComponentUtilities.getNodeProperty(node, "FORCE_COPY_DELETE") == null) {//$NON-NLS-1$
+                    ComponentUtilities.addNodeProperty(node, "FORCE_COPY_DELETE", "CHECK");//$NON-NLS-1$ //$NON-NLS-2$
+                    ComponentUtilities.getNodeProperty(node, "FORCE_COPY_DELETE").setValue("true");//$NON-NLS-1$ //$NON-NLS-2$
+                }
+
+            }
+
+        };
+
+        for (String name : compNames) {
+            IComponentFilter filter = new NameComponentFilter(name);
+
+            try {
+                ModifyComponentsAction.searchAndModify(item, processType, filter, Arrays
+                        .<IComponentConversion> asList(action));
+            } catch (PersistenceException e) {
+                ExceptionHandler.process(e);
+                return ExecutionResult.FAILURE;
+            }
+        }
+
+        return ExecutionResult.SUCCESS_NO_ALERT;
+    }
+
+    @Override
+    public Date getOrder() {
+        GregorianCalendar gc = new GregorianCalendar(2021, Calendar.APRIL, 9, 0, 0, 0);
+        return gc.getTime();
+    }
+}


### PR DESCRIPTION
* Add force copy parameter

* Copy and delete file instead of moving

**What is the current behavior?** (You can also link to an open issue here)
If the file is being moved between filesystems the process might fail

**What is the new behavior?**
In case 'Force copy instead of move' parameter is checked we will copy the file and delete it

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
https://jira.talendforge.org/browse/TDI-45859

