### PR TITLE
fix(TDI-45912): Enforce that System path separator character is indeed a character for tRunjob only as that will generated command

### DIFF
--- a/main/plugins/org.talend.designer.components.localprovider/components/tRunJob/tRunJob_begin.javajet
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tRunJob/tRunJob_begin.javajet
@@ -215,6 +215,9 @@ try {
 		java.util.Map<String,List<String>> childJob_commandLine_Mapper_<%=cid%> = new java.util.HashMap<String,List<String>>();
 		java.util.List<String> childJob_commandLine_<%=cid%> = null;
 		String classpathSeparator_<%=cid%> = System.getProperty("path.separator");
+		if (classpathSeparator_<%=cid%> != null && classpathSeparator_<%=cid%>.length() > 1) {
+			throw new RuntimeException("path separator should be single character");
+		}
 		<%
 	
 		//issue 19108: The context text field waits for a context name without quotes. The component removes the first quote and the last quote if they exist.


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-45912

**What is the new behavior?**
https://jira.talendforge.org/browse/TDI-45912

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [x] Other... Please describe: CVE

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
