### PR TITLE
fix(TUP-30430): Clone the connection's UNIQUE_NAME for some links instead of generating a new one in joblet node container.

### DIFF
--- a/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/jobletcontainer/JobletUtil.java
+++ b/main/plugins/org.talend.designer.core/src/main/java/org/talend/designer/core/ui/editor/jobletcontainer/JobletUtil.java
@@ -448,16 +448,32 @@ public class JobletUtil {
         List<? extends IElementParameter> elementParas = conn.getElementParameters();
 
         for (IElementParameter elementPara : elementParas) {
-            if (elementPara.getName() != null && !elementPara.getName().equals("UNIQUE_NAME")) {
-                IElementParameter cloneElement = cloneConn.getElementParameter(elementPara.getName());
-                Object paValue = elementPara.getValue();
-                if (paValue instanceof List) {
-                    List list = new ArrayList();
-                    list.addAll((List) paValue);
-                    cloneElement.setValue(list);
+            if (elementPara.getName() != null) {
+                if (!elementPara.getName().equals("UNIQUE_NAME")) {
+                    IElementParameter cloneElement = cloneConn.getElementParameter(elementPara.getName());
+                    Object paValue = elementPara.getValue();
+                    if (paValue instanceof List) {
+                        List list = new ArrayList();
+                        list.addAll((List) paValue);
+                        cloneElement.setValue(list);
+                    } else {
+                        cloneElement.setContextMode(elementPara.isContextMode());
+                        cloneElement.setValue(elementPara.getValue());
+                    }
                 } else {
-                    cloneElement.setContextMode(elementPara.isContextMode());
-                    cloneElement.setValue(elementPara.getValue());
+                    //TUP-30430. 
+                    //see 3443, these links should have unique name. But for joblet, the unified name 
+                    //is used for performance data and it is unique. Clone unique name from definition and no need 
+                    //to generate a new one.
+                    if (conn.getLineStyle().equals(EConnectionType.ON_COMPONENT_OK)
+                            || conn.getLineStyle().equals(EConnectionType.ON_COMPONENT_ERROR)
+                            || conn.getLineStyle().equals(EConnectionType.ON_SUBJOB_OK)
+                            || conn.getLineStyle().equals(EConnectionType.ON_SUBJOB_ERROR)
+                            || conn.getLineStyle().equals(EConnectionType.RUN_IF)
+                            || conn.getLineStyle().equals(EConnectionType.STARTS)) {
+                        String uniqueName = (String)elementPara.getValue();
+                        if (StringUtils.isNotEmpty(uniqueName)) cloneConn.setUniqueName(uniqueName);
+                    }
                 }
 
             }


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TUP-30430

**What is the new behavior?**
Clone the connection's UNIQUE_NAME for some links instead of generating a new one in joblet node container.

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


