### PR TITLE
fix(TDI-47222): invoke stop after flush (#6985)

### DIFF
--- a/main/plugins/org.talend.sdk.component.studio-integration/jet_stub/generic/processor/processor_end.javajet
+++ b/main/plugins/org.talend.sdk.component.studio-integration/jet_stub/generic/processor/processor_end.javajet
@@ -49,9 +49,4 @@
     }
 %>
 
-    if (processor_<%=cid%> != null) {
-        processor_<%=cid%>.stop();
-    }
-
     globalMap.put("<%=cid %>_NB_LINE", nbLineInput_<%=cid%>);
-    globalMap.remove("processor_<%=cid%>");

--- a/main/plugins/org.talend.sdk.component.studio-integration/jet_stub/generic/processor/processor_process_records_end.javajet
+++ b/main/plugins/org.talend.sdk.component.studio-integration/jet_stub/generic/processor/processor_process_records_end.javajet
@@ -26,3 +26,14 @@ final java.util.Map<String, Object> afterVariablesMap_<%=cid%> = org.talend.sdk.
 for (java.util.Map.Entry<String, Object> entry_<%=cid %> : afterVariablesMap_<%=cid%>.entrySet()) {
     globalMap.put("<%=cid %>_"+entry_<%=cid %>.getKey(), entry_<%=cid %>.getValue());
 }
+
+<%
+// Not the best place. Because process_data_begin+end gonna be invoke after one more time
+// But this one close resources after the data were flushed
+// Should be moved if processor_*.javajet order will be changed
+%>
+if (processor_<%=cid%> != null) {
+    processor_<%=cid%>.stop();
+}
+
+globalMap.remove("processor_<%=cid%>");


### PR DESCRIPTION
* TCK studio-integration
* method stop should be invoked after the method flush for producers (outputs)

(cherry picked from commit 54b17eea2c4d714d613d78d01c7ddd829f52a03a)

**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-47222

**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard

**What kind of change does this PR introduce?**

- [x] Bugfix

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Related pr
https://github.com/Talend/tdi-studio-se/pull/6985

