### PR TITLE
fix(TCOMP-2122): [JDBC TCK]: can't get user defined schema info in tck runtime in studio when no data outut line

### DIFF
--- a/main/plugins/org.talend.sdk.component.studio-integration/jet_stub/generic/configuration.javajet
+++ b/main/plugins/org.talend.sdk.component.studio-integration/jet_stub/generic/configuration.javajet
@@ -69,13 +69,24 @@ final java.util.Map<String, String> registry_metadata_<%=cid%> = new java.util.H
                 if (p.getFieldType() == EParameterFieldType.SCHEMA_TYPE) {
                     connections = NodeUtil.getOutgoingConnections(node, p.getContext());
                 } else {
+                    //TODO may remove this and EParameterFieldType.TACOKIT_INPUT_SCHEMA support
                     connections = NodeUtil.getIncomingConnections(node, p.getContext());
                 }
+                
+                IMetadataTable metaTable = null;
                 if(connections != null && !connections.isEmpty()) {
                     connection = connections.get(0);
+                    metaTable = (connection!=null) ? connection.getMetadataTable() : null;
+                } else if("FLOW".equals(p.getContext())) {
+                    //pass the connector schema when no output line case
+                    //for example: tfixedflowinput==>tjdbcoutput, we need the column key/db column name info in studio design schema
+                    List<IMetadataTable> metadataTables = node.getMetadataList();
+                    if(metadataTables!=null && !metadataTables.isEmpty()) {
+                        metaTable = metadataTables.get(0);
+                    }
                 }
-                if(connection != null) {
-                    IMetadataTable metaTable = connection.getMetadataTable();
+                
+                if(metaTable != null) {
                     List<IMetadataColumn> columns = metaTable.getListColumns();
                     boolean hasDynamic = false;
                     for (int i = 0; i < columns.size(); i++) {


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TCOMP-2122

**What is the new behavior?**
https://jira.talendforge.org/browse/TCOMP-2122

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No