### PR TITLE
feat(TDI-48418): Bump component-runtime to 1.48

### DIFF
--- a/main/plugins/org.talend.sdk.component.studio-integration/components/tTaCoKitGuessSchema/tTaCoKitGuessSchema_begin.javajet
+++ b/main/plugins/org.talend.sdk.component.studio-integration/components/tTaCoKitGuessSchema/tTaCoKitGuessSchema_begin.javajet
@@ -87,7 +87,8 @@ System.setOut(new java.io.PrintStream(new java.io.OutputStream() {
                                                                                     "<%=pluginName%>",
                                                                                     "<%=guessSchemaFamily%>",
                                                                                     "<%=guessSchemaOriginalName%>",
-                                                                                    <% if(actionName == null || actionName.isEmpty()){%> null <%}else {%> "<%=actionName%>" <%}%>
+                                                                                    <% if(actionName == null || actionName.isEmpty()){%> null <%}else {%> "<%=actionName%>" <%}%>,
+                                                                                    "<%=guessSchemaVersion%>"
                                                                                     );
     <% if ("input".equalsIgnoreCase(tacokitComponentType)) {  %>
             try {


### PR DESCRIPTION
https://jira.talendforge.org/browse/TDI-48418

This includes the following fixes:
- fix(TCOMP-2182): pass version to tck guess schema

***Related PR***

**master**
- https://github.com/Talend/studio-se-master/pull/679
- https://github.com/Talend/tcommon-studio-se/pull/5592
- https://github.com/Talend/tdi-studio-se/pull/7987

**maintenance/8.0**
- https://github.com/Talend/studio-se-master/pull/681
- https://github.com/Talend/tcommon-studio-se/pull/5593
- https://github.com/Talend/tdi-studio-se/pull/7988
