### PR TITLE
fix(TUP-36717): Avoid error log and NPE after after a connector use TCOMP-2230 allow a "ui.scope" target for the tck ActiveIf json metadata info

### DIFF
--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/SettingVisitor.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/SettingVisitor.java
@@ -184,8 +184,8 @@ public class SettingVisitor implements PropertyVisitor {
                     .flatMap(it -> it.getConditions().stream())
                     .map(PropertyDefinitionDecorator.Condition::getTargetPath)
                     .peek((String key) -> {
-                        if (!this.settings.containsKey(key)) {
-                            LOGGER.error("Path " + path + " not found in settings for form " + this.form);
+                        if (!this.settings.containsKey(key) && !"ui.scope".equals(key)) {
+                            LOGGER.error("Path " + key + " not found in settings for form " + this.form);
                         }
                     })
                     .map(this.settings::get)

--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/listener/ActiveIfListener.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/listener/ActiveIfListener.java
@@ -92,7 +92,8 @@ public class ActiveIfListener implements PropertyChangeListener {
         final TaCoKitElementParameter targetParam = targetParams.get(condition.getTargetPath());
         switch (evaluationStrategy) {
             case "DEFAULT":
-                return value.equals(TOSTRING_PREPROCESSOR.apply(targetParam.getStringValue()));
+                //now tck add uiscope target, so the path may not exists in model, now not process here, only return true for that case, TODO process hide logic for studio from the json info 
+                return targetParam == null || value.equals(TOSTRING_PREPROCESSOR.apply(targetParam.getStringValue()));
             case "LENGTH":
                 if (targetParam.getValue() == null) {
                     return "0".equals(value);


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TUP-36717

**What is the new behavior?**
https://jira.talendforge.org/browse/TUP-36717

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No