### PR TITLE
Fix[TCOMP-2389]: There is no response when use guess schema for tNetSuiteV2019Input

### DIFF
--- a/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/ui/guessschema/TaCoKitGuessSchemaProcess.java
+++ b/main/plugins/org.talend.sdk.component.studio-integration/src/main/java/org/talend/sdk/component/studio/ui/guessschema/TaCoKitGuessSchemaProcess.java
@@ -120,12 +120,7 @@ public class TaCoKitGuessSchemaProcess {
             final Future<GuessSchemaResult> result = executorService.submit(() -> {
                 final Pattern pattern = Pattern.compile("^\\[\\s*(INFO|WARN|ERROR|DEBUG|TRACE)\\s*]");
                 String out;
-                final List<String> err = new ArrayList();
-                // read stderr stream
-                try (final BufferedReader reader = new BufferedReader(new InputStreamReader(executeProcess.getErrorStream()))) {
-                    err.addAll(reader.lines().collect(toList()));
-                    err.add("===== Root cause ======");
-                }
+                final List<String> err = new ArrayList<String>();
                 // read stdout stream
                 try (final BufferedReader reader =
                              new BufferedReader(new InputStreamReader(executeProcess.getInputStream()))) {
@@ -135,6 +130,13 @@ public class TaCoKitGuessSchemaProcess {
                             .filter(l -> l.startsWith("[") || l.startsWith("{"))    // ignore line with non json data
                             .collect(joining("\n"));
                 }
+                
+                // read stderr stream
+                try (final BufferedReader reader = new BufferedReader(new InputStreamReader(executeProcess.getErrorStream()))) {
+                     err.addAll(reader.lines().parallel().collect(toList()));
+                     err.add("===== Root cause ======");
+                }
+                
                 return new GuessSchemaResult(out, err.stream().collect(joining("\n")));
             });
 


### PR DESCRIPTION
https://jira.talendforge.org/browse/TCOMP-2389

There is no response when use guess schema for tNetSuiteV2019Input

**What is the current behavior?** (You can also link to an open issue here)


**What is the new behavior?**


**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


