### PR TITLE
fix(TMC-25803): SubJobs names are not available via MDC Logging in RE

### DIFF
--- a/main/plugins/org.talend.designer.codegen/jet_stub/subprocess_footer.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/subprocess_footer.javajet
@@ -24,6 +24,7 @@
 	boolean stat = codeGenArgument.isStatistics();
 	IProcess process = subTree.getRootNode().getProcess();
     boolean isLog4jEnabled = ("true").equals(ElementParameterParser.getValue(process, "__LOG4J_ACTIVATE__"));
+	String MDC_CLASS = "org.slf4j.MDC";
 	for(INode node : subTree.getNodes()){
 		List<IMetadataTable> metadatas = node.getMetadataList();
 		List< ? extends IConnection> conns = node.getOutgoingConnections();
@@ -323,6 +324,16 @@
 					//ignore
 				}catch(java.lang.Error error){
 					//ignore
+				}
+				<%=MDC_CLASS%>.remove("_subJobName");
+				<%=MDC_CLASS%>.remove("_subJobPid");
+				String subJobNameMdcBackup = (String) globalMap.remove("BACKUP_SUB_JOB_NAME_<%=subTree.getName()%>");
+				if (null != subJobNameMdcBackup) {
+					<%=MDC_CLASS%>.put("_subJobName", subJobNameMdcBackup);
+				}
+				String subJobPidMdcBackup = (String) globalMap.remove("BACKUP_SUB_JOB_PID_<%=subTree.getName()%>");
+				if (null != subJobPidMdcBackup) {
+					<%=MDC_CLASS%>.put("_subJobPid", subJobPidMdcBackup);
 				}
 				resourceMap = null;
 			}

--- a/main/plugins/org.talend.designer.codegen/jet_stub/subprocess_header.javajet
+++ b/main/plugins/org.talend.designer.codegen/jet_stub/subprocess_header.javajet
@@ -1606,6 +1606,12 @@ public void <%=subTree.getName() %>Process(final java.util.Map<String, Object> g
 
  final boolean execStat = this.execStat;
 	<%if(isLog4jEnabled && isLog4j2Enabled) {%>
+		if (null != <%=MDC_CLASS%>.get("_subJobName")) {
+			globalMap.put("BACKUP_SUB_JOB_NAME_<%=subTree.getName()%>", <%=MDC_CLASS%>.get("_subJobName"));
+		}
+		if (null != <%=MDC_CLASS%>.get("_subJobPid")) {
+			globalMap.put("BACKUP_SUB_JOB_PID_<%=subTree.getName()%>", <%=MDC_CLASS%>.get("_subJobPid"));
+		}
 		mdcInfo.forEach(<%=MDC_CLASS%>::put);
 		<%=MDC_CLASS%>.put("_subJobName", "<%=subTree.getName() %>");
 		<%=MDC_CLASS%>.put("_subJobPid", TalendString.getAsciiRandomString(6));


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TMC-25803
`_subJobName` & `_subJobPid` MDC values are overwritten by `talendJobLog` processing

**What is the new behavior?**
temporary store original MDC values into `globalMap` when entering into `*Process` method
and restore them at the end of the method

**Please check if the PR fulfills these requirements**

- [ ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


