### PR TITLE
fix(TUP-41020): LDAP Metadata : Check Authentication fails when Encryption method = LDAPS(SSL) even with correct credentials. 

### DIFF
--- a/main/plugins/org.talend.designer.components.libs/libs_src/talendssl/pom.xml
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/talendssl/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.talend.components</groupId>
 	<artifactId>talendssl</artifactId>
-	<version>1.0-20190118</version>
+	<version>1.0-20231128</version>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/main/plugins/org.talend.designer.components.libs/libs_src/talendssl/src/main/java/talend/ssl/Truster.java
+++ b/main/plugins/org.talend.designer.components.libs/libs_src/talendssl/src/main/java/talend/ssl/Truster.java
@@ -103,7 +103,11 @@ public class Truster implements X509TrustManager {
             } catch (IOException _ex) {
             }
         try {
-            ks.load(in, certStorePwd);
+            if (in == null) {
+                ks = null;
+            } else {
+                ks.load(in, certStorePwd);
+            }
         } catch (Exception e) {
             System.err.println("ASF Truster: Failed to load the cert store : " + e.getMessage());
             return;

--- a/main/plugins/org.talend.designer.components.localprovider/META-INF/MANIFEST.MF
+++ b/main/plugins/org.talend.designer.components.localprovider/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Components Local provider Plug-in
+Bundle-Name: Components Local provider Plug-in R2023-12
 Bundle-SymbolicName: org.talend.designer.components.localprovider;singleton:=true
 Bundle-Version: 8.0.1.qualifier
 Bundle-Activator: org.talend.designer.components.ComponentsLocalProviderPlugin

--- a/main/plugins/org.talend.designer.components.localprovider/components/tLDAPAttributesInput/tLDAPAttributesInput_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLDAPAttributesInput/tLDAPAttributesInput_java.xml
@@ -177,7 +177,7 @@
 
 	<CODEGENERATION>
 		<IMPORTS>
-			<IMPORT NAME="ldap" MODULE="talendssl-1.0-20190118.jar" MVN="mvn:org.talend.components/talendssl/1.0-20190118"  REQUIRED="true" />
+			<IMPORT NAME="ldap" MODULE="talendssl-1.0-20231128.jar" MVN="mvn:org.talend.components/talendssl/1.0-20231128"  REQUIRED="true" />
 		</IMPORTS>
 	</CODEGENERATION>
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tLDAPConnection/tLDAPConnection_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLDAPConnection/tLDAPConnection_java.xml
@@ -110,7 +110,7 @@
 	
 	<CODEGENERATION>
 		<IMPORTS>
-			<IMPORT NAME="ldap" MODULE="talendssl-1.0-20190118.jar" MVN="mvn:org.talend.components/talendssl/1.0-20190118"  REQUIRED="true" />
+			<IMPORT NAME="ldap" MODULE="talendssl-1.0-20231128.jar" MVN="mvn:org.talend.components/talendssl/1.0-20231128"  REQUIRED="true" />
 		</IMPORTS>
 	</CODEGENERATION>
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tLDAPInput/tLDAPInput_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLDAPInput/tLDAPInput_java.xml
@@ -191,7 +191,7 @@
 
 	<CODEGENERATION>
 		<IMPORTS>
-			<IMPORT NAME="ldap" MODULE="talendssl-1.0-20190118.jar" MVN="mvn:org.talend.components/talendssl/1.0-20190118"  REQUIRED="true" />
+			<IMPORT NAME="ldap" MODULE="talendssl-1.0-20231128.jar" MVN="mvn:org.talend.components/talendssl/1.0-20231128"  REQUIRED="true" />
 		</IMPORTS>
 	</CODEGENERATION>
 

--- a/main/plugins/org.talend.designer.components.localprovider/components/tLDAPOutput/tLDAPOutput_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLDAPOutput/tLDAPOutput_java.xml
@@ -199,7 +199,7 @@
 	
 	<CODEGENERATION>
 		<IMPORTS>
-			<IMPORT NAME="ldap" MODULE="talendssl-1.0-20190118.jar" MVN="mvn:org.talend.components/talendssl/1.0-20190118"  REQUIRED="true" />
+			<IMPORT NAME="ldap" MODULE="talendssl-1.0-20231128.jar" MVN="mvn:org.talend.components/talendssl/1.0-20231128"  REQUIRED="true" />
 		</IMPORTS>
 	</CODEGENERATION>
 	<RETURNS>

--- a/main/plugins/org.talend.designer.components.localprovider/components/tLDAPRenameEntry/tLDAPRenameEntry_java.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/components/tLDAPRenameEntry/tLDAPRenameEntry_java.xml
@@ -138,7 +138,7 @@
 	
 	<CODEGENERATION>
 		<IMPORTS>
-			<IMPORT NAME="ldap" MODULE="talendssl-1.0-20190118.jar" MVN="mvn:org.talend.components/talendssl/1.0-20190118"  REQUIRED="true" />
+			<IMPORT NAME="ldap" MODULE="talendssl-1.0-20231128.jar" MVN="mvn:org.talend.components/talendssl/1.0-20231128"  REQUIRED="true" />
 		</IMPORTS>
 	</CODEGENERATION>
 	<RETURNS>

--- a/main/plugins/org.talend.designer.components.localprovider/pom.xml
+++ b/main/plugins/org.talend.designer.components.localprovider/pom.xml
@@ -128,7 +128,7 @@
 								<artifactItem>
 									<groupId>org.talend.components</groupId>
 									<artifactId>talendssl</artifactId>
-									<version>1.0-20190118</version>
+									<version>1.0-20231128</version>
 									<type>jar</type>
 									<overWrite>true</overWrite>
 									<outputDirectory>${tldapinput.dir}</outputDirectory>


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TUP-41020

**What is the new behavior?**
Initialize default trust manager if specified cacerts not found

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


